### PR TITLE
fix(usenet): nyuu article-check parity + skip_archive/archive_password consistency

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,73 @@
+name: Build and Release Standalone Binaries
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            suffix: linux
+            sep: ":"
+          - os: windows-latest
+            suffix: windows
+            sep: ";"
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.14' # Pinned to the project's target python version
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pyinstaller
+
+      - name: Download all internal utility binaries (pesto, nyuu, 7z, par2, mkbrr, bdinfo)
+        run: python bin/download_all_build_binaries.py
+
+      - name: Download all release dependencies (FFmpeg, MediaInfo)
+        run: python bin/download_release_dependencies.py
+
+      - name: Build upload binary with PyInstaller
+        run: |
+          pyinstaller --onefile --name upload-${{ matrix.suffix }} \
+            --add-data "src${{ matrix.sep }}src" \
+            --add-data "cogs${{ matrix.sep }}cogs" \
+            --add-data "bin${{ matrix.sep }}bin" \
+            --add-data "data/example_config.py${{ matrix.sep }}data" \
+            --add-data "data/tags.json${{ matrix.sep }}data" \
+            --add-data "data/templates${{ matrix.sep }}data/templates" \
+            upload.py
+
+      - name: Build config-generator binary with PyInstaller
+        run: |
+          pyinstaller --onefile --name config-generator-${{ matrix.suffix }} \
+            --add-data "src${{ matrix.sep }}src" \
+            --add-data "bin${{ matrix.sep }}bin" \
+            --add-data "data/example_config.py${{ matrix.sep }}data" \
+            config-generator.py
+
+      - name: Upload binaries to Release
+        run: |
+          gh release upload "$RELEASE_TAG" dist/upload-${{ matrix.suffix }}* dist/config-generator-${{ matrix.suffix }}* --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,14 @@ bin/7z/*
 bin/nyuu/*
 bin/par2/*
 bin/pesto/*
+bin/ffmpeg
+bin/ffmpeg.exe
+bin/ffprobe
+bin/ffprobe.exe
+bin/MediaInfo.dll
+bin/MediaInfo.exe
+bin/mediainfo
+bin/libmediainfo.so
 *.mkv
 .vscode/
 __pycache__/

--- a/bin/download_all_build_binaries.py
+++ b/bin/download_all_build_binaries.py
@@ -1,0 +1,49 @@
+# Upload Assistant © 2026 Audionut & wastaken7 — Licensed under UAPL v1.0
+import asyncio
+import sys
+from pathlib import Path
+
+# Add project root to sys.path so we can import src modules
+base_dir = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(base_dir))
+
+from bin.get_7z import SevenZipBinaryManager  # noqa: E402
+from bin.get_bdinfo import BDInfoBinaryManager  # noqa: E402
+from bin.get_mkbrr import MkbrrBinaryManager  # noqa: E402
+from bin.get_nyuu import NyuuBinaryManager  # noqa: E402
+from bin.get_par2 import Par2BinaryManager  # noqa: E402
+from bin.get_pesto import PestoBinaryManager  # noqa: E402
+
+
+async def main() -> None:
+    print("Pre-downloading all utility binaries for release build...")
+
+    print("1/6 Downloading 7-Zip...")
+    p7z = await SevenZipBinaryManager.ensure_7z_binary(base_dir)
+    print(f"Downloaded 7-Zip to {p7z}")
+
+    print("2/6 Downloading BDInfo CLI...")
+    bd = await BDInfoBinaryManager.ensure_bdinfo_binary(base_dir)
+    print(f"Downloaded BDInfo to {bd}")
+
+    print("3/6 Downloading mkbrr...")
+    mk = await MkbrrBinaryManager.ensure_mkbrr_binary(base_dir, "v1.18.0")
+    print(f"Downloaded mkbrr to {mk}")
+
+    print("4/6 Downloading Nyuu...")
+    ny = await NyuuBinaryManager.ensure_nyuu_binary(base_dir, path_7z=p7z)
+    print(f"Downloaded Nyuu to {ny}")
+
+    print("5/6 Downloading PAR2...")
+    pa = await Par2BinaryManager.ensure_par2_binary(base_dir)
+    print(f"Downloaded PAR2 to {pa}")
+
+    print("6/6 Downloading Pesto...")
+    pe = await PestoBinaryManager.ensure_pesto_binary(base_dir)
+    print(f"Downloaded Pesto to {pe}")
+
+    print("All internal utility binaries downloaded successfully!")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/bin/download_release_dependencies.py
+++ b/bin/download_release_dependencies.py
@@ -1,0 +1,196 @@
+# Upload Assistant © 2026 Audionut & wastaken7 — Licensed under UAPL v1.0
+import os
+import shutil
+import sys
+import tarfile
+import urllib.request
+import zipfile
+from pathlib import Path
+
+# URLs for FFmpeg and MediaInfo
+WIN_FFMPEG = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip"
+WIN_MEDIAINFO_DLL = "https://mediaarea.net/download/binary/libmediainfo0/24.06/MediaInfo_DLL_24.06_Windows_x64_WithoutInstaller.7z"
+WIN_MEDIAINFO_CLI = "https://mediaarea.net/download/binary/mediainfo/24.06/MediaInfo_CLI_24.06_Windows_x64.zip"
+
+LINUX_FFMPEG = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz"
+LINUX_MEDIAINFO_SO = "https://mediaarea.net/download/binary/libmediainfo0/23.04/MediaInfo_DLL_23.04_Lambda_x86_64.zip"
+LINUX_MEDIAINFO_CLI = "https://mediaarea.net/download/binary/mediainfo/23.04/MediaInfo_CLI_23.04_Lambda_x86_64.zip"
+
+
+def download_file(url: str, dest: Path) -> None:
+    print(f"Downloading {url} to {dest}...")
+    headers = {"User-Agent": "Mozilla/5.0"}
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req, timeout=60) as response, open(dest, "wb") as out_file:
+        shutil.copyfileobj(response, out_file)
+    print("Download completed.")
+
+
+def _is_safe_extract(name: str, extract_to: Path, size: int, archive_path: Path, max_size: int = 500 * 1024 * 1024) -> bool:
+    if os.path.isabs(name) or ".." in name or name.startswith("/"):
+        return False
+    full_path = os.path.realpath(os.path.join(extract_to, name))
+    base_path = os.path.realpath(extract_to)
+    if not full_path.startswith(base_path + os.sep) and full_path != base_path:
+        return False
+    if size > max_size:
+        print(f"Warning: Skipping oversized member '{name}' in archive '{archive_path}' ({size} bytes, limit is {max_size} bytes)")
+        return False
+    return True
+
+
+def extract_zip(zip_path: Path, extract_to: Path) -> None:
+    print(f"Extracting {zip_path}...")
+    import stat
+    with zipfile.ZipFile(zip_path, "r") as zip_ref:
+        for member in zip_ref.namelist():
+            info = zip_ref.getinfo(member)
+            perm = info.external_attr >> 16
+            if stat.S_ISLNK(perm):
+                continue
+            try:
+                file_size = info.file_size
+            except Exception:
+                file_size = 0
+            if not _is_safe_extract(member, extract_to, file_size, zip_path):
+                continue
+            zip_ref.extract(member, extract_to)
+
+
+def extract_tar_xz(tar_path: Path, extract_to: Path) -> None:
+    print(f"Extracting {tar_path}...")
+    with tarfile.open(tar_path, "r:xz") as tar_ref:
+        for member in tar_ref.getmembers():
+            if member.islnk() or member.issym():
+                continue
+            if not _is_safe_extract(member.name, extract_to, member.size, tar_path):
+                continue
+            tar_ref.extract(member, extract_to)
+
+
+def extract_7z(archive_path: Path, extract_to: Path) -> None:
+    print(f"Extracting {archive_path} using bundled 7-Zip...")
+    base_dir = Path(__file__).resolve().parent.parent
+    is_windows = sys.platform == "win32"
+    if is_windows:
+        seven_zip_path = base_dir / "bin" / "7z" / "windows" / "x86_64" / "7zr.exe"
+        if not seven_zip_path.exists():
+            seven_zip_path = Path(shutil.which("7z") or "7z")
+    else:
+        # On Linux, GHA runner can have 7z installed, or we use our downloaded 7zz
+        seven_zip_path = base_dir / "bin" / "7z" / "linux" / "amd64" / "7zz"
+        # If it doesn't exist, try standard system 7z
+        if not seven_zip_path.exists():
+            seven_zip_path = Path(shutil.which("7z") or "7z")
+
+    if not seven_zip_path.exists() and not shutil.which("7z"):
+        raise FileNotFoundError("7-Zip binary not found. Please run download_all_build_binaries.py first.")
+
+    import subprocess
+    cmd = [str(seven_zip_path), "x", str(archive_path), f"-o{extract_to}", "-y"]
+    subprocess.run(cmd, check=True)
+
+
+def main() -> None:
+    # Setup directories
+    base_dir = Path(__file__).resolve().parent.parent
+    bin_dir = base_dir / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    temp_dir = base_dir / "tmp_build_downloads"
+    temp_dir.mkdir(parents=True, exist_ok=True)
+
+    is_windows = sys.platform == "win32"
+
+    if is_windows:
+        # Download FFmpeg for Windows
+        ffmpeg_zip = temp_dir / "ffmpeg.zip"
+        download_file(WIN_FFMPEG, ffmpeg_zip)
+        ffmpeg_extract = temp_dir / "ffmpeg_extracted"
+        extract_zip(ffmpeg_zip, ffmpeg_extract)
+
+        # Locate ffmpeg.exe and ffprobe.exe
+        for p in ffmpeg_extract.glob("**/ffmpeg.exe"):
+            shutil.copy2(p, bin_dir / "ffmpeg.exe")
+        for p in ffmpeg_extract.glob("**/ffprobe.exe"):
+            shutil.copy2(p, bin_dir / "ffprobe.exe")
+
+        # Download MediaInfo DLL for Windows
+        mi_dll_7z = temp_dir / "mediainfo_dll.7z"
+        download_file(WIN_MEDIAINFO_DLL, mi_dll_7z)
+        mi_dll_extract = temp_dir / "mediainfo_dll_extracted"
+        extract_7z(mi_dll_7z, mi_dll_extract)
+        for p in mi_dll_extract.glob("**/MediaInfo.dll"):
+            shutil.copy2(p, bin_dir / "MediaInfo.dll")
+
+        # Download MediaInfo CLI for Windows
+        mi_cli_zip = temp_dir / "mediainfo_cli.zip"
+        download_file(WIN_MEDIAINFO_CLI, mi_cli_zip)
+        mi_cli_extract = temp_dir / "mediainfo_cli_extracted"
+        extract_zip(mi_cli_zip, mi_cli_extract)
+        for p in mi_cli_extract.glob("**/MediaInfo.exe"):
+            shutil.copy2(p, bin_dir / "MediaInfo.exe")
+
+    else:
+        # Download FFmpeg for Linux
+        ffmpeg_tar = temp_dir / "ffmpeg.tar.xz"
+        download_file(LINUX_FFMPEG, ffmpeg_tar)
+        ffmpeg_extract = temp_dir / "ffmpeg_extracted"
+        extract_tar_xz(ffmpeg_tar, ffmpeg_extract)
+
+        # Locate ffmpeg and ffprobe
+        for p in ffmpeg_extract.glob("**/ffmpeg"):
+            shutil.copy2(p, bin_dir / "ffmpeg")
+            os.chmod(bin_dir / "ffmpeg", 0o755)
+        for p in ffmpeg_extract.glob("**/ffprobe"):
+            shutil.copy2(p, bin_dir / "ffprobe")
+            os.chmod(bin_dir / "ffprobe", 0o755)
+
+        # Download MediaInfo SO (Lambda build) for Linux
+        mi_so_zip = temp_dir / "mediainfo_so.zip"
+        download_file(LINUX_MEDIAINFO_SO, mi_so_zip)
+        mi_so_extract = temp_dir / "mediainfo_so_extracted"
+        extract_zip(mi_so_zip, mi_so_extract)
+
+        # Search for libmediainfo.so or libmediainfo.so.0
+        found_so = False
+        for p in mi_so_extract.glob("**/libmediainfo.so*"):
+            shutil.copy2(p, bin_dir / "libmediainfo.so")
+            os.chmod(bin_dir / "libmediainfo.so", 0o755)
+            found_so = True
+            break
+        if not found_so:
+            # Fallback search
+            for root, _, files in os.walk(mi_so_extract):
+                for f in files:
+                    if "libmediainfo.so" in f:
+                        shutil.copy2(os.path.join(root, f), bin_dir / "libmediainfo.so")
+                        os.chmod(bin_dir / "libmediainfo.so", 0o755)
+                        break
+
+        # Download MediaInfo CLI for Linux
+        mi_cli_zip = temp_dir / "mediainfo_cli.zip"
+        download_file(LINUX_MEDIAINFO_CLI, mi_cli_zip)
+        mi_cli_extract = temp_dir / "mediainfo_cli_extracted"
+        extract_zip(mi_cli_zip, mi_cli_extract)
+
+        found_cli = False
+        for p in mi_cli_extract.glob("**/mediainfo"):
+            shutil.copy2(p, bin_dir / "mediainfo")
+            os.chmod(bin_dir / "mediainfo", 0o755)
+            found_cli = True
+            break
+        if not found_cli:
+            for root, _, files in os.walk(mi_cli_extract):
+                for f in files:
+                    if f == "mediainfo":
+                        shutil.copy2(os.path.join(root, f), bin_dir / "mediainfo")
+                        os.chmod(bin_dir / "mediainfo", 0o755)
+                        break
+
+    # Cleanup temp directory
+    shutil.rmtree(temp_dir, ignore_errors=True)
+    print("FFmpeg and MediaInfo dependencies downloaded successfully.")
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/get_7z.py
+++ b/bin/get_7z.py
@@ -58,10 +58,30 @@ class SevenZipBinaryManager:
         file_pattern = platform_info["file"]
         folder_path = platform_info["folder"]
 
+        import sys
+
+        binary_name = "7zr.exe" if system == "windows" else "7zz"
+
+        try:
+            from src.path_utils import get_bundled_binary_path
+        except ImportError:
+            get_bundled_binary_path = None
+
+        if get_bundled_binary_path:
+            bundled_path = get_bundled_binary_path("7z", folder_path, binary_name)
+            if bundled_path:
+                logger.debug(f"[blue]Using bundled 7-Zip binary: {bundled_path}[/blue]")
+                return bundled_path
+        elif getattr(sys, "frozen", False):
+            bundle_bin_dir = Path(sys._MEIPASS) / "bin" / "7z" / folder_path
+            bundle_binary_path = bundle_bin_dir / binary_name
+            if bundle_binary_path.exists():
+                logger.debug(f"[blue]Using bundled 7-Zip binary: {bundle_binary_path}[/blue]")
+                return str(bundle_binary_path)
+
         bin_dir = Path(base_dir) / "bin" / "7z" / folder_path
         bin_dir.mkdir(parents=True, exist_ok=True)
 
-        binary_name = "7zr.exe" if system == "windows" else "7zz"
         binary_path = bin_dir / binary_name
         version_path = bin_dir / version
 

--- a/bin/get_7z.py
+++ b/bin/get_7z.py
@@ -16,7 +16,21 @@ except ImportError:
         def print(self, message: str, markup: bool = False) -> None:  # noqa: ARG002
             print(message)
 
+    class SimpleLogger:
+        def info(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
+        def warning(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
+        def error(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
+        def debug(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
     console = SimpleConsole()
+    logger = SimpleLogger()
 
 
 class SevenZipBinaryManager:

--- a/bin/get_bdinfo.py
+++ b/bin/get_bdinfo.py
@@ -18,7 +18,21 @@ except ImportError:
         def print(self, message: str, markup: bool = False) -> None:  # noqa: ARG002
             print(message)
 
+    class SimpleLogger:
+        def info(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
+        def warning(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
+        def error(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
+        def debug(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
     console = SimpleConsole()
+    logger = SimpleLogger()
 
 
 class BDInfoBinaryManager:

--- a/bin/get_bdinfo.py
+++ b/bin/get_bdinfo.py
@@ -63,11 +63,31 @@ class BDInfoBinaryManager:
         logger.debug(f"[blue]Using file pattern: {file_pattern}[/blue]")
         logger.debug(f"[blue]Target folder: {folder_path}[/blue]")
 
+        import sys
+
+        binary_name = "bdinfo.exe" if system == "windows" else "bdinfo"
+
+        try:
+            from src.path_utils import get_bundled_binary_path
+        except ImportError:
+            get_bundled_binary_path = None
+
+        if get_bundled_binary_path:
+            bundled_path = get_bundled_binary_path("bdinfo", folder_path, binary_name)
+            if bundled_path:
+                logger.debug(f"[blue]Using bundled BDInfo binary: {bundled_path}[/blue]")
+                return bundled_path
+        elif getattr(sys, "frozen", False):
+            bundle_bin_dir = Path(sys._MEIPASS) / "bin" / "bdinfo" / folder_path
+            bundle_binary_path = bundle_bin_dir / binary_name
+            if bundle_binary_path.exists():
+                logger.debug(f"[blue]Using bundled BDInfo binary: {bundle_binary_path}[/blue]")
+                return str(bundle_binary_path)
+
         bin_dir = Path(base_dir) / "bin" / "bdinfo" / folder_path
         bin_dir.mkdir(parents=True, exist_ok=True)
         logger.debug(f"[blue]Binary directory: {bin_dir}[/blue]")
 
-        binary_name = "bdinfo.exe" if system == "windows" else "bdinfo"
         binary_path = bin_dir / binary_name
         logger.debug(f"[blue]Binary path: {binary_path}[/blue]")
 

--- a/bin/get_bdinfo_docker.py
+++ b/bin/get_bdinfo_docker.py
@@ -18,7 +18,21 @@ except ImportError:
         def print(self, message: str, markup: bool = False) -> None:  # noqa: ARG002
             print(message)
 
+    class SimpleLogger:
+        def info(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
+        def warning(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
+        def error(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
+        def debug(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
     console = SimpleConsole()
+    logger = SimpleLogger()
 
 
 BDINFO_VERSION = "v1.0.8"

--- a/bin/get_dvd_mediainfo_docker.py
+++ b/bin/get_dvd_mediainfo_docker.py
@@ -24,7 +24,21 @@ except ImportError:
         def print(self, message: str, markup: bool = False) -> None:  # noqa: ARG002
             print(message)
 
+    class SimpleLogger:
+        def info(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
+        def warning(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
+        def error(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
+        def debug(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
     console = SimpleConsole()
+    logger = SimpleLogger()
 
 MEDIAINFO_VERSION = "23.04"
 MEDIAINFO_CLI_BASE_URL = "https://mediaarea.net/download/binary/mediainfo"

--- a/bin/get_mkbrr.py
+++ b/bin/get_mkbrr.py
@@ -63,11 +63,25 @@ class MkbrrBinaryManager:
         logger.debug(f"[blue]Using file pattern: {file_pattern}[/blue]")
         logger.debug(f"[blue]Target folder: {folder_path}[/blue]")
 
+        binary_name = "mkbrr.exe" if system == "windows" else "mkbrr"
+
+        from src.path_utils import get_bundled_binary_path
+
+        bundled_path = get_bundled_binary_path("mkbrr", folder_path, binary_name)
+        if bundled_path:
+            if system != "windows":
+                try:
+                    p = Path(bundled_path)
+                    p.chmod(p.stat().st_mode | stat.S_IEXEC)
+                except Exception as e:
+                    logger.debug(f"[yellow]Failed to set execute permission on bundled binary: {e}[/yellow]")
+            logger.debug(f"[blue]Using bundled mkbrr binary: {bundled_path}[/blue]")
+            return bundled_path
+
         bin_dir = Path(base_dir) / "bin" / "mkbrr" / folder_path
         bin_dir.mkdir(parents=True, exist_ok=True)
         logger.debug(f"[blue]Binary directory: {bin_dir}[/blue]")
 
-        binary_name = "mkbrr.exe" if system == "windows" else "mkbrr"
         binary_path = bin_dir / binary_name
         logger.debug(f"[blue]Binary path: {binary_path}[/blue]")
 

--- a/bin/get_mkbrr.py
+++ b/bin/get_mkbrr.py
@@ -17,7 +17,21 @@ except ImportError:
         def print(self, message: str, markup: bool = False) -> None:  # noqa: ARG002
             print(message)
 
+    class SimpleLogger:
+        def info(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
+        def warning(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
+        def error(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
+        def debug(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
     console = SimpleConsole()
+    logger = SimpleLogger()
 
 
 class MkbrrBinaryManager:

--- a/bin/get_nyuu.py
+++ b/bin/get_nyuu.py
@@ -17,7 +17,21 @@ except ImportError:
         def print(self, message: str, markup: bool = False) -> None:  # noqa: ARG002
             print(message)
 
+    class SimpleLogger:
+        def info(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
+        def warning(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
+        def error(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
+        def debug(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
     console = SimpleConsole()
+    logger = SimpleLogger()
 
 
 class NyuuBinaryManager:

--- a/bin/get_nyuu.py
+++ b/bin/get_nyuu.py
@@ -60,10 +60,30 @@ class NyuuBinaryManager:
         file_pattern = platform_info["file"]
         folder_path = platform_info["folder"]
 
+        import sys
+
+        binary_name = "nyuu.exe" if system == "windows" else "nyuu"
+
+        try:
+            from src.path_utils import get_bundled_binary_path
+        except ImportError:
+            get_bundled_binary_path = None
+
+        if get_bundled_binary_path:
+            bundled_path = get_bundled_binary_path("nyuu", folder_path, binary_name)
+            if bundled_path:
+                logger.debug(f"[blue]Using bundled Nyuu binary: {bundled_path}[/blue]")
+                return bundled_path
+        elif getattr(sys, "frozen", False):
+            bundle_bin_dir = Path(sys._MEIPASS) / "bin" / "nyuu" / folder_path
+            bundle_binary_path = bundle_bin_dir / binary_name
+            if bundle_binary_path.exists():
+                logger.debug(f"[blue]Using bundled Nyuu binary: {bundle_binary_path}[/blue]")
+                return str(bundle_binary_path)
+
         bin_dir = Path(base_dir) / "bin" / "nyuu" / folder_path
         bin_dir.mkdir(parents=True, exist_ok=True)
 
-        binary_name = "nyuu.exe" if system == "windows" else "nyuu"
         binary_path = bin_dir / binary_name
         version_path = bin_dir / version
 

--- a/bin/get_par2.py
+++ b/bin/get_par2.py
@@ -57,10 +57,29 @@ class Par2BinaryManager:
         file_pattern = platform_info["file"]
         folder_path = platform_info["folder"]
 
+        import sys
+        binary_name = "par2.exe" if system == "windows" else "par2"
+
+        try:
+            from src.path_utils import get_bundled_binary_path
+        except ImportError:
+            get_bundled_binary_path = None
+
+        if get_bundled_binary_path:
+            bundled_path = get_bundled_binary_path("par2", folder_path, binary_name)
+            if bundled_path:
+                logger.debug(f"[blue]Using bundled par2 binary: {bundled_path}[/blue]")
+                return bundled_path
+        elif getattr(sys, "frozen", False):
+            bundle_bin_dir = Path(sys._MEIPASS) / "bin" / "par2" / folder_path
+            bundle_binary_path = bundle_bin_dir / binary_name
+            if bundle_binary_path.exists():
+                logger.debug(f"[blue]Using bundled par2 binary: {bundle_binary_path}[/blue]")
+                return str(bundle_binary_path)
+
         bin_dir = Path(base_dir) / "bin" / "par2" / folder_path
         bin_dir.mkdir(parents=True, exist_ok=True)
 
-        binary_name = "par2.exe" if system == "windows" else "par2"
         binary_path = bin_dir / binary_name
         version_path = bin_dir / version
 

--- a/bin/get_par2.py
+++ b/bin/get_par2.py
@@ -16,7 +16,21 @@ except ImportError:
         def print(self, message: str, markup: bool = False) -> None:  # noqa: ARG002
             print(message)
 
+    class SimpleLogger:
+        def info(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
+        def warning(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
+        def error(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
+        def debug(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
     console = SimpleConsole()
+    logger = SimpleLogger()
 
 
 class Par2BinaryManager:

--- a/bin/get_pesto.py
+++ b/bin/get_pesto.py
@@ -45,10 +45,30 @@ class PestoBinaryManager:
         file_pattern = platform_info["file"]
         folder_path = platform_info["folder"]
 
+        import sys
+
+        binary_name = "pesto.exe" if system == "windows" else "pesto"
+
+        try:
+            from src.path_utils import get_bundled_binary_path
+        except ImportError:
+            get_bundled_binary_path = None
+
+        if get_bundled_binary_path:
+            bundled_path = get_bundled_binary_path("pesto", folder_path, binary_name)
+            if bundled_path:
+                logger.debug(f"[blue]Using bundled Pesto binary: {bundled_path}[/blue]")
+                return bundled_path
+        elif getattr(sys, "frozen", False):
+            bundle_bin_dir = Path(sys._MEIPASS) / "bin" / "pesto" / folder_path
+            bundle_binary_path = bundle_bin_dir / binary_name
+            if bundle_binary_path.exists():
+                logger.debug(f"[blue]Using bundled Pesto binary: {bundle_binary_path}[/blue]")
+                return str(bundle_binary_path)
+
         bin_dir = Path(base_dir) / "bin" / "pesto" / folder_path
         bin_dir.mkdir(parents=True, exist_ok=True)
 
-        binary_name = "pesto.exe" if system == "windows" else "pesto"
         binary_path = bin_dir / binary_name
         version_path = bin_dir / version
 

--- a/bin/get_pesto.py
+++ b/bin/get_pesto.py
@@ -15,7 +15,21 @@ except ImportError:
         def print(self, message: str, markup: bool = False) -> None:  # noqa: ARG002
             print(message)
 
+    class SimpleLogger:
+        def info(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
+        def warning(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
+        def error(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
+        def debug(self, message: str, extra: dict = None) -> None:  # noqa: ARG002
+            print(message)
+
     console = SimpleConsole()
+    logger = SimpleLogger()
 
 
 class PestoBinaryManager:

--- a/config-generator.py
+++ b/config-generator.py
@@ -4,9 +4,19 @@ import ast
 import json
 import os
 import re
+import sys
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, TypedDict, cast
+
+from src.path_utils import get_resource_path, setup_frozen_environment
+
+if getattr(sys, "frozen", False):
+    base_dir = Path(sys.executable).parent
+    # Prepend sys._MEIPASS and sys._MEIPASS/bin to PATH so system can find bundled binaries
+    setup_frozen_environment()
+else:
+    base_dir = Path(__file__).resolve().parent
 
 from src.check_requirements import check_dependencies
 
@@ -27,7 +37,7 @@ UnexpectedKey = tuple[str, ConfigDict, str]
 
 def read_example_config() -> tuple[ConfigDict | None, ConfigComments]:
     """Read the example config file and return its structure and comments"""
-    example_path = Path("data/example_config.py")
+    example_path = get_resource_path("data", "example_config.py")
     comments: ConfigComments = {}
 
     if not example_path.exists():
@@ -100,10 +110,7 @@ def read_example_config() -> tuple[ConfigDict | None, ConfigComments]:
 
 def load_existing_config() -> tuple[ConfigDict | None, Path | None]:
     """Load an existing config file if available"""
-    config_paths = [
-        Path("data/config.py"),
-        Path("data/config1.py")
-    ]
+    config_paths = [base_dir / "data" / "config.py", base_dir / "data" / "config1.py"]
 
     for path in config_paths:
         if path.exists():
@@ -887,7 +894,7 @@ def configure_discord(
 def generate_config_file(config_data: ConfigDict, existing_path: Path | None = None) -> bool:
     """Generate the config.py file from the config dictionary"""
     # Create output directory if it doesn't exist
-    os.makedirs("data", exist_ok=True)
+    os.makedirs(base_dir / "data", exist_ok=True)
 
     # Determine the output path
     if existing_path:
@@ -899,8 +906,8 @@ def generate_config_file(config_data: ConfigDict, existing_path: Path | None = N
                 dst.write(src.read())
             console.print(f"\n[✓] Created backup of existing config at {backup_path}", markup=False)
     else:
-        config_path = Path("data/config.py")
-        backup_path = Path("data/config.py.bak")
+        config_path = base_dir / "data" / "config.py"
+        backup_path = base_dir / "data" / "config.py.bak"
         if config_path.exists():
             overwrite = input(f"{config_path} already exists. Overwrite? (y/n): ").lower()
             if overwrite == "y":

--- a/data/example_config.py
+++ b/data/example_config.py
@@ -2793,6 +2793,29 @@ config = {
         "pesto_check_retries": 3,
         # Parallel connections used for the verification pass (empty = same as "connections")
         "pesto_check_connections": "",
+        # nyuu only: verify every article is retrievable on the server while
+        # posting is still in progress. Missing articles are reposted and
+        # reverified automatically; the upload is only considered successful
+        # (and the NZB kept) once every article is confirmed. Strongly
+        # recommended — without this, a "successfully posted" article can
+        # still be missing/unpropagated on the server, producing a broken NZB.
+        "nyuu_check": True,
+        # Seconds to wait after EACH article is posted before verifying that
+        # specific article (nyuu --check-delay). Unlike pesto's check_delay
+        # (a single wait after the whole upload finishes), this applies
+        # per-article, so keep it low — nyuu's own default is 5. A larger value
+        # here backs up the check queue on big uploads and can stall posting.
+        "nyuu_check_delay": 5,
+        # Number of check attempts per article before marking it missing (nyuu --check-tries)
+        "nyuu_check_retries": 3,
+        # Connections used for the verification pass (nyuu --check-connections).
+        # Empty (default) splits "connections" in half between posting and
+        # checking, since nyuu checks concurrently with posting and throttles
+        # posting speed to match if checking can't keep up — this keeps the
+        # combined connection count within what you configured. Set explicitly
+        # to instead post at the full "connections" count with this many
+        # additional connections dedicated to checking.
+        "nyuu_check_connections": "",
         # Paths to binaries (defaults to looking in PATH, downloaded automatically if not found)
         # Available at: https://github.com/animetosho/nyuu
         "nyuu_path": "nyuu",

--- a/data/version.py
+++ b/data/version.py
@@ -1,5 +1,22 @@
 # Upload Assistant © 2025 Audionut & wastaken7 — Licensed under UAPL v1.0
 
+__version__ = "v2.3"
+
+"""
+Changelog for version v2.3 (2026-07-08):
+
+## What's Changed
+* **Features & Improvements**:
+  * Added support for MakingOff (MKO) tracker.
+  * Replaced standard print statements with structured logging (added option to save log files).
+  * Improved title, tags, and overview extraction for BJS tracker.
+  * Added automated release binaries workflow.
+  * Cleaned up codebase to resolve Ruff linter issues and prepare for Python 3.14.
+* **Fixes**:
+  * Fixed client handling to respect the `--skip_auto_torrent` argument.
+  * Fixed Usenet handling to avoid passwords that begin with `-`.
+"""
+
 __version__ = "v2.2"
 
 """

--- a/src/check_requirements.py
+++ b/src/check_requirements.py
@@ -10,6 +10,10 @@ def check_dependencies() -> None:
     If the Python version is unsupported or packages are missing, it outputs a clear warning and exits.
     If versions mismatch, it prints a warning but allows execution to continue.
     """
+    # Bypass check if running from frozen binary (PyInstaller)
+    if getattr(sys, "frozen", False):
+        return
+
     # Verify Python version
     required_version = (3, 14)
     if sys.version_info < required_version:

--- a/src/configvalidator.py
+++ b/src/configvalidator.py
@@ -127,6 +127,56 @@ IMAGE_HOST_API_KEYS: dict[str, str] = {
 # Valid torrent client types (must match example_config.py)
 VALID_TORRENT_CLIENTS = ["qbit", "rtorrent", "deluge", "transmission", "watch"]
 
+# Required keys in USENET section when Usenet uploading is active
+USENET_REQUIRED_KEYS = ["host", "port", "username", "password", "newsgroups"]
+
+# Expected types for known USENET keys (must match data/example_config.py's USENET section)
+USENET_KEY_TYPES: dict[str, tuple[type, ...]] = {
+    "enabled": (bool,),
+    "host": (str,),
+    "port": (str, int),
+    "username": (str,),
+    "password": (str,),
+    "ssl": (bool,),
+    "connections": (str, int),
+    "newsgroups": (str,),
+    "poster": (str,),
+    "random_poster": (bool,),
+    "skip_archive": (bool,),
+    "rar_volume_size": (str,),
+    "archive_password": (str,),
+    "par2_percentage": (str, int),
+    "obscure_subject": (bool,),
+    "usenet_uploader": (str,),
+    "pesto_check": (bool,),
+    "pesto_check_delay": (str, int),
+    "pesto_check_retries": (str, int),
+    "pesto_check_connections": (str, int),
+    "nyuu_check": (bool,),
+    "nyuu_check_delay": (str, int),
+    "nyuu_check_retries": (str, int),
+    "nyuu_check_connections": (str, int),
+    "nyuu_path": (str,),
+    "par2_path": (str,),
+    "pesto_path": (str,),
+    "7z_path": (str,),
+    "nzb_output_dir": (str,),
+    "usenet_tmp_dir": (str,),
+}
+
+# USENET keys expected to hold a plain integer or a numeric string
+USENET_NUMERIC_STRING_KEYS = [
+    "port",
+    "connections",
+    "par2_percentage",
+    "pesto_check_delay",
+    "pesto_check_retries",
+    "pesto_check_connections",
+    "nyuu_check_delay",
+    "nyuu_check_retries",
+    "nyuu_check_connections",
+]
+
 
 class ConfigValidationError(Exception):
     """Raised when config validation fails with critical errors."""
@@ -642,40 +692,13 @@ def _validate_usenet_section(usenet: dict[str, Any], is_usenet_active: bool = Fa
 
     # Check required fields for Usenet upload
     if is_usenet_active:
-        required_keys = ["host", "port", "username", "password", "newsgroups"]
-        for key in required_keys:
+        for key in USENET_REQUIRED_KEYS:
             val = usenet.get(key)
             if not val or (isinstance(val, str) and not val.strip()):
                 errors.append(f"[USENET] is active but '{key}' is empty or not configured")
 
     # Validate types of known keys
-    usenet_key_types = {
-        "enabled": (bool,),
-        "host": (str,),
-        "port": (str, int),
-        "username": (str,),
-        "password": (str,),
-        "ssl": (bool,),
-        "connections": (str, int),
-        "newsgroups": (str,),
-        "poster": (str,),
-        "random_poster": (bool,),
-        "rar_volume_size": (str,),
-        "par2_percentage": (str, int),
-        "obscure_subject": (bool,),
-        "nyuu_path": (str,),
-        "par2_path": (str,),
-        "7z_path": (str,),
-        "nzb_output_dir": (str,),
-        "usenet_tmp_dir": (str,),
-        "usenet_uploader": (str,),
-        "pesto_check": (bool,),
-        "pesto_check_delay": (str, int),
-        "pesto_check_retries": (str, int),
-        "pesto_check_connections": (str, int),
-    }
-
-    for key, expected_types in usenet_key_types.items():
+    for key, expected_types in USENET_KEY_TYPES.items():
         if key in usenet and usenet[key] is not None:
             value = usenet[key]
             if not isinstance(value, expected_types):
@@ -684,7 +707,7 @@ def _validate_usenet_section(usenet: dict[str, Any], is_usenet_active: bool = Fa
                 )
 
     # Validate numeric string values
-    for key in ["port", "connections", "par2_percentage", "pesto_check_delay", "pesto_check_retries", "pesto_check_connections"]:
+    for key in USENET_NUMERIC_STRING_KEYS:
         if key in usenet:
             value = usenet[key]
             if isinstance(value, str) and value.strip():

--- a/src/get_desc.py
+++ b/src/get_desc.py
@@ -91,6 +91,10 @@ async def gen_desc(
     if meta.description_template:
         try:
             template_path = f"{meta.base_dir}/data/templates/{meta.description_template}.txt"
+            if not os.path.exists(template_path):
+                from src.path_utils import get_resource_path
+
+                template_path = str(get_resource_path("data", "templates", f"{meta.description_template}.txt"))
             async with aiofiles.open(template_path, encoding="utf-8") as f:
                 template = Template(await f.read())
             template_desc = template.render(meta)

--- a/src/path_utils.py
+++ b/src/path_utils.py
@@ -1,0 +1,32 @@
+# Upload Assistant © 2026 Audionut & wastaken7 — Licensed under UAPL v1.0
+import os
+import sys
+from pathlib import Path
+
+
+def get_resource_path(*parts: str) -> Path:
+    """Get the absolute path to a resource, supporting both dev environment and PyInstaller bundles."""
+    if getattr(sys, "frozen", False):
+        return Path(sys._MEIPASS).joinpath(*parts)
+    else:
+        project_root = Path(__file__).resolve().parent.parent
+        return project_root.joinpath(*parts)
+
+def get_bundled_binary_path(tool_name: str, folder_path: str, binary_name: str) -> str | None:
+    """Get the path to a bundled binary if running in a frozen environment and the binary exists."""
+    if getattr(sys, "frozen", False):
+        bundle_binary_path = Path(sys._MEIPASS) / "bin" / tool_name / folder_path / binary_name
+        if bundle_binary_path.exists():
+            return str(bundle_binary_path)
+    return None
+
+def setup_frozen_environment() -> None:
+    """Safely prepend frozen bundle paths to PATH env variable, avoiding KeyError."""
+    if getattr(sys, "frozen", False):
+        meipass = sys._MEIPASS
+        bin_dir = os.path.join(meipass, "bin")
+        current_path = os.environ.get("PATH", "")
+        new_paths = [meipass, bin_dir]
+        if current_path:
+            new_paths.append(current_path)
+        os.environ["PATH"] = os.path.pathsep.join(new_paths)

--- a/src/trackers/AR.py
+++ b/src/trackers/AR.py
@@ -172,6 +172,10 @@ class AR:
             # using custom mediainfo template.
             # can not use full media info as sometimes its more than max chars per post.
             mi_template = os.path.abspath(f"{meta.base_dir}/data/templates/summary-mediainfo.csv")
+            if not os.path.exists(mi_template):
+                from src.path_utils import get_resource_path
+
+                mi_template = str(get_resource_path("data", "templates", "summary-mediainfo.csv"))
             if os.path.exists(mi_template):
                 media_info = await self.parse_mediainfo_async(video, mi_template)
                 description += (f"""[code]\n{media_info}\n[/code]\n""")

--- a/src/trackers/ASC.py
+++ b/src/trackers/ASC.py
@@ -921,6 +921,10 @@ class ASC:
             filelist = cast(list[str], meta.filelist or [])
             video_file = filelist[0] if filelist else str(meta.path or "")
             template_path = os.path.abspath(f"{meta.base_dir}/data/templates/MEDIAINFO.txt")
+            if not os.path.exists(template_path):
+                from src.path_utils import get_resource_path
+
+                template_path = str(get_resource_path("data", "templates", "MEDIAINFO.txt"))
             if os.path.exists(template_path):
                 mi_output = MediaInfo.parse(
                     video_file,

--- a/src/trackers/BHDTV.py
+++ b/src/trackers/BHDTV.py
@@ -68,6 +68,10 @@ class BHDTV:
             filelist = cast(list[str], meta.filelist or [])
             video = filelist[0] if filelist else (meta.path or "")
             mi_template = os.path.abspath(f"{meta.base_dir}/data/templates/MEDIAINFO.txt")
+            if not os.path.exists(mi_template):
+                from src.path_utils import get_resource_path
+
+                mi_template = str(get_resource_path("data", "templates", "MEDIAINFO.txt"))
             if os.path.exists(mi_template):
                 media_info = MediaInfo.parse(video, output="STRING", full=False,
                                                 mediainfo_options={"inform": f"file://{mi_template}"})

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -1467,7 +1467,12 @@ class COMMON:
             return False
 
         usenet_cfg = self.config.get("USENET", {})
-        if usenet_cfg.get("archive_password") and not await verify_nzb_has_password(nzb_path):
+        # skip_archive means no 7z/rar was created (for either uploader — pesto's
+        # --nzb-password only tags NZB metadata, it doesn't encrypt), so a
+        # configured password was never applied and won't be in the NZB.
+        # That's expected, not an error.
+        password_applies = bool(usenet_cfg.get("archive_password")) and not usenet_cfg.get("skip_archive", False)
+        if password_applies and not await verify_nzb_has_password(nzb_path):
             logger.error(f"{tracker}: [red]Error: The NZB file does not contain the password in its metadata header. Aborting upload...[/red]")
             return False
         return True

--- a/src/usenetcreate.py
+++ b/src/usenetcreate.py
@@ -806,6 +806,12 @@ async def prepare_and_upload_usenet(meta: Meta, config: dict[str, Any]) -> str |
     total_size = await asyncio.to_thread(get_path_size, input_path)
 
     if skip_archive:
+        if archive_password:
+            logger.warning(
+                "[yellow]Warning: 'archive_password' is set but 'skip_archive' is enabled — no archive "
+                "will be created, so this upload will proceed as if no password were configured (the "
+                "password is only meaningful when compressing into a 7z/rar).[/yellow]"
+            )
         # Skip 7z entirely — copy files/dir contents straight to usenet_dir
         logger.info("[cyan]Skipping archive step; copying files directly for upload...[/cyan]")
         if await aiofiles.ospath.isdir(input_path):
@@ -872,7 +878,10 @@ async def prepare_and_upload_usenet(meta: Meta, config: dict[str, Any]) -> str |
             logger.info("[cyan]Generating PAR2 parity files...[/cyan]")
             par2_file = f"{archive_name}.par2"
             relative_target_files = [os.path.basename(f) for f in target_files]
-            cmd_par2 = [path_par2 or "par2", "c", f"-r{par2_percentage}", "-n1", par2_file] + relative_target_files
+            # No -n/-u/-l flag: par2cmdline falls back to its default scheme of
+            # exponentially-sized recovery volumes, matching standard Usenet posts
+            # and letting repair tools fetch only as much recovery data as needed.
+            cmd_par2 = [path_par2 or "par2", "c", f"-r{par2_percentage}", par2_file] + relative_target_files
             if is_debug and not path_par2:
                 logger.info(f"[yellow][DEBUG SIMULATION] Would run: {' '.join(cmd_par2)}[/yellow]")
                 mock_par2 = os.path.normpath(os.path.join(usenet_dir, par2_file))
@@ -957,7 +966,11 @@ async def prepare_and_upload_usenet(meta: Meta, config: dict[str, Any]) -> str |
         if obscure_subject and not custom_subject:
             cmd_pesto.append("--obfuscate=full")
 
-        if archive_password:
+        # --nzb-password only writes the <meta type="password"> tag in the NZB;
+        # it doesn't itself encrypt anything (that would be pesto's own
+        # --password/--compress, which UA never passes here). Real protection
+        # still comes from the 7z step above, so gate this the same way.
+        if archive_password and not skip_archive:
             cmd_pesto.extend(["--nzb-password", archive_password])
 
         # --check: after posting, verify every article is retrievable via STAT.
@@ -1066,8 +1079,10 @@ async def prepare_and_upload_usenet(meta: Meta, config: dict[str, Any]) -> str |
                         await aiofiles.os.remove(nzb_file)
                 raise
 
-        # nyuu doesn't inject the password into the NZB — do it manually
-        if archive_password and await aiofiles.ospath.exists(nzb_file):
+        # nyuu doesn't inject the password into the NZB — do it manually.
+        # Skipped when skip_archive is on: no 7z archive was created to encrypt,
+        # so the password never protected anything and shouldn't be advertised.
+        if archive_password and not skip_archive and await aiofiles.ospath.exists(nzb_file):
             if is_debug:
                 logger.info(f"[cyan][DEBUG SIMULATION] Injecting password '{archive_password}' into NZB file...[/cyan]")
             else:

--- a/src/usenetcreate.py
+++ b/src/usenetcreate.py
@@ -13,7 +13,6 @@ from typing import Any
 import aiofiles
 import aiofiles.os
 import aiofiles.ospath
-import cli_ui
 from rich.progress import BarColumn, Progress, TaskID, TaskProgressColumn, TextColumn
 
 from src.console import console, logger
@@ -67,6 +66,32 @@ def get_dynamic_volume_size(total_bytes: int) -> str:
         return "500m"
     else:
         return "1g"
+
+
+def compute_nyuu_connections(total_connections: int, nyuu_check_enabled: bool, check_connections_cfg: str | int | None) -> tuple[int, int | None]:
+    """Split the configured connection budget between nyuu posting and checking.
+
+    Unlike pesto (which checks in a separate phase after posting finishes), nyuu
+    checks concurrently with posting over its own connections, and throttles
+    posting speed to match if the check connections can't keep up. So by default
+    (check_connections_cfg empty), `total_connections` is split between posting
+    and checking, keeping the combined socket count within what was configured
+    instead of adding check connections on top of it. An explicit
+    check_connections_cfg overrides this and posts at the full connection count,
+    with that many additional connections dedicated to checking.
+
+    Returns (post_connections, check_connections), where check_connections is
+    None when checking is disabled.
+    """
+    if not nyuu_check_enabled:
+        return total_connections, None
+
+    if check_connections_cfg not in (None, ""):
+        return total_connections, int(check_connections_cfg)
+
+    post_connections = max(1, total_connections // 2)
+    check_connections = max(1, total_connections - post_connections)
+    return post_connections, check_connections
 
 
 async def check_binary(binary_name: str, config_path: str | None = None, meta: Meta | None = None, path_7z: str | None = None) -> str:
@@ -231,7 +256,13 @@ async def run_7z_with_progress(cmd: list[str], usenet_dir: str, safe_name: str, 
 
 
 async def run_par2_with_progress(cmd: list[str], cwd: str | None = None) -> None:
-    """Execute par2 c with real-time percentage progress parsing."""
+    """Execute par2 c with real-time percentage progress via a persistent rich progress bar.
+
+    par2 redraws its percentage in place using carriage returns with no trailing newline,
+    so readline() (which only splits on '\\n') can't pick up individual updates — it would
+    buffer everything into one blob until an unrelated real newline happens to show up.
+    Reads raw chunks instead and splits on either '\\r' or '\\n' to get each update.
+    """
     redacted_cmd = []
     skip_next = False
     for i, arg in enumerate(cmd):
@@ -253,31 +284,56 @@ async def run_par2_with_progress(cmd: list[str], cwd: str | None = None) -> None
         process = await asyncio.create_subprocess_exec(*cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT, cwd=cwd)
 
         stdout_accum = []
-        last_percent = 0
 
         if process.stdout is None:
             raise RuntimeError("Process stdout is None")
 
-        while True:
-            line_bytes = await process.stdout.readline()
-            if not line_bytes:
-                break
-            line = line_bytes.decode(errors="replace")
-            stdout_accum.append(line)
-            line = line.strip()
+        tasks: dict[str, TaskID] = {}
+        buffer = b""
+        with Progress(
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            TaskProgressColumn(),
+            console=console,
+            transient=False,
+        ) as progress:
+            while True:
+                chunk = await process.stdout.read(4096)
+                if not chunk:
+                    break
+                stdout_accum.append(chunk.decode(errors="replace"))
+                buffer += chunk
 
-            match = re.search(r"(\d+(?:\.\d+)?)%", line)
-            if match:
-                percent = float(match.group(1))
-                last_percent = int(percent)
-                action = "Generating PAR2"
-                if "Computing" in line:
-                    action = "Computing PAR2"
-                elif "Writing" in line:
-                    action = "Writing PAR2"
-                elif "Loading" in line:
-                    action = "Loading PAR2"
-                cli_ui.info_progress(f"{action}... {percent:.1f}%", int(percent), 100)
+                while True:
+                    idx_r = buffer.find(b"\r")
+                    idx_n = buffer.find(b"\n")
+                    candidates = [i for i in (idx_r, idx_n) if i != -1]
+                    if not candidates:
+                        break
+                    idx = min(candidates)
+                    line = buffer[:idx].decode(errors="replace").strip()
+                    buffer = buffer[idx + 1 :]
+                    if not line:
+                        continue
+
+                    match = re.search(r"(\d+(?:\.\d+)?)%", line)
+                    if match:
+                        percent = float(match.group(1))
+                        action = "Generating PAR2"
+                        if "Constructing" in line:
+                            action = "Computing PAR2 recovery matrix"
+                        elif "Processing" in line or "Computing" in line:
+                            action = "Computing PAR2"
+                        elif "Writing" in line:
+                            action = "Writing PAR2"
+                        elif "Loading" in line:
+                            action = "Loading PAR2"
+                        if "par2" not in tasks:
+                            tasks["par2"] = progress.add_task(action, total=100)
+                        progress.update(tasks["par2"], description=action, completed=percent)
+
+            if "par2" in tasks:
+                progress.update(tasks["par2"], completed=100)
 
         await process.wait()
 
@@ -288,16 +344,18 @@ async def run_par2_with_progress(cmd: list[str], cwd: str | None = None) -> None
                 logger.info(f"[red]OUTPUT:[/red]\n{stdout_str}")
             raise RuntimeError(f"Command '{redacted_str}' failed with exit code {process.returncode}")
 
-        # Finish progress display cleanly
-        if last_percent < 100:
-            cli_ui.info_progress("Generating PAR2... 100.0%", 100, 100)
-
     except Exception as e:
         raise RuntimeError(f"Failed to execute command '{redacted_str}': {e}") from e
 
 
 async def run_nyuu_with_progress(cmd: list[str], cwd: str | None = None) -> None:
-    """Execute nyuu upload with real-time speed, ETA, and percentage progress parsing."""
+    """Execute nyuu upload, parsing its periodic `--progress log` output for posting/check status.
+
+    Nyuu's default terminal progress indicator redraws a single line via carriage-return
+    style ANSI codes with no trailing newline, which readline()-based parsing can't pick up
+    incrementally. `--progress log:Ns` instead emits a normal newline-terminated log line on
+    a fixed interval, which is what's parsed here.
+    """
     redacted_cmd = []
     skip_next = False
     for i, arg in enumerate(cmd):
@@ -315,36 +373,55 @@ async def run_nyuu_with_progress(cmd: list[str], cwd: str | None = None) -> None
     cwd_str = f" in {cwd}" if cwd else ""
     logger.debug(f"[cyan]Running command: {redacted_str}{cwd_str}[/cyan]")
 
+    total_re = re.compile(r"Uploading (\d+) article\(s\)")
+    progress_re = re.compile(r"Article posting progress: \d+ read, (\d+) posted(?:, (\d+) checked)?")
+
     try:
         process = await asyncio.create_subprocess_exec(*cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT, cwd=cwd)
 
         stdout_accum = []
-        last_percent = 0
+        total_articles = 0
 
         if process.stdout is None:
             raise RuntimeError("Process stdout is None")
 
-        while True:
-            line_bytes = await process.stdout.readline()
-            if not line_bytes:
-                break
-            line = line_bytes.decode(errors="replace")
-            stdout_accum.append(line)
-            line = line.strip()
+        tasks: dict[str, TaskID] = {}
+        with Progress(
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            TaskProgressColumn(),
+            console=console,
+            transient=False,
+        ) as progress:
+            while True:
+                line_bytes = await process.stdout.readline()
+                if not line_bytes:
+                    break
+                line = line_bytes.decode(errors="replace")
+                stdout_accum.append(line)
+                line = line.strip()
 
-            if "Upload:" in line:
-                match = re.search(r"\((\d+(?:\.\d+)?)\%\)", line)
-                if match:
-                    percent = float(match.group(1))
-                    last_percent = int(percent)
-                    # Extract speed and ETA if possible
-                    speed_match = re.search(r"\|\s*([\d\.]+\s*\w+/s)", line)
-                    eta_match = re.search(r"ETA:\s*([\d:]+)", line)
+                total_match = total_re.search(line)
+                if total_match:
+                    total_articles = int(total_match.group(1))
 
-                    speed_str = f" ({speed_match.group(1)})" if speed_match else ""
-                    eta_str = f" | ETA: {eta_match.group(1)}" if eta_match else ""
+                progress_match = progress_re.search(line)
+                if progress_match and total_articles:
+                    posted = int(progress_match.group(1))
+                    checked = progress_match.group(2)
+                    if checked is not None:
+                        checked = int(checked)
+                        pct = ((checked + posted) / 2) / total_articles * 100
+                        description = "Verifying articles on server" if posted >= total_articles else "Posting & verifying to Usenet"
+                    else:
+                        pct = posted / total_articles * 100
+                        description = "Posting to Usenet"
+                    if "upload" not in tasks:
+                        tasks["upload"] = progress.add_task(description, total=100)
+                    progress.update(tasks["upload"], description=description, completed=pct)
 
-                    cli_ui.info_progress(f"Posting to Usenet...{speed_str}{eta_str}", int(percent), 100)
+            if "upload" in tasks:
+                progress.update(tasks["upload"], completed=100)
 
         await process.wait()
 
@@ -354,10 +431,6 @@ async def run_nyuu_with_progress(cmd: list[str], cwd: str | None = None) -> None
             if stdout_str:
                 logger.info(f"[red]OUTPUT:[/red]\n{stdout_str}")
             raise RuntimeError(f"Command '{redacted_str}' failed with exit code {process.returncode}")
-
-        # Finish progress display cleanly
-        if last_percent < 100:
-            cli_ui.info_progress("Posting to Usenet... 100.0%", 100, 100)
 
     except Exception as e:
         raise RuntimeError(f"Failed to execute command '{redacted_str}': {e}") from e
@@ -925,21 +998,50 @@ async def prepare_and_upload_usenet(meta: Meta, config: dict[str, Any]) -> str |
                 raise
     else:
         # 6b. Upload via nyuu
+        total_connections = int(usenet_cfg.get("connections", 20))
+        nyuu_check_enabled = usenet_cfg.get("nyuu_check", True)
+        post_connections, check_connections = compute_nyuu_connections(total_connections, nyuu_check_enabled, usenet_cfg.get("nyuu_check_connections"))
+
         cmd_nyuu = [
             path_nyuu or "nyuu",
             "-h", usenet_cfg.get("host"),
             "-P", str(usenet_cfg.get("port", 563)),
             "-u", usenet_cfg.get("username"),
             "-p", usenet_cfg.get("password"),
-            "-n", str(usenet_cfg.get("connections", 20)),
+            "-n", str(post_connections),
             "-g", usenet_cfg.get("newsgroups"),
             "-f", poster,
             "-s", subject,
             "-o", nzb_file,
+            "--progress", "log:2s",
         ]
 
         if usenet_cfg.get("ssl", True):
             cmd_nyuu.append("-S")
+
+        # --filename: obfuscate the yEnc "name=" field embedded in each posted
+        # article's body — this is what most indexers/downloaders show as the
+        # "real" filename, independent of the (already obfuscated) Subject
+        # header. ${rand(16)} is resolved once per file and stays identical
+        # across every segment of that file (verified empirically), so
+        # multi-part reconstruction still works; it varies between different
+        # files in the same upload. No on-disk renaming needed.
+        if obscure_subject and not custom_subject:
+            cmd_nyuu.extend(["--filename", "${rand(16)}"])
+
+        # --check-connections: verify every article is retrievable on the server
+        # while posting is still in progress. Missing articles are reposted
+        # automatically and reverified (nyuu --check-post-tries, default 1); nyuu
+        # exits non-zero if any are still missing after that, so we know the NZB
+        # is trustworthy whenever this command succeeds.
+        if nyuu_check_enabled:
+            cmd_nyuu.extend(["--check-connections", str(check_connections)])
+            check_delay = usenet_cfg.get("nyuu_check_delay")
+            if check_delay is not None and str(check_delay).strip() != "":
+                cmd_nyuu.extend(["--check-delay", str(check_delay)])
+            check_retries = usenet_cfg.get("nyuu_check_retries")
+            if check_retries is not None and str(check_retries).strip() != "":
+                cmd_nyuu.extend(["--check-tries", str(check_retries)])
 
         cmd_nyuu.extend(all_upload_files)
 
@@ -948,7 +1050,21 @@ async def prepare_and_upload_usenet(meta: Meta, config: dict[str, Any]) -> str |
             async with aiofiles.open(nzb_file, "w", encoding="utf-8") as f:
                 await f.write(mock_nzb_content)
         else:
-            await run_nyuu_with_progress(cmd_nyuu, cwd=usenet_dir)
+            try:
+                await run_nyuu_with_progress(cmd_nyuu, cwd=usenet_dir)
+            except Exception:
+                # nyuu writes the NZB progressively as files are posted, before
+                # the post-check verification (if enabled) confirms every article
+                # is actually retrievable on the server. A failed check (missing
+                # articles that couldn't be reposted) can still leave a
+                # well-formed (but incomplete) .nzb file behind. is_valid_nzb()
+                # only checks XML structure, so if we don't remove it here, the
+                # next attempt would find it at the top of this function and
+                # reuse it as-is instead of re-uploading the missing articles.
+                with contextlib.suppress(Exception):
+                    if await aiofiles.ospath.exists(nzb_file):
+                        await aiofiles.os.remove(nzb_file)
+                raise
 
         # nyuu doesn't inject the password into the NZB — do it manually
         if archive_password and await aiofiles.ospath.exists(nzb_file):

--- a/upload.py
+++ b/upload.py
@@ -63,7 +63,37 @@ from src.uphelper import UploadHelper
 from src.uploadscreens import UploadScreensManager
 
 cli_ui.setup(color='always', title="Upload Assistant")
-base_dir = os.path.abspath(os.path.dirname(__file__))
+if getattr(sys, "frozen", False):
+    base_dir = os.path.abspath(os.path.dirname(sys.executable))
+    # Prepend sys._MEIPASS and sys._MEIPASS/bin to PATH so system can find bundled binaries
+    from src.path_utils import setup_frozen_environment
+
+    setup_frozen_environment()
+    # Tell pymediainfo to find DLL/so in sys._MEIPASS by monkey-patching MediaInfo.parse
+    try:
+        from pymediainfo import MediaInfo
+
+        _orig_parse = MediaInfo.parse
+        if sys.platform == "win32":
+            lib_path = os.path.join(sys._MEIPASS, "MediaInfo.dll")
+        else:
+            lib_path = os.path.join(sys._MEIPASS, "libmediainfo.so")
+
+        @classmethod
+        def _wrapped_parse(cls, filename, library_file=None, *args, **kwargs):  # noqa: ARG001
+            if library_file is None:
+                library_file = lib_path
+            return _orig_parse(filename, *args, library_file=library_file, **kwargs)
+
+        MediaInfo.parse = _wrapped_parse
+    except Exception:
+        # Fallback to env variable if pymediainfo import/patch fails
+        if sys.platform == "win32":
+            os.environ["MEDIAINFO_PATH"] = os.path.join(sys._MEIPASS, "MediaInfo.dll")
+        else:
+            os.environ["MEDIAINFO_PATH"] = os.path.join(sys._MEIPASS, "libmediainfo.so")
+else:
+    base_dir = os.path.abspath(os.path.dirname(__file__))
 
 # Global state for shutdown handling (reset via _reset_shutdown_state() for in-process runs)
 _shutdown_requested = False


### PR DESCRIPTION
This PR bundles two related pieces of work on the Usenet upload path, done back to back: first making `nyuu` as reliable as `pesto` at confirming a post actually landed, then fixing how the archive password interacts with `skip_archive`. Both commits are described below, in the order they happened.

## Commit 1 — Bring nyuu to parity with pesto's article-check, and fix a filename obfuscation gap

### The reliability gap

`pesto` already had a `--check` step: after posting, it re-verifies every article is actually retrievable on the news server, and reposts anything missing before considering the upload done. `nyuu` supports the exact same capability natively (`--check-connections`/`--check-tries`/`--check-delay`) — it just wasn't wired up in Upload-Assistant. Without it, nyuu could report "success" while some articles silently failed to propagate, leaving you with a broken `.nzb` you wouldn't discover until someone tried to download it.

This is now enabled by default (`nyuu_check: true`). Because nyuu checks *while* posting (concurrently, over its own connections) rather than in a separate phase afterward like pesto, the configured connection budget is now split between posting and checking instead of just adding check connections on top — otherwise you'd end up with more simultaneous server connections than you configured.

One consequence: if the check ultimately finds articles that couldn't be recovered, nyuu now fails loudly. Previously the code could leave a partially-written `.nzb` behind that looked valid (correct XML structure) but was missing content; a retry would find that file and reuse it as-is instead of re-uploading the missing pieces. The failure path now deletes that incomplete file so a retry actually retries.

### The filename leak

`obscure_subject` was only hiding the NNTP `Subject` header — it wasn't touching the yEnc `name=` field embedded inside each article's body, which is what most indexers and download clients actually display as the "real" filename. So even with obfuscation turned on, the real filename could still leak, most easily reproduced whenever `skip_archive` was on (no 7z archive to already obscure the name for you). Fixed using nyuu's own `--filename ${rand(16)}` token, which resolves to the same random value for every segment of a given file (so multi-part reconstruction still works) but varies between different files in the same upload.

### Smaller fixes bundled in while touching this code

- Both nyuu's and PAR2's progress bars were parsing for text patterns that don't reliably appear in their actual output, so they just jumped straight to 100% at the end instead of showing real progress. Both now parse output that's guaranteed to be there.
- `nyuu_check_delay` defaulted to 30s, a value copied from pesto's config without noticing that pesto applies its delay once globally while nyuu applies it *per article* — lowered to nyuu's own native default of 5s to avoid needlessly stalling large uploads.
- The USENET config-key type table lived as a dict rebuilt inline on every validation call instead of a shared constant; hoisted it out, and in doing so noticed `skip_archive`, `archive_password`, and `pesto_path` had no type validation at all — added it.

## Commit 2 — Honor `skip_archive` over `archive_password`, and use exponential PAR2 volumes

### The problem, in short

Upload-Assistant has a `skip_archive` option that skips the compression step (`7z`/`rar`) before posting to Usenet — useful for people who want speed and don't need that extra layer. The problem: when this option was enabled, the tool still behaved as if a password-protected archive existed, even though nothing had actually been encrypted. It's like putting a "locked safe" sticker on a box that's actually open.

This caused two concrete problems:

1. **Phantom password in the `.nzb`**: the generated `.nzb` file (the "receipt" describing what was posted) carried a password tag, but the content was never encrypted with it. The password protected nothing — it was just misleading metadata.
2. **Uploads rejected for no real reason**: some trackers (CRP, DS, SUIO) run their own safeguard that says "if a password is configured, it must be present in the NZB." Once the password stopped being written where it didn't apply, that safeguard started blocking otherwise-valid uploads with `The NZB file does not contain the password in its metadata header`.

### A note on the two different "checks" involved

It's easy to conflate this with Commit 1's article-check work, so to be explicit — these are two unrelated mechanisms:

- **nyuu's `--check-connections` (article check, Commit 1)** — after posting, nyuu re-fetches each article from the NNTP server via STAT to confirm it's actually retrievable. This verifies *delivery to the news server* and has nothing to do with passwords.
- **`COMMON.check_nzb_file` (tracker safeguard, this commit)** — before *submitting* the already-posted NZB to a tracker like CRP, Upload-Assistant verifies the NZB's metadata contains the configured password. This runs client-side and is what produced the `does not contain the password in its metadata header` error.

The error hit in testing came from the second one, not from nyuu's article-check machinery.

### The changes, one by one

**1. The password is only used where it actually protects something.** `archive_password` only has a real effect in one place in the code: the `7z` command that compresses and encrypts the archive (`7z ... -p<password> -mhe=on`). If `skip_archive` is on, that step never runs — so the password never encrypts anything. Now, when that happens, the tool warns the user (`'archive_password' is set but 'skip_archive' is enabled — no archive will be created, so this upload will proceed as if no password were configured`) and no longer writes the password into the `.nzb`. Applies to both `nyuu` and `pesto`.

**2. The `pesto` uploader had the same bug, hidden.** Upload-Assistant passes `pesto` a flag called `--nzb-password`, but per `pesto`'s own docs, that flag **only writes the password into the NZB header** — it doesn't encrypt anything by itself. Real encryption would need a different flag (`--password`/`--compress`), which Upload-Assistant never passes. So on the `pesto` path, the password was *always* just decorative metadata, independent of `skip_archive`. The fix makes `pesto` follow the exact same rule as `nyuu`: only told to write the password when it actually protected something.

**3. The tracker-side safety check is now consistent.** `check_nzb_file` used to treat `pesto` and `nyuu` differently — blindly trusting `pesto`'s password was always valid, while requiring `nyuu`'s password unconditionally regardless of `skip_archive`. Both uploaders now follow the same rule: the password is only required in the `.nzb` when `skip_archive` is off, which is exactly when it's real.

**4. Bonus: PAR2 recovery files now follow standard Usenet convention.** PAR2 is what lets a Usenet post be "repaired" if pieces go missing. The tool used to force a **single** recovery volume (`-n1`), so fixing even the smallest issue meant downloading the entire recovery file. The convention most Usenet posts follow instead is several volumes of increasing size (1, 2, 4, 8, 16 blocks...), so repairs only need to download as much recovery data as actually needed. Removed the hardcoded flag and let `par2cmdline` fall back to its own default behavior, which already follows this scheme.

## How this was validated

Tested the full flow with `skip_archive` enabled and a password configured, on both `nyuu` and `pesto`, watching the upload live end to end — both completed successfully and passed the CRP tracker's validation without the missing-password error.
