### PR TITLE
feat(ZNTH):adjust book titles, narrators, covers, and series

### DIFF
--- a/src/book_extractors.py
+++ b/src/book_extractors.py
@@ -13,6 +13,15 @@ from typing import Any
 from src.console import logger
 
 
+def normalize_series_index(value: str) -> str:
+    """Drop a trailing .0 from a series index ("5.0" -> "5"), keeping "5.5"/"0.5"."""
+    try:
+        idx = float(value)
+    except (TypeError, ValueError):
+        return str(value).strip()
+    return str(int(idx)) if idx.is_integer() else str(idx)
+
+
 def extract_epub_metadata(epub_path: str) -> dict[str, Any]:
     """Extract metadata from an EPUB zip container's OPF file."""
     metadata: dict[str, Any] = {}
@@ -56,6 +65,8 @@ def extract_epub_metadata(epub_path: str) -> dict[str, Any]:
             identifier = ""
             description = ""
             publisher = ""
+            series = ""
+            series_index = ""
 
             for elem in root.iter():
                 tag_local = elem.tag.split("}")[-1]
@@ -79,6 +90,12 @@ def extract_epub_metadata(epub_path: str) -> dict[str, Any]:
                     description = (elem.text or "").strip()
                 elif tag_local == "publisher":
                     publisher = (elem.text or "").strip()
+                elif tag_local == "meta":
+                    meta_name = (elem.attrib.get("name") or "").lower()
+                    if meta_name == "calibre:series":
+                        series = (elem.attrib.get("content") or "").strip()
+                    elif meta_name == "calibre:series_index":
+                        series_index = (elem.attrib.get("content") or "").strip()
 
             if title:
                 metadata["title"] = title
@@ -98,11 +115,24 @@ def extract_epub_metadata(epub_path: str) -> dict[str, Any]:
                 metadata["overview"] = description
             if publisher:
                 metadata["publisher"] = publisher
+            if series:
+                metadata["book_series"] = series
+            if series_index:
+                metadata["book_series_index"] = normalize_series_index(series_index)
 
     except Exception as e:
         logger.debug(f"[yellow]Warning: Error parsing EPUB metadata: {e}[/yellow]")
 
     return metadata
+
+
+def extract_series_from_filename(filename: str) -> tuple[str, str]:
+    """Parse (series, index) from a filename like "Author - Series #5 - Title", or ("", "")."""
+    name = os.path.splitext(os.path.basename(filename))[0]
+    match = re.search(r"[-–]\s*([^-–#\[\]]+?)\s*#\s*(\d+(?:\.\d+)?)", name)
+    if not match:
+        return "", ""
+    return match.group(1).strip(), normalize_series_index(match.group(2))
 
 
 def extract_cbr_cbz_metadata(filepath: str) -> dict[str, Any]:

--- a/src/book_extractors.py
+++ b/src/book_extractors.py
@@ -18,7 +18,7 @@ def normalize_series_index(value: str) -> str:
     try:
         idx = float(value)
     except (TypeError, ValueError):
-        return str(value).strip()
+        return (value).strip()
     return str(int(idx)) if idx.is_integer() else str(idx)
 
 
@@ -416,3 +416,369 @@ def extract_isbn_from_pdf(pdf_path: str) -> str | None:
         logger.debug(f"[yellow]Warning: Error extracting ISBN from PDF: {e}[/yellow]")
 
     return None
+
+
+def date_event_from_str(event_str: str | None) -> str | None:
+    if not event_str:
+        return "Epub"
+    val = event_str.strip().lower()
+    if val == "dcterms:available":
+        return "Available"
+    if val in ("dcterms:created", "publication"):
+        return "Created"
+    if val == "dcterms:date":
+        return "Date"
+    if val == "dcterms:dateaccepted":
+        return "DateAccepted"
+    if val == "dcterms:datecopyrighted":
+        return "DateCopyrighted"
+    if val == "dcterms:datesubmitted":
+        return "DateSubmitted"
+    if val in ("dcterms:issued", "original-publication"):
+        return "Issued"
+    if val == "dcterms:modified":
+        return "Modified"
+    if val == "dcterms:valid":
+        return "Valid"
+    return None
+
+
+def get_attr_ignore_ns(elem: ET.Element, attr_name: str) -> str | None:
+    if attr_name in elem.attrib:
+        return elem.attrib[attr_name]
+    for k, v in elem.attrib.items():
+        if k.split("}")[-1] == attr_name:
+            return v
+    return None
+
+
+def get_epubmeta_output(epub_path: str) -> str | None:
+    """Extract and format EPUB metadata to match the output of epubmeta."""
+    if not os.path.isfile(epub_path) or not zipfile.is_zipfile(epub_path):
+        return None
+
+    try:
+        with zipfile.ZipFile(epub_path, "r") as z:
+            rootfile_path = None
+            try:
+                container_data = z.read("META-INF/container.xml")
+                root = ET.fromstring(container_data)
+                for elem in root.iter():
+                    if elem.tag.split("}")[-1] == "rootfile":
+                        rootfile_path = elem.attrib.get("full-path")
+                        if rootfile_path:
+                            break
+            except Exception:
+                pass
+
+            if not rootfile_path:
+                for name in z.namelist():
+                    if name.endswith(".opf"):
+                        rootfile_path = name
+                        break
+
+            if not rootfile_path or rootfile_path not in z.namelist():
+                return None
+
+            opf_data = z.read(rootfile_path)
+            root = ET.fromstring(opf_data)
+
+            # Get package tag attributes
+            version = get_attr_ignore_ns(root, "version") or ""
+            unique_id = get_attr_ignore_ns(root, "unique-identifier") or ""
+
+            metadata_elem = None
+            for elem in root.iter():
+                if elem.tag.split("}")[-1] == "metadata":
+                    metadata_elem = elem
+                    break
+
+            if metadata_elem is None:
+                return None
+
+            # Collect refinements
+            refinements = []
+            for child in metadata_elem:
+                tag = child.tag.split("}")[-1]
+                if tag == "meta":
+                    refines = get_attr_ignore_ns(child, "refines")
+                    if refines:
+                        ref_id = refines.lstrip("#")
+                        prop = get_attr_ignore_ns(child, "property") or ""
+                        scheme = get_attr_ignore_ns(child, "scheme") or ""
+                        text = (child.text or "").strip()
+                        refinements.append({"refId": ref_id, "refProp": prop, "refScheme": scheme, "refText": text})
+
+            def find_refinement(ref_id, prop):
+                for r in refinements:
+                    if r["refId"] == ref_id and r["refProp"] == prop:
+                        return r
+                return None
+
+            identifiers = []
+            titles = []
+            languages = []
+            contributors = []
+            creators = []
+            dates_map = {}
+            sources = []
+            mType = None
+            coverages = []
+            descriptions = []
+            formats = []
+            publishers = []
+            relations = []
+            rights = []
+            subjects = []
+
+            for child in metadata_elem:
+                tag = child.tag.split("}")[-1]
+                text = (child.text or "").strip()
+
+                if tag == "identifier":
+                    id_val = get_attr_ignore_ns(child, "id")
+                    scheme_val = get_attr_ignore_ns(child, "scheme")
+                    id_type = None
+                    if id_val:
+                        ref = find_refinement(id_val, "identifier-type")
+                        if ref:
+                            id_type = ref["refText"]
+                            if not scheme_val:
+                                scheme_val = ref["refScheme"]
+                    identifiers.append({"id": id_val, "identifier_type": id_type, "scheme": scheme_val, "text": text})
+
+                elif tag == "title":
+                    id_val = get_attr_ignore_ns(child, "id")
+                    lang_val = get_attr_ignore_ns(child, "lang")
+                    title_type = None
+                    title_seq = None
+                    if id_val:
+                        ref_type = find_refinement(id_val, "title-type")
+                        if ref_type:
+                            title_type = ref_type["refText"]
+                        ref_seq = find_refinement(id_val, "display-seq")
+                        if ref_seq:
+                            with contextlib.suppress(ValueError):
+                                title_seq = int(ref_seq["refText"])
+                    titles.append({"lang": lang_val, "title_type": title_type, "title_seq": title_seq, "text": text})
+
+                elif tag == "language":
+                    languages.append(text)
+
+                elif tag in ("contributor", "creator"):
+                    id_val = get_attr_ignore_ns(child, "id")
+                    role_val = get_attr_ignore_ns(child, "role")
+                    file_as_val = get_attr_ignore_ns(child, "file-as")
+                    creator_seq = None
+
+                    if id_val:
+                        ref_role = find_refinement(id_val, "role")
+                        if ref_role:
+                            role_val = ref_role["refText"]
+                        ref_file = find_refinement(id_val, "file-as")
+                        if ref_file:
+                            file_as_val = ref_file["refText"]
+                        ref_seq = find_refinement(id_val, "display-seq")
+                        if ref_seq:
+                            with contextlib.suppress(ValueError):
+                                creator_seq = int(ref_seq["refText"])
+
+                    item = {"role": role_val, "file_as": file_as_val, "creator_seq": creator_seq, "text": text}
+                    if tag == "creator":
+                        creators.append(item)
+                    else:
+                        contributors.append(item)
+
+                elif tag == "date":
+                    event_val = get_attr_ignore_ns(child, "event")
+                    event_name = date_event_from_str(event_val)
+                    if event_name:
+                        dates_map[event_name] = text
+
+                elif tag == "meta":
+                    refines = get_attr_ignore_ns(child, "refines")
+                    if not refines:
+                        prop = get_attr_ignore_ns(child, "property")
+                        if prop and prop.startswith("dcterms:"):
+                            event_name = date_event_from_str(prop)
+                            if event_name:
+                                dates_map[event_name] = text
+
+                elif tag == "source":
+                    id_val = get_attr_ignore_ns(child, "id")
+                    id_type = None
+                    scheme_val = None
+                    source_of = None
+                    if id_val:
+                        ref_type = find_refinement(id_val, "identifier-type")
+                        if ref_type:
+                            id_type = ref_type["refText"]
+                            scheme_val = ref_type["refScheme"] or None
+                        ref_sof = find_refinement(id_val, "source-of")
+                        if ref_sof:
+                            source_of = ref_sof["refText"]
+                    sources.append({"id_type": id_type, "scheme": scheme_val, "source_of": source_of, "text": text})
+
+                elif tag == "type" and mType is None:
+                    mType = text
+
+                elif tag == "coverage":
+                    coverages.append(text)
+
+                elif tag == "description":
+                    lang_val = get_attr_ignore_ns(child, "lang")
+                    descriptions.append({"lang": lang_val, "text": text})
+
+                elif tag == "format":
+                    formats.append(text)
+
+                elif tag == "publisher":
+                    publishers.append(text)
+
+                elif tag == "relation":
+                    relations.append(text)
+
+                elif tag == "rights":
+                    rights.append(text)
+
+                elif tag == "subject":
+                    subjects.append(text)
+
+            # Build formatted lines
+            lines = []
+            lines.append("package")
+            lines.append(f"  version: {version}")
+            lines.append(f"  unique-identifier: {unique_id}")
+
+            def format_subline(key, val):
+                if val is None or val == "":
+                    return ""
+                return f"  {key}: {val}"
+
+            # 1. Identifiers
+            for ident in identifiers:
+                lines.append("identifier")
+                if ident.get("id"):
+                    lines.append(format_subline("id", ident["id"]))
+                if ident.get("identifier_type"):
+                    lines.append(format_subline("identifier-type", ident["identifier_type"]))
+                if ident.get("scheme"):
+                    lines.append(format_subline("scheme", ident["scheme"]))
+                lines.append(format_subline("text", ident["text"]))
+
+            # 2. Titles
+            for title in titles:
+                if title.get("lang") is None and title.get("title_type") is None and title.get("title_seq") is None:
+                    lines.append(f"title: {title['text']}")
+                else:
+                    lines.append("title")
+                    lines.append(format_subline("text", title["text"]))
+                    if title.get("lang"):
+                        lines.append(format_subline("lang", title["lang"]))
+                    if title.get("title_type"):
+                        lines.append(format_subline("title-type", title["title_type"]))
+                    if title.get("title_seq") is not None:
+                        lines.append(format_subline("display-seq", str(title["title_seq"])))
+
+            # 3. Languages
+            lines.extend(f"language: {lang}" for lang in languages)
+
+            # 4. Contributors
+            for contributor in contributors:
+                if contributor.get("role") is None and contributor.get("file_as") is None and contributor.get("creator_seq") is None:
+                    lines.append(f"contributor: {contributor['text']}")
+                else:
+                    lines.append("contributor")
+                    lines.append(format_subline("text", contributor["text"]))
+                    if contributor.get("file_as"):
+                        lines.append(format_subline("file-as", contributor["file_as"]))
+                    if contributor.get("role"):
+                        lines.append(format_subline("role", contributor["role"]))
+                    if contributor.get("creator_seq") is not None:
+                        lines.append(format_subline("display-seq", str(contributor["creator_seq"])))
+
+            # 5. Creators
+            for creator in creators:
+                if creator.get("role") is None and creator.get("file_as") is None and creator.get("creator_seq") is None:
+                    lines.append(f"creator: {creator['text']}")
+                else:
+                    lines.append("creator")
+                    lines.append(format_subline("text", creator["text"]))
+                    if creator.get("file_as"):
+                        lines.append(format_subline("file-as", creator["file_as"]))
+                    if creator.get("role"):
+                        lines.append(format_subline("role", creator["role"]))
+                    if creator.get("creator_seq") is not None:
+                        lines.append(format_subline("display-seq", str(creator["creator_seq"])))
+
+            # 6. Dates
+            date_event_order = ["Available", "Created", "Date", "DateAccepted", "DateCopyrighted", "DateSubmitted", "Epub", "Issued", "Modified", "Valid"]
+            date_event_strings = {
+                "Available": "available",
+                "Created": "created",
+                "Date": "date",
+                "DateAccepted": "dateAccepted",
+                "DateCopyrighted": "dateCopyrighted",
+                "DateSubmitted": "dateSubmitted",
+                "Epub": "EPUB created",
+                "Issued": "issued",
+                "Modified": "modified",
+                "Valid": "valid",
+            }
+            for event_name in date_event_order:
+                if event_name in dates_map:
+                    lines.append("date")
+                    lines.append(format_subline("event", date_event_strings[event_name]))
+                    lines.append(format_subline("text", dates_map[event_name]))
+
+            # 7. Sources
+            for source in sources:
+                if source.get("id_type") is None and source.get("scheme") is None and source.get("source_of") is None:
+                    lines.append(f"source: {source['text']}")
+                else:
+                    lines.append("source")
+                    lines.append(format_subline("text", source["text"]))
+                    if source.get("id_type"):
+                        lines.append(format_subline("identifier-type", source["id_type"]))
+                    if source.get("scheme"):
+                        lines.append(format_subline("scheme", source["scheme"]))
+                    if source.get("source_of"):
+                        lines.append(format_subline("source-of", source["source_of"]))
+
+            # 8. Type
+            if mType:
+                lines.append(f"type: {mType}")
+
+            # 9. Coverage
+            lines.extend(f"coverage: {coverage}" for coverage in coverages)
+
+            # 10. Descriptions
+            for desc in descriptions:
+                if desc.get("lang") is None:
+                    lines.append(f"description: {desc['text']}")
+                else:
+                    lines.append("description")
+                    if desc.get("lang"):
+                        lines.append(format_subline("lang", desc["lang"]))
+                    lines.append(format_subline("text", desc["text"]))
+
+            # 11. Formats
+            lines.extend(f"format: {fmt}" for fmt in formats)
+
+            # 12. Publishers
+            lines.extend(f"publisher: {pub}" for pub in publishers)
+
+            # 13. Relations
+            lines.extend(f"relation: {rel}" for rel in relations)
+
+            # 14. Rights
+            lines.extend(f"rights: {right}" for right in rights)
+
+            # 15. Subjects
+            lines.extend(f"subject: {subject}" for subject in subjects)
+
+            return "\n".join(lines) + "\n"
+
+    except Exception as e:
+        logger.debug(f"[yellow]Warning: Error parsing EPUB for epubmeta output: {e}[/yellow]")
+        return None

--- a/src/book_prep.py
+++ b/src/book_prep.py
@@ -22,6 +22,7 @@ from src.book_extractors import (
 )
 from src.book_extractors import (
     extract_epub_metadata as _extract_epub_metadata,
+    get_epubmeta_output as _get_epubmeta_output,
 )
 from src.book_extractors import (
     extract_isbn_from_pdf as _extract_isbn_from_pdf,
@@ -210,6 +211,7 @@ async def gather_book_prep(
 
     # Extract EPUB metadata directly if the file is an EPUB
     if videopath.lower().endswith(".epub") and os.path.isfile(videopath):  # noqa: ASYNC240
+        meta.epubmeta_output = _get_epubmeta_output(videopath)
         epub_meta = _extract_epub_metadata(videopath)
         if epub_meta:
             logger.debug(f"[cyan]EPUB metadata extracted: {epub_meta}[/cyan]")

--- a/src/book_prep.py
+++ b/src/book_prep.py
@@ -29,6 +29,12 @@ from src.book_extractors import (
 from src.book_extractors import (
     extract_mobi_metadata as _extract_mobi_metadata,
 )
+from src.book_extractors import (
+    extract_series_from_filename as _extract_series_from_filename,
+)
+from src.book_extractors import (
+    normalize_series_index as _normalize_series_index,
+)
 from src.console import logger
 from src.exportmi import exportInfo
 from src.meta import Meta
@@ -135,6 +141,19 @@ def sanitize_book_language(meta: Meta) -> None:
 # ---------------------------------------------------------------------------
 # MediaInfo metadata extraction
 # ---------------------------------------------------------------------------
+
+
+def _mi_extra(general_track: dict[str, Any], name: str) -> str:
+    """Case-insensitive lookup of a freeform tag in a MediaInfo General track's extra dict."""
+    extra = general_track.get("extra")
+    if not isinstance(extra, dict):
+        return ""
+    for key, val in extra.items():
+        if key.lower() == name.lower() and val and not isinstance(val, dict):
+            text = str(val).strip()
+            if text:
+                return text
+    return ""
 
 
 def _unescape_meta_val(val: Any) -> str | None:
@@ -343,6 +362,15 @@ async def gather_book_prep(
                 if asin_val and not meta.asin:
                     meta.asin = asin_val
 
+                # Series from extra.SERIES / extra.SERIESPART
+                if not meta.book_series:
+                    series_val = _mi_extra(general_track, "SERIES")
+                    if series_val:
+                        meta.book_series = series_val
+                        part_val = _mi_extra(general_track, "SERIESPART")
+                        if part_val and not meta.book_series_index:
+                            meta.book_series_index = _normalize_series_index(part_val)
+
                 # 6. Overview/Comment
                 comment = _unescape_meta_val(general_track.get("Comment") or general_track.get("comment"))
                 description = _unescape_meta_val(general_track.get("Description") or general_track.get("description"))
@@ -410,6 +438,14 @@ async def gather_book_prep(
                                     break
         except Exception as ex:
             logger.debug(f"[yellow]Warning: Error extracting embedded book metadata: {ex}[/yellow]")
+
+    # Series fallback from filename (embedded Calibre/MediaInfo tags take precedence)
+    if not meta.book_series:
+        fname_series, fname_index = _extract_series_from_filename(os.path.basename(videopath))
+        if fname_series:
+            meta.book_series = fname_series
+            if fname_index and not meta.book_series_index:
+                meta.book_series_index = fname_index
 
     # MyAnonamouse API search using torrent client comments (online lookup takes precedence)
     if not meta.torrent_comments and not meta.skip_auto_torrent and not meta.edit and config:
@@ -718,7 +754,7 @@ async def get_audiobook_bitrate(filelist: list[str]) -> int | None:
         return None
 
     avg_bps = sum(valid_bitrates) / len(valid_bitrates)
-    avg_kbps = int(avg_bps / 1000) if avg_bps >= 1000 else int(avg_bps)
+    avg_kbps = round(avg_bps / 1000) if avg_bps >= 1000 else round(avg_bps)
     return avg_kbps
 
 

--- a/src/get_desc.py
+++ b/src/get_desc.py
@@ -647,6 +647,9 @@ class DescriptionBuilder:
                 table_lines.append("[/table]")
                 final_book_parts.append("\n".join(table_lines))
 
+            if meta.epubmeta_output:
+                final_book_parts.append(f"[spoiler=EPUB Metadata][code]{meta.epubmeta_output}[/code][/spoiler]")
+
             if overview:
                 final_book_parts.append(f"{header}{str_overview if not underline else str_overview}{header_end}\n{overview}")
 
@@ -1835,6 +1838,7 @@ class DescriptionBuilder:
             description = bbcode.remove_img_resize(description)
             description = bbcode.convert_to_align(description)
             description = bbcode.remove_list(description)
+            description = description.replace("[code]", "[pre]").replace("[/code]", "[/pre]")
 
         if tracker == "ANT":
             description = bbcode.convert_to_align(description)
@@ -1843,6 +1847,7 @@ class DescriptionBuilder:
             description = bbcode.remove_sub(description)
             description = bbcode.remove_list(description)
             description = description.replace("•", "-").replace("’", "'").replace("–", "-")
+            description = description.replace("[code]", "[pre]").replace("[/code]", "[/pre]")
 
         if tracker == "DC":
             description = description.replace("[user]", "").replace("[/user]", "")
@@ -1913,6 +1918,7 @@ class DescriptionBuilder:
             description = bbcode.remove_sub(description)
             description = bbcode.convert_to_align(description)
             description = bbcode.remove_list(description)
+            description = description.replace("[code]", "[pre]").replace("[/code]", "[/pre]")
             description = re.sub(r"\[url=[^\]]+\]\[img(?:=[^\]]+)?\]([^\[]+)\[/img\]\[/url\]", r"[img]\1[/img]", description, flags=re.IGNORECASE)
 
         if tracker == "HDS":

--- a/src/meta.py
+++ b/src/meta.py
@@ -60,6 +60,8 @@ class Meta:
     book_language_iso: str = ""
     book_language: str = ""
     book_publisher: str | None = None
+    book_series: str = ""
+    book_series_index: str = ""
     book_title: str | None = None
     book_translator: str | None = None
     btn: str | int | None = None
@@ -493,10 +495,8 @@ class Meta:
             setattr(self, k, v)
 
     def copy(self) -> Meta:
-        """Ensure copy returns a Meta instance with deep copied attributes."""
-        import copy
-
-        return copy.deepcopy(self)
+        """Ensure copy returns a Meta instance."""
+        return Meta(self.to_dict())
 
     def __copy__(self) -> Meta:
         return Meta(self.to_dict())

--- a/src/meta.py
+++ b/src/meta.py
@@ -495,8 +495,10 @@ class Meta:
             setattr(self, k, v)
 
     def copy(self) -> Meta:
-        """Ensure copy returns a Meta instance."""
-        return Meta(self.to_dict())
+        """Ensure copy returns a Meta instance with deep copied attributes."""
+        import copy
+
+        return copy.deepcopy(self)
 
     def __copy__(self) -> Meta:
         return Meta(self.to_dict())

--- a/src/meta.py
+++ b/src/meta.py
@@ -130,6 +130,7 @@ class Meta:
     episode_tmdb_data: dict[str, Any] = field(default_factory=dict)
     episode: str = ""
     episodes: list[dict[str, Any]] | None = None
+    epubmeta_output: str | None = None
     exclusive: bool = False
     ext_torrenthash: str | None = None
     extra_openlibrary_ids: int | None = None

--- a/src/tags.py
+++ b/src/tags.py
@@ -21,6 +21,10 @@ def guessit_fn(value: str, options: dict[str, Any] | None = None) -> dict[str, A
 
 
 async def get_tag(video: str, meta: Meta, season_pack_check: bool = False) -> str:
+    # books have no release group; a user --tag is applied upstream (runs only when meta.tag is None)
+    if meta.category == "BOOK":
+        return ""
+
     # Using regex from cross-seed (https://github.com/cross-seed/cross-seed/tree/master?tab=Apache-2.0-1-ov-file)
     release_group = None
     basename = os.path.basename(video)

--- a/src/tags.py
+++ b/src/tags.py
@@ -90,9 +90,22 @@ async def get_tag(video: str, meta: Meta, season_pack_check: bool = False) -> st
                     title_norm = "".join(c for c in (meta.title or "").lower() if c.isalnum())
                     author_norm = "".join(c for c in (meta.author or "").lower() if c.isalnum())
                     if tag_norm and (
-                        tag_norm in (title_norm, author_norm) or (len(title_norm) >= 4 and title_norm in tag_norm) or (len(author_norm) >= 4 and author_norm in tag_norm)
+                        tag_norm in (title_norm, author_norm)
+                        or (len(tag_norm) >= 4 and (tag_norm in title_norm or tag_norm in author_norm))
+                        or (len(title_norm) >= 4 and title_norm in tag_norm)
+                        or (len(author_norm) >= 4 and author_norm in tag_norm)
                     ):
                         release_group = None
+                    else:
+                        # Rejoin an intra-word hyphen (e.g. "Spider-Man" -> "spiderman") so short
+                        # trailing fragments of hyphenated title/author words aren't taken as groups
+                        prefix_match = re.search(r'(\w+)$', basename_stripped[:hyphen_idx])
+                        first_word_match = re.match(r'\w+', release_group)
+                        if prefix_match and first_word_match:
+                            merged = (prefix_match.group(1) + first_word_match.group(0)).lower()
+                            merged = "".join(c for c in merged if c.isalnum())
+                            if merged and (merged in title_norm or merged in author_norm):
+                                release_group = None
 
             if release_group:
                 if "Z0N3" in release_group:

--- a/src/tags.py
+++ b/src/tags.py
@@ -21,10 +21,6 @@ def guessit_fn(value: str, options: dict[str, Any] | None = None) -> dict[str, A
 
 
 async def get_tag(video: str, meta: Meta, season_pack_check: bool = False) -> str:
-    # books have no release group; a user --tag is applied upstream (runs only when meta.tag is None)
-    if meta.category == "BOOK":
-        return ""
-
     # Using regex from cross-seed (https://github.com/cross-seed/cross-seed/tree/master?tab=Apache-2.0-1-ov-file)
     release_group = None
     basename = os.path.basename(video)
@@ -84,10 +80,23 @@ async def get_tag(video: str, meta: Meta, season_pack_check: bool = False) -> st
         non_anime_match = re.search(r'(?<=-)((?!\s*(?:WEB-DL|Blu-ray|H-264|H-265))(?:\W|\b)(?!(?:\d{3,4}[ip]))(?!\d+\b)(?:\W|\b)([\w .]+?))(?:\[.+\])?(?:\))?(?:\s\[.+\])?$', basename_stripped)
         if non_anime_match:
             release_group = non_anime_match.group(1).strip()
-            if "Z0N3" in release_group:
-                release_group = release_group.replace("Z0N3", "D-Z0N3")
-            if not meta.scene and release_group and len(release_group) > 12:
-                release_group = None
+            # Prevent misinterpreting "Author - Title" space-hyphen-space separators as release groups
+            if meta.category in ("BOOK", "GAME") and release_group:
+                hyphen_idx = non_anime_match.start() - 1
+                if hyphen_idx > 0 and basename_stripped[hyphen_idx - 1].isspace():
+                    release_group = None
+                else:
+                    tag_norm = "".join(c for c in release_group.lower() if c.isalnum())
+                    title_norm = "".join(c for c in (meta.title or "").lower() if c.isalnum())
+                    author_norm = "".join(c for c in (meta.author or "").lower() if c.isalnum())
+                    if tag_norm and (tag_norm in (title_norm, author_norm) or (title_norm and title_norm in tag_norm) or (author_norm and author_norm in tag_norm)):
+                        release_group = None
+
+            if release_group:
+                if "Z0N3" in release_group:
+                    release_group = release_group.replace("Z0N3", "D-Z0N3")
+                if not meta.scene and len(release_group) > 12:
+                    release_group = None
             logger.debug(f"Non-anime regex match: {release_group}")
 
     # If regex patterns didn't work, fall back to guessit

--- a/src/tags.py
+++ b/src/tags.py
@@ -89,7 +89,9 @@ async def get_tag(video: str, meta: Meta, season_pack_check: bool = False) -> st
                     tag_norm = "".join(c for c in release_group.lower() if c.isalnum())
                     title_norm = "".join(c for c in (meta.title or "").lower() if c.isalnum())
                     author_norm = "".join(c for c in (meta.author or "").lower() if c.isalnum())
-                    if tag_norm and (tag_norm in (title_norm, author_norm) or (title_norm and title_norm in tag_norm) or (author_norm and author_norm in tag_norm)):
+                    if tag_norm and (
+                        tag_norm in (title_norm, author_norm) or (len(title_norm) >= 4 and title_norm in tag_norm) or (len(author_norm) >= 4 and author_norm in tag_norm)
+                    ):
                         release_group = None
 
             if release_group:

--- a/src/trackers/UNIT3D/ZNTH.py
+++ b/src/trackers/UNIT3D/ZNTH.py
@@ -1,11 +1,31 @@
+import os
 from typing import Any
 
+import aiofiles
+
+from src.book_prep import extract_first_author as _primary_name
 from src.console import logger
 from src.meta import Meta
 from src.trackers.COMMON import COMMON
 from src.trackers.UNIT3D import UNIT3D, ParamsList
 
 Config = dict[str, Any]
+
+
+def _iso_639_2_code(iso3: str) -> str:
+    """Uppercase 3-letter language code (e.g. 'ENG') from a normalized ISO 639-2 code, or ''."""
+    code = (iso3 or "").strip().upper()
+    return code if len(code) == 3 else ""
+
+
+def _is_misc(meta: Meta) -> bool:
+    """True for comic/manga/magazine/newspaper (ZNTH Misc, not ebook/audiobook)."""
+    return bool(meta.comic or meta.manga or meta.magazine or meta.newspaper)
+
+
+def _book_format(meta: Meta) -> str:
+    """Uppercased format token, e.g. 'EPUB', 'M4B'."""
+    return str(meta.type or meta.container or "").strip().upper().lstrip(".")
 
 
 class ZNTH(UNIT3D):
@@ -27,12 +47,20 @@ class ZNTH(UNIT3D):
         self.banned_groups: list[str] = []
 
     async def get_additional_checks(self, meta: Meta) -> bool:
-        if meta.category == "BOOK":
+        if meta.category == "BOOK" and not _is_misc(meta):
             if not meta.isbn and not meta.asin:
-                logger.info(f"{self.tracker}: [bold red]ISBN or ASIN is required for books. Skipping upload...[/bold red]")
+                logger.info(f"{self.tracker}: [bold red]ISBN or ASIN is required for ebooks and audiobooks. Skipping upload...[/bold red]")
                 return False
-            if meta.audiobook and not meta.narrator:
-                logger.info(f"{self.tracker}: [bold red]Narrator is required for audiobooks. Skipping upload...[/bold red]")
+            book_format = _book_format(meta)
+            if meta.audiobook:
+                if not meta.narrator:
+                    logger.info(f"{self.tracker}: [bold red]Narrator is required for audiobooks. Skipping upload...[/bold red]")
+                    return False
+                if book_format not in ("MP3", "FLAC", "M4B"):
+                    logger.info(f"{self.tracker}: [bold red]Audiobooks must be MP3, FLAC, or M4B. Skipping upload...[/bold red]")
+                    return False
+            elif book_format not in ("EPUB", "PDF", "MOBI", "AZW3", "DJVU"):
+                logger.info(f"{self.tracker}: [bold red]Ebooks must be EPUB, PDF, MOBI, AZW3, or DJVU. Skipping upload...[/bold red]")
                 return False
 
         return self.common.check_and_confirm_adult_media_upload(meta, self.tracker)
@@ -51,46 +79,33 @@ class ZNTH(UNIT3D):
         audiobook = meta.audiobook
 
         if category == "BOOK":
-            author = meta.author or "".strip()
-            title = meta.title or meta.name or "".strip()
+            if _is_misc(meta):
+                return {"name": meta.name}
+
+            author = _primary_name(meta.author or "")
+            title = (meta.title or meta.name or "").strip()
             year = str(meta.year) if meta.year is not None else ""
-            format_val = (meta.type or meta.container or "").strip().upper()
-            tag = meta.tag or "".strip().lstrip("-")
-
-            # Determine source/retail
-            source = meta.source or "".strip().upper()
-            manual_source = (meta.manual_source or "").strip().upper()
-            if manual_source in ("RETAIL", "SCAN", "HYBRID"):
-                source = manual_source
-
-            if source not in ("RETAIL", "SCAN", "HYBRID"):
-                filename_lower = (meta.basename_no_ext + " " + meta.title).lower()
-                if "scan" in filename_lower:
-                    source = "SCAN"
-                elif "hybrid" in filename_lower:
-                    source = "HYBRiD"
-                elif "retail" in filename_lower:
-                    source = "RETAiL"
-                else:
-                    ext = format_val.upper()
-                    source = "SCAN" if ext == "PDF" else "RETAiL"
-
-            is_retail = source in ("RETAIL", "RETAiL") or "retail" in meta.basename_no_ext.lower()
+            format_val = _book_format(meta)
+            # get_tag returns "" for books, so this is only a user-supplied --tag ("-Group")
+            tag = (meta.tag or "").strip()
 
             if audiobook:
-                # AudioBook Naming
-                # Required: Author - Name Year Format ISBN-Tag
-                # Recommended: Author - Name Year Format Bitrate ISBN Retail-Tag
-                lossy_formats = ["MP3", "AAC", "OPUS", "VORBIS", "M4B", "M4A", "OGG"]
-                bitrate_val = ""
-                if format_val in lossy_formats:
-                    bitrate = meta.audiobook_bitrate
-                    if bitrate:
-                        bitrate_val = f"{bitrate}kbps"
+                # AudioBook: Author - Title (Year) LANG [Edition] {Narrator} [Source] [Container] Codec Bitrate
+                language = _iso_639_2_code(meta.book_language_iso)
+                edition = str(meta.manual_edition or meta.edition or "").strip()
+                narrator = _primary_name(meta.narrator or "")
+                source = (str(meta.manual_source or "").strip() or str(meta.source or "").strip() or "WEB").upper()
 
-                book_id = meta.isbn or meta.asin
+                audio_map = {
+                    "FLAC": ("", "FLAC"),
+                    "MP3": ("", "MP3"),
+                    "M4B": ("M4B", "AAC"),
+                }
+                container, codec = audio_map.get(format_val, ("", format_val))
 
-                parts = []
+                bitrate_val = f"{meta.audiobook_bitrate}kbps" if meta.audiobook_bitrate else ""
+
+                parts: list[str] = []
                 if author:
                     parts.append(author)
                 if title:
@@ -98,62 +113,83 @@ class ZNTH(UNIT3D):
                         parts.append("-")
                     parts.append(title)
                 if year:
-                    parts.append(year)
-                if format_val:
-                    parts.append(format_val)
+                    parts.append(f"({year})")
+                if language:
+                    parts.append(language)
+                if edition:
+                    parts.append(edition)
+                if narrator:
+                    parts.append(f"{{{narrator}}}")
+                if source:
+                    parts.append(f"[{source}]")
+                if container:
+                    parts.append(container)
+                if codec:
+                    parts.append(codec)
                 if bitrate_val:
                     parts.append(bitrate_val)
-                if book_id:
-                    parts.append(book_id)
-                if is_retail:
-                    parts.append("Retail")
 
                 base_name = " ".join(parts)
                 base_name = " ".join(base_name.split())
-                znth_name = f"{base_name}-{tag}" if tag else base_name
+                znth_name = f"{base_name}{tag}"
 
             else:
-                # eBook Naming
-                # Required: Author - Name Year Format ISBN
-                # Additional: Author - Name Year Edition Format ISBN Retail Scan OCR
+                # eBook: Author - [Series #N -] Title [Year] LANG [Edition] Format [Retail]
+                language = _iso_639_2_code(meta.book_language_iso)
+                series = (meta.book_series or "").strip()
+                series_index = (meta.book_series_index or "").strip()
+                series_part = ""
+                if series:
+                    series_part = f"{series} #{series_index}" if series_index else series
                 edition = str(meta.manual_edition or meta.edition or "").strip()
                 if edition:
                     edition_lower = edition.lower()
                     if "1st" in edition_lower or "first" in edition_lower:
                         edition = ""
-                    else:
-                        if not any(x in edition_lower for x in ["edition", "ed.", "ed"]):
-                            edition = f"{edition} Edition"
+                    elif not any(x in edition_lower for x in ["edition", "ed.", "ed"]):
+                        edition = f"{edition} Edition"
 
-                isbn_val = meta.isbn or "".strip()
-                is_scan = source == "SCAN" or "scan" in meta.basename_no_ext.lower() or "scan" in meta.title.lower()
-                is_ocr = bool(meta.ocr) or "ocr" in meta.basename_no_ext.lower() or "ocr" in meta.title.lower()
+                source = str(meta.source or "").strip().upper()
+                manual_source = str(meta.manual_source or "").strip().upper()
+                if manual_source in ("RETAIL", "SCAN", "HYBRID"):
+                    source = manual_source
+                if source not in ("RETAIL", "SCAN", "HYBRID"):
+                    filename_lower = (meta.basename_no_ext + " " + meta.title).lower()
+                    if "scan" in filename_lower:
+                        source = "SCAN"
+                    elif "hybrid" in filename_lower:
+                        source = "HYBRID"
+                    elif "retail" in filename_lower:
+                        source = "RETAIL"
+                    else:
+                        source = "SCAN" if format_val == "PDF" else "RETAIL"
+                is_retail = source == "RETAIL" or "retail" in meta.basename_no_ext.lower()
 
                 parts = []
                 if author:
                     parts.append(author)
+                if series_part:
+                    if parts:
+                        parts.append("-")
+                    parts.append(series_part)
                 if title:
                     if parts:
                         parts.append("-")
                     parts.append(title)
                 if year:
                     parts.append(year)
+                if language:
+                    parts.append(language)
                 if edition:
                     parts.append(edition)
                 if format_val:
                     parts.append(format_val)
-                if isbn_val:
-                    parts.append(isbn_val)
                 if is_retail:
                     parts.append("Retail")
-                if is_scan:
-                    parts.append("Scan")
-                if is_ocr:
-                    parts.append("OCR")
 
                 base_name = " ".join(parts)
                 base_name = " ".join(base_name.split())
-                znth_name = f"{base_name}-{tag}" if tag else base_name
+                znth_name = f"{base_name}{tag}"
 
             return {"name": znth_name}
 
@@ -176,6 +212,7 @@ class ZNTH(UNIT3D):
             "TV": "2",
             "AUDIOBOOK": "7",
             "BOOK": "6",
+            "MISC": "9",
             "GAME": "3",
         }
         if mapping_only:
@@ -188,6 +225,8 @@ class ZNTH(UNIT3D):
             meta_category = meta.category
             if meta.audiobook:
                 meta_category = "AUDIOBOOK"
+            elif _is_misc(meta):
+                meta_category = "MISC"
             resolved_id = category_id.get(meta_category, "0")
             return {"category_id": resolved_id}
 
@@ -200,9 +239,12 @@ class ZNTH(UNIT3D):
             "HDTV": "6",
             "ENCODE": "3",
             "DVDRIP": "11",
+            "FLAC": "7",
+            "MP3": "8",
+            "EPUB": "9",
+            "M4B": "10",
+            "PDF": "19",
             "OTHER": "16",
-            "AUDIOBOOK": "10",
-            "BOOK": "9",
         }
         if mapping_only:
             return type_id
@@ -217,13 +259,33 @@ class ZNTH(UNIT3D):
             if isinstance(meta_type, str):
                 meta_type = meta_type.upper().strip().lstrip(".")
 
-            resolved_id = type_id.get(meta_type or "", "0")
-
             if category == "GAME":
                 resolved_id = "16"
-            elif meta.audiobook:
-                resolved_id = "10"
             elif category == "BOOK":
-                resolved_id = "9"
+                resolved_id = type_id.get(meta_type or "", "16")
+            else:
+                resolved_id = type_id.get(meta_type or "", "0")
 
             return {"type_id": resolved_id}
+
+    async def get_additional_data(self, meta: Meta) -> dict[str, str]:
+        data: dict[str, str] = {}
+        if meta.category == "BOOK" and not _is_misc(meta):
+            if meta.isbn:
+                data["isbn"] = str(meta.isbn)
+            if meta.asin:
+                data["asin"] = str(meta.asin)
+        return data
+
+    async def get_additional_files(self, meta: Meta) -> dict[str, tuple[str, bytes, str]]:
+        files = await super().get_additional_files(meta)
+        # audiobook: send the original uncropped cover, real format sniffed; base cover if >5MB
+        if meta.audiobook and meta.cover_path and os.path.exists(meta.cover_path):
+            if os.path.getsize(meta.cover_path) <= 5 * 1024 * 1024:
+                async with aiofiles.open(meta.cover_path, "rb") as f:
+                    raw = await f.read()
+                if raw[:3] == b"\xff\xd8\xff":
+                    files["torrent-cover"] = ("cover.jpg", raw, "image/jpeg")
+                elif raw[:8] == b"\x89PNG\r\n\x1a\n":
+                    files["torrent-cover"] = ("cover.png", raw, "image/png")
+        return files

--- a/src/trackers/UNIT3D/ZNTH.py
+++ b/src/trackers/UNIT3D/ZNTH.py
@@ -146,7 +146,7 @@ class ZNTH(UNIT3D):
                     edition_lower = edition.lower()
                     if "1st" in edition_lower or "first" in edition_lower:
                         edition = ""
-                    elif not any(x in edition_lower for x in ["edition", "ed.", "ed"]):
+                    elif not any(t in ("edition", "ed") for t in edition_lower.replace(".", " ").split()):
                         edition = f"{edition} Edition"
 
                 source = str(meta.source or "").strip().upper()
@@ -262,7 +262,7 @@ class ZNTH(UNIT3D):
             if category == "GAME":
                 resolved_id = "16"
             elif category == "BOOK":
-                resolved_id = type_id.get(meta_type or "", "16")
+                resolved_id = type_id.get(_book_format(meta) or "", "16")
             else:
                 resolved_id = type_id.get(meta_type or "", "0")
 

--- a/src/trackers/UNIT3D/ZNTH.py
+++ b/src/trackers/UNIT3D/ZNTH.py
@@ -1,4 +1,6 @@
 import os
+import re
+import unicodedata
 from typing import Any
 
 import aiofiles
@@ -20,17 +22,34 @@ def _iso_639_2_code(iso3: str) -> str:
 
 def _is_misc(meta: Meta) -> bool:
     """True for comic/manga/magazine/newspaper (ZNTH Misc, not ebook/audiobook)."""
-    return bool(meta.comic or meta.manga or meta.magazine or meta.newspaper)
+    return meta.comic or meta.manga or meta.magazine or meta.newspaper
 
 
 def _book_format(meta: Meta) -> str:
     """Uppercased format token, e.g. 'EPUB', 'M4B'."""
-    return str(meta.type or meta.container or "").strip().upper().lstrip(".")
+    return (meta.type or meta.container or "").strip().upper().lstrip(".")
 
 
 class ZNTH(UNIT3D):
     supported_categories = ("TV", "MOVIE", "BOOK", "GAME")
-    tracker_urls = ['https://znth.cx']
+    tracker_urls = ["https://znth.cx"]
+
+    _banned_authors_raw = [
+        "J.R.R. Tolkien",
+        "Anne Perry",
+        "Simon Scarrow",
+        "Sara Gruen",
+        "Joan Elliott",
+        "Alan Dart",
+        "Chris Mead",
+        "Paul Moore & Gavin Jones",
+        "Noah K Sturdevant",
+        "Benedict Brown",
+        "Erika T Wurth",
+        "Randolph Lalonde",
+        "Andrea Sfiligoi",
+        "Ana-Maria Babanica",
+    ]
 
     def __init__(self, config: Config) -> None:
         super().__init__(config, tracker_name="ZNTH")
@@ -45,6 +64,89 @@ class ZNTH(UNIT3D):
         self.torrent_url = f"{self.base_url}/torrents/"
         self.banned_url = f"{self.base_url}/api/bannedReleaseGroups"
         self.banned_groups: list[str] = []
+
+        self.banned_author_sets: list[set[str]] = []
+        for author in self._banned_authors_raw:
+            parts = re.split(r"\s*(?:\&|\band\b)\s*", author, flags=re.IGNORECASE)
+            for part in parts:
+                norm = self._normalize_author(part)
+                if norm:
+                    self.banned_author_sets.append(norm)
+                # Handle middle initials (e.g. Erika T Wurth)
+                words = part.split()
+                if len(words) > 2:
+                    for idx, w in enumerate(words[1:-1], start=1):
+                        if len(w.strip(".")) == 1:
+                            without_initial = " ".join(words[:idx] + words[idx + 1 :])
+                            norm_without = self._normalize_author(without_initial)
+                            if norm_without:
+                                self.banned_author_sets.append(norm_without)
+
+    @staticmethod
+    def _normalize_author(name: str) -> set[str]:
+        if not name:
+            return set()
+        nfkd_form = unicodedata.normalize("NFKD", name)
+        cleaned = "".join(c for c in nfkd_form if not unicodedata.combining(c))
+        cleaned = re.sub(r"[^a-zA-Z0-9\s]", " ", cleaned)
+        cleaned = cleaned.lower()
+        words = cleaned.split()
+        conjunctions = {"and", "e", "y", "with", "und", "et"}
+        words = [w for w in words if w not in conjunctions]
+        merged_words = []
+        initials_buffer = []
+        for w in words:
+            if len(w) == 1 and w.isalpha():
+                initials_buffer.append(w)
+            else:
+                if initials_buffer:
+                    merged_words.append("".join(initials_buffer))
+                    initials_buffer = []
+                merged_words.append(w)
+        if initials_buffer:
+            merged_words.append("".join(initials_buffer))
+        return set(merged_words)
+
+    @staticmethod
+    def _split_authors(author_str: str) -> list[str]:
+        if not author_str:
+            return []
+        major_pattern = r"\s*(?:;|&|/|\+|\band\b|\be\b|\by\b|\bwith\b|\s+-\s+)\s*"
+        candidates = re.split(major_pattern, author_str, flags=re.IGNORECASE)
+
+        final_authors = []
+        for cand in candidates:
+            cand = cand.strip()
+            if not cand:
+                continue
+            if "," in cand:
+                comma_parts = [p.strip() for p in cand.split(",")]
+                if len(comma_parts) == 2:
+                    p1, p2 = comma_parts
+                    p2_words = p2.split()
+                    is_initials = all(len(w.strip(".")) <= 3 for w in p2_words)
+                    if len(p2_words) == 1 or is_initials:
+                        final_authors.append(cand)
+                    else:
+                        final_authors.extend(comma_parts)
+                else:
+                    final_authors.extend(comma_parts)
+            else:
+                final_authors.append(cand)
+        return final_authors
+
+    def _is_banned_author(self, meta_author: str) -> bool:
+        if not meta_author:
+            return False
+        parts = self._split_authors(meta_author)
+        for part in parts:
+            part_norm = self._normalize_author(part)
+            if not part_norm:
+                continue
+            for banned in self.banned_author_sets:
+                if banned.issubset(part_norm):
+                    return True
+        return False
 
     async def get_additional_checks(self, meta: Meta) -> bool:
         if meta.category == "BOOK" and not _is_misc(meta):
@@ -61,6 +163,10 @@ class ZNTH(UNIT3D):
                     return False
             elif book_format not in ("EPUB", "PDF", "MOBI", "AZW3", "DJVU"):
                 logger.info(f"{self.tracker}: [bold red]Ebooks must be EPUB, PDF, MOBI, AZW3, or DJVU. Skipping upload...[/bold red]")
+                return False
+
+            if meta.author and self._is_banned_author(meta.author):
+                logger.info(f"{self.tracker}: [bold red]Author '{meta.author}' is banned on {self.tracker}. Skipping upload...[/bold red]")
                 return False
 
         return self.common.check_and_confirm_adult_media_upload(meta, self.tracker)
@@ -94,7 +200,7 @@ class ZNTH(UNIT3D):
                 language = _iso_639_2_code(meta.book_language_iso)
                 edition = str(meta.manual_edition or meta.edition or "").strip()
                 narrator = _primary_name(meta.narrator or "")
-                source = (str(meta.manual_source or "").strip() or str(meta.source or "").strip() or "WEB").upper()
+                source = ((meta.manual_source or "").strip() or (meta.source or "").strip() or "WEB").upper()
 
                 audio_map = {
                     "FLAC": ("", "FLAC"),
@@ -149,8 +255,8 @@ class ZNTH(UNIT3D):
                     elif not any(t in ("edition", "ed") for t in edition_lower.replace(".", " ").split()):
                         edition = f"{edition} Edition"
 
-                source = str(meta.source or "").strip().upper()
-                manual_source = str(meta.manual_source or "").strip().upper()
+                source = (meta.source or "").strip().upper()
+                manual_source = (meta.manual_source or "").strip().upper()
                 if manual_source in ("RETAIL", "SCAN", "HYBRID"):
                     source = manual_source
                 if source not in ("RETAIL", "SCAN", "HYBRID"):
@@ -272,20 +378,19 @@ class ZNTH(UNIT3D):
         data: dict[str, str] = {}
         if meta.category == "BOOK" and not _is_misc(meta):
             if meta.isbn:
-                data["isbn"] = str(meta.isbn)
+                data["isbn"] = meta.isbn
             if meta.asin:
-                data["asin"] = str(meta.asin)
+                data["asin"] = meta.asin
         return data
 
     async def get_additional_files(self, meta: Meta) -> dict[str, tuple[str, bytes, str]]:
         files = await super().get_additional_files(meta)
         # audiobook: send the original uncropped cover, real format sniffed; base cover if >5MB
-        if meta.audiobook and meta.cover_path and os.path.exists(meta.cover_path):
-            if os.path.getsize(meta.cover_path) <= 5 * 1024 * 1024:
-                async with aiofiles.open(meta.cover_path, "rb") as f:
-                    raw = await f.read()
-                if raw[:3] == b"\xff\xd8\xff":
-                    files["torrent-cover"] = ("cover.jpg", raw, "image/jpeg")
-                elif raw[:8] == b"\x89PNG\r\n\x1a\n":
-                    files["torrent-cover"] = ("cover.png", raw, "image/png")
+        if meta.audiobook and meta.cover_path and os.path.exists(meta.cover_path) and os.path.getsize(meta.cover_path) <= 5 * 1024 * 1024:
+            async with aiofiles.open(meta.cover_path, "rb") as f:
+                raw = await f.read()
+            if raw[:3] == b"\xff\xd8\xff":
+                files["torrent-cover"] = ("cover.jpg", raw, "image/jpeg")
+            elif raw[:8] == b"\x89PNG\r\n\x1a\n":
+                files["torrent-cover"] = ("cover.png", raw, "image/png")
         return files


### PR DESCRIPTION
Improve ZNTH book and audiobook naming and metadata.

#### Naming:

- Names are now generated in the correct ZNTH format (Craig Alanson - Convergence # 5 - Desperate Measures 2025 ENG EPUB Retail).
- Language surfaces as a three letter code (ENG), and ebooks include the series name and index when present.

#### Metadata extraction:

- Series name and number are read from EPUB (Calibre) metadata, from embedded audiobook tags, and from the filename as a fallback for other formats (MOBI, PDF, AZW3).
- Use primary author and primary narrator for the title.
- Audiobook bitrate rounds to nearest value.

#### ZNTH and non ZNTH fixes:

- The release group detector doesn't misinterpret a book's title separator as a group tag. (--tag continues to work)
- Audiobook covers are sent full size to be processed server side. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added book series (`book_series`) and normalized series index (`book_series_index`) for ebooks/audiobooks from EPUB metadata, embedded technical metadata, and filename fallback.
* **Bug Fixes**
  * Prevented incorrect release-group detection from “Author - Title” separator patterns.
  * Improved audiobook bitrate averaging by using rounding instead of truncation, and enhanced cover detection via magic-byte validation with size limits.
* **Changes**
  * Strengthened BOOK upload eligibility and improved category/type mapping, naming rules, and payload/files generation (including stricter audiobook requirements).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->