### PR TITLE
fix(MKO): get the correct release name

### DIFF
--- a/src/trackers/MKO.py
+++ b/src/trackers/MKO.py
@@ -1100,7 +1100,7 @@ class MKO:
         title_orig = title_br if self._is_brazilian(meta) else meta.original_title or title_br
 
         release_name = meta.basename_no_ext or meta.name or meta.uuid
-        release = release_name.replace(" ", ".").rsplit(".", 1)[0]
+        release = release_name.replace(" ", ".")
 
         # Prefer TMDB PT-BR overview already cached by the UA; fall back to
         # translation details from the pre-fetched translations list.


### PR DESCRIPTION
meta.basename_no_ext doesn't have the file extension, the rsplit isn't necessary here, it is resulting on a incomplete release name. Removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release information formatting in forum post descriptions by preserving the full release value while converting spaces to dots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->