### PR TITLE
fix(usenet): adapt pesto integration to v0.3.53+'s streaming --check

### DIFF
--- a/bin/get_pesto.py
+++ b/bin/get_pesto.py
@@ -22,7 +22,7 @@ class PestoBinaryManager:
     """Download Pesto binaries for the host architecture."""
 
     @staticmethod
-    async def ensure_pesto_binary(base_dir: str | Path, version: str = "v0.3.41") -> str:
+    async def ensure_pesto_binary(base_dir: str | Path, version: str = "v0.3.53") -> str:
         system = platform.system().lower()
         machine = platform.machine().lower()
         logger.debug(f"[blue]Pesto: Detected system: {system}, architecture: {machine}[/blue]")

--- a/bin/get_pesto.py
+++ b/bin/get_pesto.py
@@ -22,7 +22,7 @@ class PestoBinaryManager:
     """Download Pesto binaries for the host architecture."""
 
     @staticmethod
-    async def ensure_pesto_binary(base_dir: str | Path, version: str = "v0.3.53") -> str:
+    async def ensure_pesto_binary(base_dir: str | Path, version: str = "v0.3.54") -> str:
         system = platform.system().lower()
         machine = platform.machine().lower()
         logger.debug(f"[blue]Pesto: Detected system: {system}, architecture: {machine}[/blue]")

--- a/data/example_config.py
+++ b/data/example_config.py
@@ -2791,18 +2791,24 @@ config = {
         # Uploader backend: "nyuu" (default) or "pesto"
         # pesto handles PAR2 and NZB password injection internally
         "usenet_uploader": "nyuu",
-        # pesto only: after posting, verify every article is retrievable on the
-        # server via STAT. Missing articles are reposted and reverified
-        # automatically; the upload is only considered successful (and the NZB
-        # kept) once every article is confirmed. Strongly recommended — without
-        # this, a "successfully posted" article can still be missing/unpropagated
-        # on the server, producing a broken NZB.
+        # pesto only: a streaming STAT check that runs concurrently with the
+        # upload, confirming each article shortly after it posts. Missing
+        # articles are reposted and reverified automatically; the upload is
+        # only considered successful (and the NZB kept) once every article is
+        # confirmed. Strongly recommended — without this, a "successfully
+        # posted" article can still be missing/unpropagated on the server,
+        # producing a broken NZB.
         "pesto_check": True,
-        # Seconds to wait after the last article is posted before verifying (pesto --check-delay)
-        "pesto_check_delay": 30,
+        # Seconds to wait after EACH article posts before its first STAT check
+        # (streaming, concurrent with the upload — not a single wait at the end
+        # of the whole run) (pesto --check-delay)
+        "pesto_check_delay": 5,
         # Number of STAT attempts per article before marking it missing (pesto --check-retries)
         "pesto_check_retries": 3,
-        # Parallel connections used for the verification pass (empty = same as "connections")
+        # Dedicated parallel connections for the check queue, carved out of
+        # "connections" (never opened on top of it). Empty = pesto auto-derives
+        # a small pool from "connections"; if "connections" is too low to spare
+        # any, the check is skipped (pesto --check-connections)
         "pesto_check_connections": "",
         # Number of repost+reverify rounds to attempt for articles still missing
         # after the check (pesto --check-post-retries). Raise this on providers

--- a/src/usenetcreate.py
+++ b/src/usenetcreate.py
@@ -465,8 +465,11 @@ async def run_pesto_with_progress(cmd: list[str], cwd: str | None = None) -> Non
 
         stderr_accum = []
         check_missing_count = 0
-        check_total = 0
-        check_wait_total = 0
+        check_checked_total = 0
+        # Every posted article also gets checked (see pesto's check.rs), so
+        # the running total_segments count pesto already reports on each
+        # segment_done doubles as the check phase's expected total.
+        check_expected_total = 0
 
         if process.stdout is None or process.stderr is None:
             raise RuntimeError("Process stdout or stderr is None")
@@ -508,6 +511,7 @@ async def run_pesto_with_progress(cmd: list[str], cwd: str | None = None) -> Non
                         if "upload" not in tasks:
                             tasks["upload"] = progress.add_task("Posting to Usenet", total=100)
                         progress.update(tasks["upload"], completed=pct)
+                        check_expected_total = event.get("total_segments", check_expected_total)
                     elif etype == "status":
                         text = event.get("text", "").strip()
                         if text:
@@ -537,60 +541,42 @@ async def run_pesto_with_progress(cmd: list[str], cwd: str | None = None) -> Non
                         if "par2_write" not in tasks:
                             tasks["par2_write"] = progress.add_task("Writing PAR2 recovery files", total=1)
                         progress.advance(tasks["par2_write"])
-                    elif etype == "check_started":
-                        check_total = event.get("total", 0)
-                        if "check" not in tasks:
-                            tasks["check"] = progress.add_task("Verifying articles on server", total=check_total or 1)
-                        else:
-                            progress.update(tasks["check"], description="Verifying articles on server", total=check_total or 1, completed=0)
-                    elif etype == "check_waiting":
-                        remaining = event.get("remaining_secs", 0)
-                        if "check" not in tasks:
-                            check_wait_total = remaining
-                        description = f"Waiting {remaining}s before verifying articles..."
-                        if "check" not in tasks:
-                            tasks["check"] = progress.add_task(description, total=check_wait_total or 1)
-                        progress.update(tasks["check"], description=description, completed=max(check_wait_total - remaining, 0))
                     elif etype == "check_progress":
+                        # pesto >=0.3.51 streams the STAT check concurrently
+                        # with the upload instead of running it as its own
+                        # phase, so it no longer sends its own upfront total
+                        # (check_started was removed). Every posted article
+                        # also gets checked though, so the total_segments
+                        # count already tracked from segment_done above
+                        # doubles as the check phase's total, letting the bar
+                        # show "checked/total" instead of being indeterminate.
                         checked = event.get("checked", 0)
+                        check_checked_total = checked
+                        if not event.get("ok", True):
+                            check_missing_count += 1
                         if "check" not in tasks:
-                            tasks["check"] = progress.add_task("Verifying articles on server", total=check_total or checked or 1)
-                        progress.update(tasks["check"], completed=checked)
+                            tasks["check"] = progress.add_task("Verifying articles on server", total=check_expected_total or None)
+                        else:
+                            progress.update(tasks["check"], total=check_expected_total or None)
+                        description = "Verifying articles on server"
+                        if check_missing_count:
+                            description += f" ({check_missing_count} failed so far)"
+                        progress.update(tasks["check"], description=description, completed=checked)
                     elif etype == "check_done":
                         failed = event.get("failed", 0)
                         check_missing_count = failed
-                        if "check" in tasks and check_total:
-                            progress.update(tasks["check"], completed=check_total)
-                        # Only announce success here; a missing count is always
-                        # immediately followed by a "repost_round_started" event
-                        # (below), which reports it with round context instead.
+                        if "check" in tasks:
+                            final_total = check_expected_total or check_checked_total or 1
+                            progress.update(tasks["check"], total=final_total, completed=final_total)
                         if not failed:
                             logger.info("[green]Article check: all articles verified on server.[/green]")
+                        else:
+                            logger.info(f"[yellow]Article check: {failed} article(s) still missing after every repost attempt.[/yellow]")
                     elif etype == "check_retrying":
                         attempt = event.get("attempt", 0)
                         max_attempts = event.get("max_attempts", 0)
                         delay = event.get("delay_secs", 0)
-                        check_wait_total = delay
                         logger.debug(f"[cyan]Article check: retry {attempt}/{max_attempts} in {delay}s...[/cyan]")
-                    elif etype == "repost_round_started":
-                        round_num = event.get("round", 0)
-                        max_rounds = event.get("max_rounds", 0)
-                        missing = event.get("missing", 0)
-                        logger.info(
-                            f"[yellow]Article check: round {round_num}/{max_rounds} — "
-                            f"{missing} article(s) missing, reposting automatically...[/yellow]"
-                        )
-                    elif etype == "repost_round_done":
-                        round_num = event.get("round", 0)
-                        max_rounds = event.get("max_rounds", 0)
-                        reposted = event.get("reposted", 0)
-                        still_missing = event.get("still_missing", 0)
-                        check_missing_count = still_missing
-                        if still_missing:
-                            logger.info(
-                                f"[yellow]Article check: round {round_num}/{max_rounds} — "
-                                f"reposted {reposted} article(s), {still_missing} still missing[/yellow]"
-                            )
                 except json.JSONDecodeError:
                     pass
 
@@ -993,11 +979,13 @@ async def prepare_and_upload_usenet(meta: Meta, config: dict[str, Any]) -> str |
         if archive_password and not skip_archive:
             cmd_pesto.extend(["--nzb-password", archive_password])
 
-        # --check: after posting, verify every article is retrievable via STAT.
-        # Missing articles are reposted and reverified in a loop (up to
-        # --check-post-retries rounds); pesto exits non-zero if any are still
-        # missing after that, so we know the NZB is trustworthy whenever this
-        # command succeeds.
+        # --check: a streaming STAT check that runs concurrently with the
+        # upload, confirming each article shortly after it posts. Missing
+        # articles are reposted and reverified automatically, internally to
+        # pesto; it exits non-zero if any are still missing after that, so we
+        # know the NZB is trustworthy whenever this command succeeds.
+        # pesto >=0.3.51 defaults --check to on, so pesto_check: False must
+        # pass --no-check explicitly or the check would run anyway.
         if usenet_cfg.get("pesto_check", True):
             cmd_pesto.append("--check")
             check_delay = usenet_cfg.get("pesto_check_delay")
@@ -1021,6 +1009,8 @@ async def prepare_and_upload_usenet(meta: Meta, config: dict[str, Any]) -> str |
             check_post_retries = usenet_cfg.get("pesto_check_post_retries", 3)
             if str(check_post_retries).strip() != "":
                 cmd_pesto.extend(["--check-post-retries", str(check_post_retries)])
+        else:
+            cmd_pesto.append("--no-check")
 
         cmd_pesto.extend(all_upload_files)
 

--- a/src/usenetcreate.py
+++ b/src/usenetcreate.py
@@ -71,10 +71,9 @@ def get_dynamic_volume_size(total_bytes: int) -> str:
 def compute_nyuu_connections(total_connections: int, nyuu_check_enabled: bool, check_connections_cfg: str | int | None) -> tuple[int, int | None]:
     """Split the configured connection budget between nyuu posting and checking.
 
-    Unlike pesto (which checks in a separate phase after posting finishes), nyuu
-    checks concurrently with posting over its own connections, and throttles
-    posting speed to match if the check connections can't keep up. So by default
-    (check_connections_cfg empty), `total_connections` is split between posting
+    Like pesto, nyuu checks concurrently with posting over its own connections,
+    and throttles posting speed to match if the check connections can't keep up.
+    So by default (check_connections_cfg empty), `total_connections` is split between posting
     and checking, keeping the combined socket count within what was configured
     instead of adding check connections on top of it. An explicit
     check_connections_cfg overrides this and posts at the full connection count,


### PR DESCRIPTION
## Summary
- Bumps the pinned pesto binary from v0.3.41 to v0.3.54.
- pesto >=0.3.51 reworked `--check` into a streaming STAT check that runs concurrently with the upload (instead of a separate post-upload phase), and it now defaults **on** (it used to default off). Since we never passed `--no-check`, disabling `pesto_check` in config would silently stop working against the new binary — now fixed by passing `--no-check` explicitly.
- The old `check_started`/`check_waiting`/`repost_round_started`/`repost_round_done` JSON events no longer exist; `check_progress` now reports one event per checked article (`checked` + `ok`) with no upfront total. Reworked the progress parser accordingly, reusing the `total_segments` count already carried on every `segment_done` event (every posted article is also checked) so the "Verifying articles on server" bar still shows checked/total instead of running indeterminate.
- Updated `example_config.py`'s `pesto_check_*` comments/defaults (delay default 30s -> 5s, connections comment) to match the new streaming semantics.
- Confirmed v0.3.53 -> v0.3.54 only changed unrelated group-reporting/multi-server STAT targeting, no progress-event schema changes, so this update is just the version bump plus a leftover stale docstring fix in `compute_nyuu_connections`.

## Test plan
- [x] `python3 -m py_compile` on the changed files
- [x] Fed a fake pesto process emitting the v0.3.54 JSON event schema through `run_pesto_with_progress` end-to-end (all four progress bars — PAR2 parity, posting, verification, PAR2 write — render and reach 100% with no exceptions)
- [x] Manual test against the **real** pesto v0.3.54 binary and a local mock NNTP server (no real Usenet touched): a 30MB file with `--check` produced all four progress bars (PAR2 parity, PAR2 write, posting, verification) reaching 100%, `check_progress`/`check_done` resolved correctly, and a valid 43-segment NZB was written; a second run with `pesto_check: False` (`--no-check`) posted correctly with only the posting bar shown and no verification bar. Real Usenet upload (with the user's own account) still pending.