### PR TITLE
fix(DS): add new required header api_key

### DIFF
--- a/data/example_config.py
+++ b/data/example_config.py
@@ -894,9 +894,7 @@ config = {
         "DS": {
             # Instead of using the tracker acronym for folder name when sym/hard linking, you can use a custom name
             "link_dir_name": "",
-            # Provide the DrunkenSlug upload page URL here, it ends with /upload_form
-            "upload_url": "",
-            # Provide the DrunkenSlug API key here
+            # Provide the DrunkenSlug API key here, can be found at https://drunkenslug.com/profile
             "api_key": "",
             "inject_delay": 0,
         },

--- a/data/example_config.py
+++ b/data/example_config.py
@@ -896,6 +896,8 @@ config = {
             "link_dir_name": "",
             # Provide the DrunkenSlug upload page URL here, it ends with /upload_form
             "upload_url": "",
+            # Provide the DrunkenSlug API key here
+            "api_key": "",
             "inject_delay": 0,
         },
         "DT": {

--- a/src/trackers/USENET/DS.py
+++ b/src/trackers/USENET/DS.py
@@ -23,7 +23,9 @@ class DS:
     def __init__(self, config: Config) -> None:
         self.config = config
         self.common = COMMON(config)
-        self.upload_url = str(self.config.get("TRACKERS", {}).get(self.tracker, {}).get("upload_url", "").replace("/upload_form", "/upload.php")).strip()
+        tracker_cfg = self.config.get("TRACKERS", {}).get(self.tracker, {})
+        self.upload_url = str(tracker_cfg.get("upload_url", "").replace("/upload_form", "/upload.php")).strip()
+        self.api_key = str(tracker_cfg.get("api_key", "")).strip()
 
     async def search_existing(self, meta: Meta) -> list[Any]:
         release_name = await self.get_name(meta)
@@ -48,6 +50,10 @@ class DS:
             status_dict["status_message"] = "data error: DS upload_url is not configured in config.py under TRACKERS -> DS -> upload_url"
             return False
 
+        if not self.api_key:
+            status_dict["status_message"] = "data error: DS api_key is not configured in config.py under TRACKERS -> DS -> api_key"
+            return False
+
         nzb_path = meta.nzb_path
         if not nzb_path or not await self.common.check_nzb_file(self.tracker, meta):
             status_dict["status_message"] = "data error: NZB file missing or password missing in header"
@@ -61,6 +67,9 @@ class DS:
         files = {
             'files[]': (nzb_name, nzb_content, 'application/x-nzb')
         }
+        headers = {
+            'X-API-Key': self.api_key
+        }
 
         if meta.debug:
             status_dict["status_message"] = "Debug mode enabled, skipping upload."
@@ -68,7 +77,7 @@ class DS:
         else:
             try:
                 async with httpx.AsyncClient() as client:
-                    response = await client.post(self.upload_url, files=files)
+                    response = await client.post(self.upload_url, headers=headers, files=files)
 
                 if response.status_code not in (200, 201):
                     status_dict["status_message"] = f"data error: HTTP {response.status_code} - {response.text}"

--- a/src/trackers/USENET/DS.py
+++ b/src/trackers/USENET/DS.py
@@ -24,7 +24,6 @@ class DS:
         self.config = config
         self.common = COMMON(config)
         tracker_cfg = self.config.get("TRACKERS", {}).get(self.tracker, {})
-        self.upload_url = str(tracker_cfg.get("upload_url", "").replace("/upload_form", "/upload.php")).strip()
         self.api_key = str(tracker_cfg.get("api_key", "")).strip()
 
     async def search_existing(self, meta: Meta) -> list[Any]:
@@ -45,14 +44,6 @@ class DS:
         if self.tracker not in status_map:
             status_map[self.tracker] = {}
         status_dict = status_map[self.tracker]
-
-        if not self.upload_url:
-            status_dict["status_message"] = "data error: DS upload_url is not configured in config.py under TRACKERS -> DS -> upload_url"
-            return False
-
-        if not self.api_key:
-            status_dict["status_message"] = "data error: DS api_key is not configured in config.py under TRACKERS -> DS -> api_key"
-            return False
 
         nzb_path = meta.nzb_path
         if not nzb_path or not await self.common.check_nzb_file(self.tracker, meta):
@@ -77,7 +68,7 @@ class DS:
         else:
             try:
                 async with httpx.AsyncClient() as client:
-                    response = await client.post(self.upload_url, headers=headers, files=files)
+                    response = await client.post("https://nzbs.drunkenslug.com/upload.php", headers=headers, files=files)
 
                 if response.status_code not in (200, 201):
                     status_dict["status_message"] = f"data error: HTTP {response.status_code} - {response.text}"


### PR DESCRIPTION
Since this morning they start ask for API_KEY header. This is documented in the error message. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API key authentication for DrunkenSlug uploads via an `X-API-Key` header.
  * Updated DrunkenSlug configuration to accept an API key (and removed the prior upload URL setting).

* **Bug Fixes**
  * DrunkenSlug uploads no longer rely on a configurable upload URL and now target the fixed upload endpoint.
  * Uploads will require the DrunkenSlug API key to be present in configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->