### PR TITLE
feat(usenet): add duplicate search support

### DIFF
--- a/data/example_config.py
+++ b/data/example_config.py
@@ -899,6 +899,9 @@ config: dict[str, Any] = {
             "link_dir_name": "",
             # Provide the DRUNKENSLUG API key here, can be found at https://drunkenslug.com/profile
             "api_key": "",
+            # Enable duplicate search using the API.
+            # Default False because DrunkenSlug has a limited daily API hit quota.
+            "search_api": False,
             "inject_delay": 0,
         },
         "DESITORRENTS": {
@@ -1707,6 +1710,9 @@ config: dict[str, Any] = {
             "username": "",
             # Your API Key
             "api_key": "",
+            # Enable duplicate search using the API.
+            # Default False because this indexer has a limited daily API hit quota.
+            "search_api": False,
             "anon": True,
             # If False, the indexer will decide (uses ID "0").
             # If True, the script will resolve the audio language ID:

--- a/src/meta.py
+++ b/src/meta.py
@@ -189,6 +189,7 @@ class Meta:
     imdb_mismatch: bool = False
     imdb_rating: str = ""
     imdb: str | None = ""
+    imdb_tt: str = ""
     imghost: str = ""
     infohash: str = ""
     initial_dupes: dict[str, Any] = field(default_factory=dict)

--- a/src/prep_helpers.py
+++ b/src/prep_helpers.py
@@ -1500,8 +1500,10 @@ async def finalize_metadata(
     if imdb_id_value != 0:
         imdb_str = str(imdb_id_value).zfill(7)
         meta.imdb = imdb_str
+        meta.imdb_tt = f"tt{imdb_str}"
     else:
         meta.imdb = "0"
+        meta.imdb_tt = ""
     meta.mal = meta.mal_id
     meta.tvdb = meta.tvdb_id
     meta.tvmaze = meta.tvmaze_id

--- a/src/trackers/USENET/curupira.py
+++ b/src/trackers/USENET/curupira.py
@@ -2,7 +2,8 @@
 import contextlib
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
+from xml.etree import ElementTree
 
 import aiofiles
 import httpx
@@ -12,6 +13,7 @@ from cogs.redaction import Redaction
 from src.console import logger
 from src.meta import Meta
 from src.trackers.common import Common
+from src.trackers.USENET.search_helpers import build_newznab_search_query, parse_newznab_dupes
 
 Config = dict[str, Any]
 
@@ -33,6 +35,16 @@ class Curupira:
     def __init__(self, config: Config) -> None:
         self.config = config
         self.common = Common(config)
+        self.api_key = self.config.get("TRACKERS", {}).get(self.tracker, {}).get("api_key", "").strip()
+
+    async def get_search_name(self, meta: Meta) -> str:
+        return await self.get_name(meta)
+
+    def get_search_query(self, meta: Meta) -> str:
+        return build_newznab_search_query(meta)
+
+    def _parse_dupes_from_response(self, response_text: str) -> list[dict[str, Any]]:
+        return parse_newznab_dupes(response_text)
 
     async def search_existing(self, meta: Meta) -> list[Any]:
         release_name = await self.get_name(meta)
@@ -41,7 +53,82 @@ class Curupira:
             logger.info(f"{self.tracker}: [yellow]Found local upload cache.[/yellow]")
             return [release_name]
 
-        logger.info(f"{self.tracker}: [yellow]Searching for existing releases is not supported.[/yellow]")
+        params_list: list[dict[str, str]] = []
+        exact_name = await self.get_search_name(meta)
+        if exact_name:
+            params_list.append({
+                "t": "search",
+                "q": exact_name,
+            })
+
+        params: dict[str, str] = {}
+
+        category = meta.category.upper()
+
+        if category == "TV":
+            params["t"] = "tvsearch"
+            if meta.tvdb_id and str(meta.tvdb_id).isdigit() and int(meta.tvdb_id) > 0:
+                params["tvdbid"] = str(meta.tvdb_id)
+            elif meta.tmdb_id and str(meta.tmdb_id).isdigit() and int(meta.tmdb_id) > 0:
+                params["tmdbid"] = str(meta.tmdb_id)
+            elif meta.imdb_id and int(meta.imdb_id) > 0:
+                params["imdbid"] = f"tt{meta.imdb}"
+            else:
+                params["q"] = self.get_search_query(meta)
+
+            if meta.season_int > 0:
+                params["season"] = str(meta.season_int)
+            if meta.episode_int > 0:
+                params["ep"] = str(meta.episode_int)
+        elif category == "MOVIE":
+            params["t"] = "movie"
+            if meta.imdb_id and int(meta.imdb_id) > 0:
+                params["imdbid"] = f"tt{meta.imdb}"
+            elif meta.tmdb_id and str(meta.tmdb_id).isdigit() and int(meta.tmdb_id) > 0:
+                params["tmdbid"] = str(meta.tmdb_id)
+            else:
+                params["q"] = self.get_search_query(meta)
+        else:
+            params["t"] = "search"
+            params["cat"] = self.get_category_id(meta)
+            params["q"] = self.get_search_query(meta)
+
+        if "q" not in params or not params["q"]:
+            params["q"] = self.get_search_query(meta)
+
+        params_list.append(params)
+
+        try:
+            dupes: list[dict[str, Any]] = []
+            seen_keys: set[str] = set()
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                for query_params in params_list:
+                    request_params = {
+                        "apikey": str(self.api_key),
+                        "limit": "100",
+                        **query_params,
+                    }
+                    response = await client.get("https://curupira.cc/api", params=request_params)
+
+                    if response.status_code != 200 or not response.text.strip():
+                        logger.info(f"{self.tracker}: [yellow]Duplicate search failed with HTTP {response.status_code}.[/yellow]")
+                        continue
+
+                    for dupe in self._parse_dupes_from_response(response.text):
+                        key = str(dupe.get("link") or dupe.get("name") or "")
+                        if key in seen_keys:
+                            continue
+                        seen_keys.add(key)
+                        dupes.append(dupe)
+
+            return dupes
+        except ElementTree.ParseError:
+            logger.info(f"{self.tracker}: [yellow]Failed to parse duplicate search response.[/yellow]")
+        except httpx.TimeoutException:
+            logger.info(f"{self.tracker}: [yellow]Duplicate search timed out.[/yellow]")
+        except httpx.RequestError as e:
+            logger.info(f"{self.tracker}: [yellow]Duplicate search request failed: {e}[/yellow]")
+
         return []
 
     async def get_additional_checks(self, _meta: Meta) -> bool:
@@ -168,19 +255,21 @@ class Curupira:
         return ""
 
     async def get_screens(self, meta: Meta) -> list[str]:
-        menu_images = meta.menu_images
-        images_list = meta.get(f"{self.tracker}_images_key", meta.image_list)
-        spectrograms_images = meta.spectrograms_images
+        menu_images = [cast(dict[str, Any], img) for img in meta.menu_images if isinstance(img, dict)]
+        images_value = meta.get(f"{self.tracker}_images_key", meta.image_list)
+        image_entries: list[Any] = cast(list[Any], images_value) if isinstance(images_value, list) else []
+        images_list = [cast(dict[str, Any], img) for img in image_entries if isinstance(img, dict)]
+        spectrograms_images = [cast(dict[str, Any], img) for img in meta.spectrograms_images if isinstance(img, dict)]
 
-        combined_images = []
-        if isinstance(menu_images, list):
-            combined_images.extend([img for img in menu_images if isinstance(img, dict)])
-        if isinstance(images_list, list):
-            combined_images.extend([img for img in images_list if isinstance(img, dict)])
-        if isinstance(spectrograms_images, list):
-            combined_images.extend([img for img in spectrograms_images if isinstance(img, dict)])
+        combined_images: list[dict[str, Any]] = []
+        if menu_images:
+            combined_images.extend(menu_images)
+        if images_list:
+            combined_images.extend(images_list)
+        if spectrograms_images:
+            combined_images.extend(spectrograms_images)
 
-        urls = []
+        urls: list[str] = []
         for image in combined_images:
             raw_url = image.get("raw_url")
             if isinstance(raw_url, str) and raw_url:
@@ -188,7 +277,7 @@ class Curupira:
 
         return urls
 
-    async def _prepare_data(self, meta: Meta, tracker_cfg: Config) -> dict[str, Any]:
+    async def _prepare_data(self, meta: Meta) -> dict[str, Any]:
         screenshot_urls = await self.get_screens(meta)
         data = {
             "name": await self.get_name(meta),
@@ -217,15 +306,19 @@ class Curupira:
 
         if meta.is_disc:
             # Audio and Subtitles languages (optional, as ISO 639-1 JSON array)
-            audio_langs = []
+            audio_langs: list[str] = []
             for lang in meta.audio_languages or []:
                 iso = self.get_iso_639_1(lang)
                 if iso:
                     audio_langs.append(iso)
             if audio_langs:
                 data["audio_langs"] = json.dumps(audio_langs)
-            subs_langs = []
-            for lang in meta.subtitle_languages or []:
+            subtitle_languages = meta.subtitle_languages
+            subtitle_langs = (
+                subtitle_languages if isinstance(subtitle_languages, list) else [subtitle_languages] if isinstance(subtitle_languages, str) and subtitle_languages else []
+            )
+            subs_langs: list[str] = []
+            for lang in subtitle_langs:
                 iso = self.get_iso_639_1(lang)
                 if iso:
                     subs_langs.append(iso)
@@ -246,7 +339,7 @@ class Curupira:
             data["mal_id"] = str(mal_id)
 
         # Anonymous (optional)
-        anon = 0 if meta.anon == 0 and not tracker_cfg.get("anon", False) else 1
+        anon = 0 if meta.anon == 0 and not self.config.get("TRACKERS", {}).get(self.tracker, {}).get("anon", False) else 1
         if anon:
             data["anonymous"] = "true"
 
@@ -266,16 +359,13 @@ class Curupira:
             status_dict["status_message"] = "data error: NZB file missing or password missing in header"
             return False
 
-        tracker_cfg = self.config.get("TRACKERS", {}).get(self.tracker, {})
-        api_key = tracker_cfg.get("api_key", "").strip()
-
         files = await self._prepare_files(meta)
         if not files:
             logger.error(f"[red]Error: NZB file not found for {self.tracker}.[/red]")
             status_dict["status_message"] = "data error: NZB file not found"
             return False
 
-        data = await self._prepare_data(meta, tracker_cfg)
+        data = await self._prepare_data(meta)
 
         if meta.debug:
             logger.debug("[cyan]Curupira Upload (DEBUG MODE):[/cyan]")
@@ -290,7 +380,7 @@ class Curupira:
             return True
 
         # Perform actual upload
-        params = {"apikey": api_key}
+        params = {"apikey": self.api_key}
         try:
             async with httpx.AsyncClient(timeout=60.0) as client:
                 response = await client.post(

--- a/src/trackers/USENET/curupira.py
+++ b/src/trackers/USENET/curupira.py
@@ -98,11 +98,11 @@ class Curupira:
 
         params_list.append(params)
 
-        try:
-            dupes: list[dict[str, Any]] = []
-            seen_keys: set[str] = set()
-            async with httpx.AsyncClient(timeout=10.0) as client:
-                for query_params in params_list:
+        dupes: list[dict[str, Any]] = []
+        seen_keys: set[str] = set()
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            for query_params in params_list:
+                try:
                     request_params = {
                         "apikey": str(self.api_key),
                         "limit": "100",
@@ -120,16 +120,14 @@ class Curupira:
                             continue
                         seen_keys.add(key)
                         dupes.append(dupe)
+                except ElementTree.ParseError:
+                    logger.info(f"{self.tracker}: [yellow]Failed to parse duplicate search response.[/yellow]")
+                except httpx.TimeoutException:
+                    logger.info(f"{self.tracker}: [yellow]Duplicate search timed out.[/yellow]")
+                except httpx.RequestError as e:
+                    logger.info(f"{self.tracker}: [yellow]Duplicate search request failed: {e}[/yellow]")
 
-            return dupes
-        except ElementTree.ParseError:
-            logger.info(f"{self.tracker}: [yellow]Failed to parse duplicate search response.[/yellow]")
-        except httpx.TimeoutException:
-            logger.info(f"{self.tracker}: [yellow]Duplicate search timed out.[/yellow]")
-        except httpx.RequestError as e:
-            logger.info(f"{self.tracker}: [yellow]Duplicate search request failed: {e}[/yellow]")
-
-        return []
+        return dupes
 
     async def get_additional_checks(self, _meta: Meta) -> bool:
         return True

--- a/src/trackers/USENET/drunkenslug.py
+++ b/src/trackers/USENET/drunkenslug.py
@@ -2,6 +2,7 @@
 import json
 from pathlib import Path
 from typing import Any
+from xml.etree import ElementTree
 
 import aiofiles
 import httpx
@@ -9,6 +10,7 @@ import httpx
 from src.console import logger
 from src.meta import Meta
 from src.trackers.common import Common
+from src.trackers.USENET.search_helpers import build_newznab_search_query, get_newznab_search_category_id, parse_newznab_dupes
 
 Config = dict[str, Any]
 
@@ -22,6 +24,7 @@ class DrunkenSlug:
     tracker = "DRUNKENSLUG"
     display_name = "DrunkenSlug"
     banned_groups = ()
+    search_url = "https://drunkenslug.com/api"
     torrent_url = "https://drunkenslug.com/search/"
     supported_categories = ("TV", "MOVIE", "GAME", "BOOK")
     is_usenet = True
@@ -39,11 +42,84 @@ class DrunkenSlug:
             logger.info(f"{self.tracker}: [yellow]Found local upload cache.[/yellow]")
             return [release_name]
 
-        logger.info(f"{self.tracker}: [yellow]Searching for existing releases is not supported.[/yellow]")
+        if not self.api_key:
+            logger.info(f"{self.tracker}: [yellow]Duplicate search skipped due to missing API key.[/yellow]")
+            return []
+        if not bool(self.config.get("TRACKERS", {}).get(self.tracker, {}).get("search_api", False)):
+            logger.info(f"{self.tracker}: [yellow]Duplicate search via API is disabled in config.[/yellow]")
+            return []
+
+        params: dict[str, str] = {
+            "cat": get_newznab_search_category_id(meta),
+        }
+        category = meta.category.upper()
+        if category == "TV":
+            params["t"] = "tvsearch"
+            if meta.tvdb_id and str(meta.tvdb_id).isdigit() and int(meta.tvdb_id) > 0:
+                params["tvdbid"] = str(meta.tvdb_id)
+            elif meta.tmdb_id and str(meta.tmdb_id).isdigit() and int(meta.tmdb_id) > 0:
+                params["tmdbid"] = str(meta.tmdb_id)
+            elif meta.imdb_id and int(meta.imdb_id) > 0:
+                params["imdbid"] = str(meta.imdb_id)
+            else:
+                params["q"] = self.get_search_query(meta)
+
+            if meta.season_int > 0:
+                params["season"] = str(meta.season_int)
+            if meta.episode_int > 0:
+                params["ep"] = str(meta.episode_int)
+        elif category == "MOVIE":
+            params["t"] = "movie"
+            if meta.imdb_id and int(meta.imdb_id) > 0:
+                params["imdbid"] = str(meta.imdb_id)
+            elif meta.tmdb_id and str(meta.tmdb_id).isdigit() and int(meta.tmdb_id) > 0:
+                params["tmdbid"] = str(meta.tmdb_id)
+            else:
+                params["q"] = self.get_search_query(meta)
+        else:
+            params["t"] = "search"
+            params["q"] = self.get_search_query(meta)
+
+        try:
+            dupes: list[dict[str, Any]] = []
+            seen_keys: set[str] = set()
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                request_params = {
+                    "apikey": self.api_key,
+                    "limit": "100",
+                    "extended": "1",
+                    **params,
+                }
+                response = await client.get(self.search_url, params=request_params)
+                if response.status_code != 200 or not response.text.strip():
+                    logger.info(f"{self.tracker}: [yellow]Duplicate search failed with HTTP {response.status_code}.[/yellow]")
+                    return []
+
+                for dupe in self._parse_dupes_from_response(response.text):
+                    key = str(dupe.get("link") or dupe.get("name") or "")
+                    if key in seen_keys:
+                        continue
+                    seen_keys.add(key)
+                    dupes.append(dupe)
+
+            return dupes
+        except ElementTree.ParseError:
+            logger.info(f"{self.tracker}: [yellow]Failed to parse duplicate search response.[/yellow]")
+        except httpx.TimeoutException:
+            logger.info(f"{self.tracker}: [yellow]Duplicate search timed out.[/yellow]")
+        except httpx.RequestError as e:
+            logger.info(f"{self.tracker}: [yellow]Duplicate search request failed: {e}[/yellow]")
+
         return []
 
     async def get_name(self, meta: Meta) -> str:
         return meta.scene_name or meta.basename_no_ext
+
+    def get_search_query(self, meta: Meta) -> str:
+        return build_newznab_search_query(meta)
+
+    def _parse_dupes_from_response(self, response_text: str) -> list[dict[str, Any]]:
+        return parse_newznab_dupes(response_text)
 
     async def upload(self, meta: Meta) -> bool:
         status_map = meta.tracker_status

--- a/src/trackers/USENET/search_helpers.py
+++ b/src/trackers/USENET/search_helpers.py
@@ -1,6 +1,7 @@
 # Upload Assistant © 2026 Audionut & wastaken7 — Licensed under UAPL v1.0
 from typing import Any
-from xml.etree import ElementTree
+
+from defusedxml import ElementTree
 
 from src.meta import Meta
 
@@ -36,7 +37,11 @@ def get_newznab_search_category_id(meta: Meta) -> str:
 
 def build_newznab_search_query(meta: Meta) -> str:
     title = str(meta.title or meta.original_title or "").strip()
-    year = int(meta.year or meta.search_year or 0)
+    raw_year = meta.year or meta.search_year or 0
+    try:
+        year = int(raw_year)
+    except (TypeError, ValueError):
+        year = 0
 
     if meta.category.upper() == "TV":
         if title and meta.season_int > 0 and meta.episode_int > 0:
@@ -84,6 +89,7 @@ def parse_newznab_dupes(
             elif use_guid_attr_as_id and attr_name == "guid" and attr_value and not guid:
                 guid = attr_value
 
+        item_link = str(item.findtext("link") or item_link)
         if item_link and not item_link.startswith(("http://", "https://")) and guid and torrent_url:
             item_link = f"{torrent_url}{guid}"
 

--- a/src/trackers/USENET/search_helpers.py
+++ b/src/trackers/USENET/search_helpers.py
@@ -1,0 +1,97 @@
+# Upload Assistant © 2026 Audionut & wastaken7 — Licensed under UAPL v1.0
+from typing import Any
+from xml.etree import ElementTree
+
+from src.meta import Meta
+
+
+def get_newznab_search_category_id(meta: Meta) -> str:
+    category = meta.category.upper()
+    resolution = meta.resolution.lower()
+    uhd_resolutions = {"2160p", "4320p", "8640p"}
+    hd_resolutions = {"1080p", "1080i", "720p", "1440p"}
+
+    if category == "MOVIE":
+        if resolution in uhd_resolutions:
+            return "2045"
+        if resolution in hd_resolutions:
+            return "2040"
+        return "2030"
+    if category == "TV":
+        if resolution in uhd_resolutions:
+            return "5045"
+        if resolution in hd_resolutions:
+            return "5040"
+        return "5030"
+    if category == "BOOK":
+        if meta.audiobook:
+            return "3030"
+        return "7020"
+    if category == "GAME":
+        return "4050"
+    if category == "MUSIC":
+        return "3000"
+    return "2000"
+
+
+def build_newznab_search_query(meta: Meta) -> str:
+    title = str(meta.title or meta.original_title or "").strip()
+    year = int(meta.year or meta.search_year or 0)
+
+    if meta.category.upper() == "TV":
+        if title and meta.season_int > 0 and meta.episode_int > 0:
+            return f"{title} S{meta.season_int:02d}E{meta.episode_int:02d}"
+        if title and meta.season_int > 0:
+            return f"{title} S{meta.season_int:02d}"
+        if title:
+            return title
+    elif meta.category.upper() == "MOVIE":
+        if title and year > 0:
+            return f"{title} {year}"
+        if title:
+            return title
+
+    return str(meta.basename_no_ext or title).strip()
+
+
+def parse_newznab_dupes(
+    response_text: str,
+    torrent_url: str | None = None,
+    *,
+    use_guid_attr_as_id: bool = False,
+) -> list[dict[str, Any]]:
+    dupes: list[dict[str, Any]] = []
+    response_xml = ElementTree.fromstring(response_text)
+    channel = response_xml.find("channel")
+    if channel is None:
+        return dupes
+
+    for item in channel.findall("item"):
+        title = str(item.findtext("title") or "")
+        guid = str(item.findtext("guid") or "")
+        item_link = guid
+        size_text = "0"
+
+        enclosure = item.find("enclosure")
+        if enclosure is not None:
+            size_text = str(enclosure.attrib.get("length") or "0")
+
+        for attr in item.findall("{http://www.newznab.com/DTD/2010/feeds/attributes/}attr"):
+            attr_name = str(attr.attrib.get("name") or "").lower()
+            attr_value = str(attr.attrib.get("value") or "")
+            if attr_name == "size" and attr_value:
+                size_text = attr_value
+            elif use_guid_attr_as_id and attr_name == "guid" and attr_value and not guid:
+                guid = attr_value
+
+        if item_link and not item_link.startswith(("http://", "https://")) and guid and torrent_url:
+            item_link = f"{torrent_url}{guid}"
+
+        dupes.append({
+            "name": title,
+            "files": title,
+            "size": int(size_text) if size_text.isdigit() else 0,
+            "link": item_link,
+        })
+
+    return dupes

--- a/src/trackers/USENET/suio.py
+++ b/src/trackers/USENET/suio.py
@@ -8,6 +8,7 @@ import unicodedata
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
+from xml.etree import ElementTree
 
 import aiofiles
 import httpx
@@ -17,6 +18,7 @@ from cogs.redaction import Redaction
 from src.console import logger
 from src.meta import Meta
 from src.trackers.common import Common
+from src.trackers.USENET.search_helpers import build_newznab_search_query, get_newznab_search_category_id, parse_newznab_dupes
 
 Config = dict[str, Any]
 
@@ -32,14 +34,16 @@ class Suio:
     banned_groups: tuple[str, ...] = ()
     upload_url: str | None = None
     torrent_url: str | None = None
+    search_url: str | None = None
     supported_categories = ("MOVIE", "TV", "GAME", "BOOK")
     is_usenet = True
 
     def __init__(self, config: Config) -> None:
         self.config = config
         self.common = Common(config)
-        tracker_cfg = config.get("TRACKERS", {}).get(self.tracker, {})
-        base_url = str(tracker_cfg.get("base_url", "")).strip().rstrip("/")
+        self.tracker_cfg = config.get("TRACKERS", {}).get(self.tracker, {})
+        self.api_key = str(self.tracker_cfg.get("api_key", "")).strip()
+        base_url = str(self.tracker_cfg.get("base_url", "")).strip().rstrip("/")
         if base_url:
             # Verify the domain matches the expected indexer domain hash to prevent credentials leak
             url_to_parse = base_url if base_url.startswith(("http://", "https://")) else "https://" + base_url
@@ -52,16 +56,32 @@ class Suio:
                 if domain_hash == "a0fcf409be81cbcec4e212cb69331960e5d709449c0e9cad40e36369d8da8f3c":
                     self.upload_url = f"{base_url}/api-upload"
                     self.torrent_url = f"{base_url}/details.php?id="
+                    parsed_url = urlparse(url_to_parse)
+                    scheme = parsed_url.scheme or "https"
+                    hostname = parsed_url.netloc or parsed_url.path
+                    self.search_url = f"{scheme}://api.{hostname.split('@')[-1]}/api"
                 else:
                     self.upload_url = None
                     self.torrent_url = None
+                    self.search_url = None
                     logger.info(f"{self.tracker} [red]base_url from config.py does not match the expected domain. Skipping...[/red]")
             except Exception:
                 self.upload_url = None
                 self.torrent_url = None
+                self.search_url = None
         else:
             self.upload_url = None
             self.torrent_url = None
+            self.search_url = None
+
+    def get_search_query(self, meta: Meta) -> str:
+        return build_newznab_search_query(meta)
+
+    async def get_search_name(self, meta: Meta) -> str:
+        return await self.get_name(meta)
+
+    def _parse_dupes_from_response(self, response_text: str) -> list[dict[str, Any]]:
+        return parse_newznab_dupes(response_text, self.torrent_url, use_guid_attr_as_id=True)
 
     async def search_existing(self, meta: Meta) -> list[Any]:
         release_name = await self.get_name(meta)
@@ -70,7 +90,82 @@ class Suio:
             logger.info(f"{self.tracker}: [yellow]Found local upload cache.[/yellow]")
             return [release_name]
 
-        logger.info(f"{self.tracker}: [yellow]Searching for existing releases is not supported.[/yellow]")
+        if not self.search_url:
+            return []
+        if not bool(self.tracker_cfg.get("search_api", False)):
+            logger.info(f"{self.tracker}: [yellow]Duplicate search via API is disabled in config.[/yellow]")
+            return []
+
+        params_list: list[dict[str, str]] = []
+        exact_name = await self.get_search_name(meta)
+        if exact_name:
+            params_list.append({
+                "t": "search",
+                "q": exact_name,
+                "pw": "0",
+            })
+
+        params: dict[str, str] = {
+            "cat": get_newznab_search_category_id(meta),
+        }
+
+        category = meta.category.upper()
+        if category == "TV":
+            params["t"] = "tvsearch"
+            if meta.tvdb_id and str(meta.tvdb_id).isdigit() and int(meta.tvdb_id) > 0:
+                params["tvdbid"] = str(meta.tvdb_id)
+            else:
+                params["q"] = self.get_search_query(meta)
+
+            if meta.season_int > 0:
+                params["season"] = str(meta.season_int)
+            if meta.episode_int > 0:
+                params["ep"] = str(meta.episode_int)
+        elif category == "MOVIE":
+            params["t"] = "movie"
+            if meta.imdb_tt:
+                params["imdbid"] = meta.imdb_tt
+            else:
+                params["q"] = self.get_search_query(meta)
+        else:
+            params["t"] = "search"
+            params["q"] = self.get_search_query(meta)
+
+        params_list.append(params)
+
+        try:
+            dupes: list[dict[str, Any]] = []
+            seen_keys: set[str] = set()
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                for query_params in params_list:
+                    request_params = {
+                        "apikey": self.api_key,
+                        "limit": "100",
+                        "extended": "1",
+                        "pw": "2",
+                        **query_params,
+                    }
+                    response = await client.get(self.search_url, params=request_params)
+
+                    if response.status_code != 200 or not response.text.strip():
+                        logger.info(f"{self.tracker}: [yellow]Duplicate search failed with HTTP {response.status_code}.[/yellow]")
+                        continue
+
+                    for dupe in self._parse_dupes_from_response(response.text):
+                        key = str(dupe.get("link") or dupe.get("name") or "")
+                        if key in seen_keys:
+                            continue
+                        seen_keys.add(key)
+                        dupes.append(dupe)
+
+            return dupes
+        except ElementTree.ParseError:
+            logger.info(f"{self.tracker}: [yellow]Failed to parse duplicate search response.[/yellow]")
+        except httpx.TimeoutException:
+            logger.info(f"{self.tracker}: [yellow]Duplicate search timed out.[/yellow]")
+        except httpx.RequestError as e:
+            logger.info(f"{self.tracker}: [yellow]Duplicate search request failed: {e}[/yellow]")
+
         return []
 
     async def get_additional_checks(self, _meta: Meta) -> bool:
@@ -320,9 +415,7 @@ class Suio:
             status_dict["status_message"] = "data error: base_url missing"
             return False
 
-        tracker_cfg = self.config.get("TRACKERS", {}).get(self.tracker, {})
-        username = tracker_cfg.get("username", "").strip()
-        api_key = tracker_cfg.get("api_key", "").strip()
+        username = self.tracker_cfg.get("username", "").strip()
 
         files = await self._prepare_files(meta)
         if not files:
@@ -339,10 +432,12 @@ class Suio:
             logger.debug({k: v[0] for k, v in files.items()})
             status_dict["status_message"] = "Debug mode enabled, skipping upload."
             return True
+
         params = {
-            "user": username,
-            "api": api_key,
+            "user": str(username),
+            "api": self.api_key,
         }
+
         try:
             async with httpx.AsyncClient(timeout=60.0) as client:
                 response = await client.post(


### PR DESCRIPTION
Extract shared Newznab search helpers and enable duplicate lookup for Curupira, DrunkenSlug, and Suio.

Add optional `search_api` config flags for quota-limited indexers and persist `imdb_tt` metadata for API queries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added API-based duplicate searching for Curupira, DrunkenSlug, and SUIO.
  - Prepared metadata now supports TMDb-style IMDb `tt` identifiers (`imdb_tt`).
- **Bug Fixes**
  - Improved duplicate search result normalization and deduplication.
  - Enhanced reliability around parsing and request handling (including better media/image and language handling).
- **Configuration**
  - Introduced a per-tracker `search_api` option (default: disabled) for API duplicate searching on DrunkenSlug and SUIO.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->