### PR TITLE
Add daily API hit limits for USENET duplicate search

### DIFF
--- a/data/example_config.py
+++ b/data/example_config.py
@@ -899,9 +899,9 @@ config: dict[str, Any] = {
             "link_dir_name": "",
             # Provide the DRUNKENSLUG API key here, can be found at https://drunkenslug.com/profile
             "api_key": "",
-            # Enable duplicate search using the API.
-            # Default False because DrunkenSlug has a limited daily API hit quota.
-            "search_api": False,
+            # Maximum number of API hits the script may make within 24 hours for duplicate search.
+            # Set to 0 to disable duplicate search via API.
+            "daily_api_hit_limit": 0,
             "inject_delay": 0,
         },
         "DESITORRENTS": {
@@ -1710,9 +1710,9 @@ config: dict[str, Any] = {
             "username": "",
             # Your API Key
             "api_key": "",
-            # Enable duplicate search using the API.
-            # Default False because this indexer has a limited daily API hit quota.
-            "search_api": False,
+            # Maximum number of API hits the script may make within 24 hours for duplicate search.
+            # Set to 0 to disable duplicate search via API.
+            "daily_api_hit_limit": 0,
             "anon": True,
             # If False, the indexer will decide (uses ID "0").
             # If True, the script will resolve the audio language ID:

--- a/src/audio.py
+++ b/src/audio.py
@@ -318,7 +318,7 @@ async def _get_audio_v2(
             if tracks_with_order:
                 try:
                     first_audio_track = min(tracks_with_order, key=lambda x: int(str(x.get("StreamOrder", "999"))))
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     first_audio_track = tracks_with_order[0]
             else:
                 tracks_with_id = [t for t in audio_tracks if t.get("ID") and not isinstance(t.get("ID"), dict)]
@@ -330,7 +330,7 @@ async def _get_audio_v2(
                             return int(id_match.group()) if id_match else 999
 
                         first_audio_track = min(tracks_with_id, key=get_id_num)
-                    except (ValueError, TypeError, AttributeError):
+                    except ValueError, TypeError, AttributeError:
                         first_audio_track = tracks_with_id[0]
                 else:
                     first_audio_track = audio_tracks[0]

--- a/src/book_extractors.py
+++ b/src/book_extractors.py
@@ -19,7 +19,7 @@ def normalize_series_index(value: str) -> str:
     """Drop a trailing .0 from a series index ("5.0" -> "5"), keeping "5.5"/"0.5"."""
     try:
         idx = float(value)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return (value).strip()
     return str(int(idx)) if idx.is_integer() else str(idx)
 

--- a/src/cookie_auth.py
+++ b/src/cookie_auth.py
@@ -1,7 +1,6 @@
 # Upload Assistant © 2025 Audionut & wastaken7 — Licensed under UAPL v1.0
 import http.cookiejar
 import json
-import pickle  # nosec B403 - Only used for legacy cookie migration
 import re
 import stat
 import traceback

--- a/src/discparse.py
+++ b/src/discparse.py
@@ -761,7 +761,7 @@ class DiscParse:
 
                             selected_playlists = [valid_playlists[i] for i in selected_indices]
                             break  # Exit the loop when valid input is provided
-                        except (ValueError, IndexError):
+                        except ValueError, IndexError:
                             logger.info("[red]Invalid input. Please try again.")
 
                 # Extract the .EVO files from the selected playlists

--- a/src/is_scene.py
+++ b/src/is_scene.py
@@ -133,7 +133,7 @@ class SceneManager:
                                     for file in release_details_dict.get("files", []):
                                         if file["name"].endswith(".nfo"):
                                             release_lower = re.sub(r"[^A-Za-z0-9._-]+", "_", Path(file["name"]).stem).strip("._") or release_lower
-                                except (KeyError, ValueError):
+                                except KeyError, ValueError:
                                     pass
 
                             nfo_url = f"https://www.srrdb.com/download/file/{release}/{release_lower}.nfo"

--- a/src/trackers/UNIT3D/aura4k.py
+++ b/src/trackers/UNIT3D/aura4k.py
@@ -97,7 +97,7 @@ class Aura4K(UNIT3D):
                         if bit_rate:
                             try:
                                 bit_rate_num = int(bit_rate)
-                            except (ValueError, TypeError):
+                            except ValueError, TypeError:
                                 bit_rate_num = None
 
                             if bit_rate_num is not None:

--- a/src/trackers/USENET/curupira.py
+++ b/src/trackers/USENET/curupira.py
@@ -56,10 +56,12 @@ class Curupira:
         params_list: list[dict[str, str]] = []
         exact_name = await self.get_search_name(meta)
         if exact_name:
-            params_list.append({
-                "t": "search",
-                "q": exact_name,
-            })
+            params_list.append(
+                {
+                    "t": "search",
+                    "q": exact_name,
+                }
+            )
 
         params: dict[str, str] = {}
 

--- a/src/trackers/USENET/drunkenslug.py
+++ b/src/trackers/USENET/drunkenslug.py
@@ -10,7 +10,13 @@ import httpx
 from src.console import logger
 from src.meta import Meta
 from src.trackers.common import Common
-from src.trackers.USENET.search_helpers import build_newznab_search_query, get_newznab_search_category_id, parse_newznab_dupes
+from src.trackers.USENET.search_helpers import (
+    build_newznab_search_query,
+    get_daily_api_hit_limit,
+    get_newznab_search_category_id,
+    parse_newznab_dupes,
+    reserve_daily_api_hit,
+)
 
 Config = dict[str, Any]
 
@@ -32,8 +38,9 @@ class DrunkenSlug:
     def __init__(self, config: Config) -> None:
         self.config = config
         self.common = Common(config)
-        tracker_cfg = self.config.get("TRACKERS", {}).get(self.tracker, {})
-        self.api_key = str(tracker_cfg.get("api_key", "")).strip()
+        self.tracker_cfg = self.config.get("TRACKERS", {}).get(self.tracker, {})
+        self.api_key = str(self.tracker_cfg.get("api_key", "")).strip()
+        self.daily_api_hit_limit = get_daily_api_hit_limit(self.tracker_cfg)
 
     async def search_existing(self, meta: Meta) -> list[Any]:
         release_name = await self.get_name(meta)
@@ -45,8 +52,8 @@ class DrunkenSlug:
         if not self.api_key:
             logger.info(f"{self.tracker}: [yellow]Duplicate search skipped due to missing API key.[/yellow]")
             return []
-        if not bool(self.config.get("TRACKERS", {}).get(self.tracker, {}).get("search_api", False)):
-            logger.info(f"{self.tracker}: [yellow]Duplicate search via API is disabled in config.[/yellow]")
+        if self.daily_api_hit_limit <= 0:
+            logger.info(f"{self.tracker}: [yellow]Duplicate search via API is disabled because daily_api_hit_limit is 0.[/yellow]")
             return []
 
         params: dict[str, str] = {
@@ -84,6 +91,13 @@ class DrunkenSlug:
             dupes: list[dict[str, Any]] = []
             seen_keys: set[str] = set()
             async with httpx.AsyncClient(timeout=10.0) as client:
+                allowed, used_hits = await reserve_daily_api_hit(meta.base_dir, self.tracker, self.daily_api_hit_limit)
+                if not allowed:
+                    logger.info(
+                        f"{self.tracker}: [yellow]Duplicate search skipped because the 24-hour API hit limit "
+                        f"({self.daily_api_hit_limit}) has been reached.[/yellow]"
+                    )
+                    return []
                 request_params = {
                     "apikey": self.api_key,
                     "limit": "100",
@@ -91,6 +105,9 @@ class DrunkenSlug:
                     **params,
                 }
                 response = await client.get(self.search_url, params=request_params)
+                logger.debug(
+                    f"{self.tracker}: Duplicate search used API hit {used_hits}/{self.daily_api_hit_limit} in the last 24 hours."
+                )
                 if response.status_code != 200 or not response.text.strip():
                     logger.info(f"{self.tracker}: [yellow]Duplicate search failed with HTTP {response.status_code}.[/yellow]")
                     return []

--- a/src/trackers/USENET/drunkenslug.py
+++ b/src/trackers/USENET/drunkenslug.py
@@ -93,10 +93,7 @@ class DrunkenSlug:
             async with httpx.AsyncClient(timeout=10.0) as client:
                 allowed, used_hits = await reserve_daily_api_hit(meta.base_dir, self.tracker, self.daily_api_hit_limit)
                 if not allowed:
-                    logger.info(
-                        f"{self.tracker}: [yellow]Duplicate search skipped because the 24-hour API hit limit "
-                        f"({self.daily_api_hit_limit}) has been reached.[/yellow]"
-                    )
+                    logger.info(f"{self.tracker}: [yellow]Duplicate search skipped because the 24-hour API hit limit ({self.daily_api_hit_limit}) has been reached.[/yellow]")
                     return []
                 request_params = {
                     "apikey": self.api_key,
@@ -105,9 +102,7 @@ class DrunkenSlug:
                     **params,
                 }
                 response = await client.get(self.search_url, params=request_params)
-                logger.debug(
-                    f"{self.tracker}: Duplicate search used API hit {used_hits}/{self.daily_api_hit_limit} in the last 24 hours."
-                )
+                logger.debug(f"{self.tracker}: Duplicate search used API hit {used_hits}/{self.daily_api_hit_limit} in the last 24 hours.")
                 if response.status_code != 200 or not response.text.strip():
                     logger.info(f"{self.tracker}: [yellow]Duplicate search failed with HTTP {response.status_code}.[/yellow]")
                     return []

--- a/src/trackers/USENET/search_helpers.py
+++ b/src/trackers/USENET/search_helpers.py
@@ -1,6 +1,8 @@
 # Upload Assistant © 2026 Audionut & wastaken7 — Licensed under UAPL v1.0
 import asyncio
+import contextlib
 import json
+import os
 import time
 from pathlib import Path
 from typing import Any
@@ -10,7 +12,9 @@ from defusedxml import ElementTree
 from src.meta import Meta
 
 API_HIT_WINDOW_SECONDS = 24 * 60 * 60
-API_HIT_COUNTER_FILENAME = "usenet_api_hit_counters.json"
+API_HIT_COUNTER_DIRNAME = "usenet_api_hit_counters"
+API_HIT_COUNTER_LOCK_TIMEOUT_SECONDS = 10.0
+API_HIT_COUNTER_LOCK_POLL_SECONDS = 0.05
 
 
 def get_newznab_search_category_id(meta: Meta) -> str:
@@ -118,42 +122,77 @@ def get_daily_api_hit_limit(tracker_cfg: dict[str, Any]) -> int:
     return max(limit, 0)
 
 
-def _get_api_hit_counter_path(base_dir: str) -> Path:
-    return Path(base_dir) / "tmp" / API_HIT_COUNTER_FILENAME
+def _get_api_hit_counter_filename(tracker: str) -> str:
+    safe_tracker = "".join(char if char.isalnum() else "_" for char in tracker.strip().lower())
+    safe_tracker = safe_tracker.strip("_") or "default"
+    return f"{safe_tracker}.json"
+
+
+def _get_api_hit_counter_path(base_dir: str, tracker: str) -> Path:
+    return Path(base_dir) / "tmp" / API_HIT_COUNTER_DIRNAME / _get_api_hit_counter_filename(tracker)
+
+
+def _get_api_hit_counter_lock_path(base_dir: str, tracker: str) -> Path:
+    return _get_api_hit_counter_path(base_dir, tracker).with_suffix(".lock")
+
+
+def _acquire_api_hit_counter_lock(lock_path: Path) -> int:
+    deadline = time.monotonic() + API_HIT_COUNTER_LOCK_TIMEOUT_SECONDS
+    while True:
+        try:
+            return os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_RDWR)
+        except FileExistsError:
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"Timed out waiting for API hit counter lock: {lock_path}") from None
+            time.sleep(API_HIT_COUNTER_LOCK_POLL_SECONDS)
+
+
+def _release_api_hit_counter_lock(lock_fd: int, lock_path: Path) -> None:
+    try:
+        os.close(lock_fd)
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            lock_path.unlink()
+
+
+def _write_api_hit_cache(cache_path: Path, tracker_hits: list[float]) -> None:
+    temp_path = cache_path.with_suffix(f"{cache_path.suffix}.tmp.{os.getpid()}")
+    temp_path.write_text(json.dumps(tracker_hits, indent=2), encoding="utf-8")
+    temp_path.replace(cache_path)
 
 
 def _reserve_daily_api_hit_sync(base_dir: str, tracker: str, limit: int) -> tuple[bool, int]:
-    cache_path = _get_api_hit_counter_path(base_dir)
+    cache_path = _get_api_hit_counter_path(base_dir, tracker)
     cache_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = _get_api_hit_counter_lock_path(base_dir, tracker)
+    lock_fd = _acquire_api_hit_counter_lock(lock_path)
+    try:
+        tracker_hits: list[Any] = []
+        if cache_path.exists():
+            try:
+                loaded_cache = json.loads(cache_path.read_text(encoding="utf-8"))
+                if isinstance(loaded_cache, list):
+                    tracker_hits = loaded_cache
+            except OSError, json.JSONDecodeError:
+                tracker_hits = []
 
-    raw_cache: dict[str, Any] = {}
-    if cache_path.exists():
-        try:
-            raw_cache = json.loads(cache_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            raw_cache = {}
+        now = time.time()
+        cutoff = now - API_HIT_WINDOW_SECONDS
+        recent_hits: list[float] = []
+        for hit in tracker_hits:
+            if isinstance(hit, (int, float)):
+                hit_value = float(hit)
+                if hit_value >= cutoff:
+                    recent_hits.append(hit_value)
+        if len(recent_hits) >= limit:
+            _write_api_hit_cache(cache_path, recent_hits)
+            return False, len(recent_hits)
 
-    now = time.time()
-    cutoff = now - API_HIT_WINDOW_SECONDS
-    tracker_hits = raw_cache.get(tracker, [])
-    if not isinstance(tracker_hits, list):
-        tracker_hits = []
-
-    recent_hits: list[float] = []
-    for hit in tracker_hits:
-        if isinstance(hit, (int, float)):
-            hit_value = float(hit)
-            if hit_value >= cutoff:
-                recent_hits.append(hit_value)
-    if len(recent_hits) >= limit:
-        raw_cache[tracker] = recent_hits
-        cache_path.write_text(json.dumps(raw_cache, indent=2, sort_keys=True), encoding="utf-8")
-        return False, len(recent_hits)
-
-    recent_hits.append(now)
-    raw_cache[tracker] = recent_hits
-    cache_path.write_text(json.dumps(raw_cache, indent=2, sort_keys=True), encoding="utf-8")
-    return True, len(recent_hits)
+        recent_hits.append(now)
+        _write_api_hit_cache(cache_path, recent_hits)
+        return True, len(recent_hits)
+    finally:
+        _release_api_hit_counter_lock(lock_fd, lock_path)
 
 
 async def reserve_daily_api_hit(base_dir: str, tracker: str, limit: int) -> tuple[bool, int]:

--- a/src/trackers/USENET/search_helpers.py
+++ b/src/trackers/USENET/search_helpers.py
@@ -1,9 +1,16 @@
 # Upload Assistant © 2026 Audionut & wastaken7 — Licensed under UAPL v1.0
+import asyncio
+import json
+import time
+from pathlib import Path
 from typing import Any
 
 from defusedxml import ElementTree
 
 from src.meta import Meta
+
+API_HIT_WINDOW_SECONDS = 24 * 60 * 60
+API_HIT_COUNTER_FILENAME = "usenet_api_hit_counters.json"
 
 
 def get_newznab_search_category_id(meta: Meta) -> str:
@@ -101,3 +108,53 @@ def parse_newznab_dupes(
         })
 
     return dupes
+
+
+def get_daily_api_hit_limit(tracker_cfg: dict[str, Any]) -> int:
+    try:
+        limit = int(tracker_cfg.get("daily_api_hit_limit", 0))
+    except (TypeError, ValueError):
+        return 0
+    return max(limit, 0)
+
+
+def _get_api_hit_counter_path(base_dir: str) -> Path:
+    return Path(base_dir) / "tmp" / API_HIT_COUNTER_FILENAME
+
+
+def _reserve_daily_api_hit_sync(base_dir: str, tracker: str, limit: int) -> tuple[bool, int]:
+    cache_path = _get_api_hit_counter_path(base_dir)
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+
+    raw_cache: dict[str, Any] = {}
+    if cache_path.exists():
+        try:
+            raw_cache = json.loads(cache_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            raw_cache = {}
+
+    now = time.time()
+    cutoff = now - API_HIT_WINDOW_SECONDS
+    tracker_hits = raw_cache.get(tracker, [])
+    if not isinstance(tracker_hits, list):
+        tracker_hits = []
+
+    recent_hits: list[float] = []
+    for hit in tracker_hits:
+        if isinstance(hit, (int, float)):
+            hit_value = float(hit)
+            if hit_value >= cutoff:
+                recent_hits.append(hit_value)
+    if len(recent_hits) >= limit:
+        raw_cache[tracker] = recent_hits
+        cache_path.write_text(json.dumps(raw_cache, indent=2, sort_keys=True), encoding="utf-8")
+        return False, len(recent_hits)
+
+    recent_hits.append(now)
+    raw_cache[tracker] = recent_hits
+    cache_path.write_text(json.dumps(raw_cache, indent=2, sort_keys=True), encoding="utf-8")
+    return True, len(recent_hits)
+
+
+async def reserve_daily_api_hit(base_dir: str, tracker: str, limit: int) -> tuple[bool, int]:
+    return await asyncio.to_thread(_reserve_daily_api_hit_sync, base_dir, tracker, limit)

--- a/src/trackers/USENET/search_helpers.py
+++ b/src/trackers/USENET/search_helpers.py
@@ -1,11 +1,20 @@
 # Upload Assistant © 2026 Audionut & wastaken7 — Licensed under UAPL v1.0
 import asyncio
-import contextlib
 import json
 import os
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, BinaryIO
+
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
+
+try:
+    import msvcrt
+except ImportError:
+    msvcrt = None
 
 from defusedxml import ElementTree
 
@@ -51,7 +60,7 @@ def build_newznab_search_query(meta: Meta) -> str:
     raw_year = meta.year or meta.search_year or 0
     try:
         year = int(raw_year)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         year = 0
 
     if meta.category.upper() == "TV":
@@ -104,12 +113,14 @@ def parse_newznab_dupes(
         if item_link and not item_link.startswith(("http://", "https://")) and guid and torrent_url:
             item_link = f"{torrent_url}{guid}"
 
-        dupes.append({
-            "name": title,
-            "files": title,
-            "size": int(size_text) if size_text.isdigit() else 0,
-            "link": item_link,
-        })
+        dupes.append(
+            {
+                "name": title,
+                "files": title,
+                "size": int(size_text) if size_text.isdigit() else 0,
+                "link": item_link,
+            }
+        )
 
     return dupes
 
@@ -117,7 +128,7 @@ def parse_newznab_dupes(
 def get_daily_api_hit_limit(tracker_cfg: dict[str, Any]) -> int:
     try:
         limit = int(tracker_cfg.get("daily_api_hit_limit", 0))
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return 0
     return max(limit, 0)
 
@@ -136,23 +147,51 @@ def _get_api_hit_counter_lock_path(base_dir: str, tracker: str) -> Path:
     return _get_api_hit_counter_path(base_dir, tracker).with_suffix(".lock")
 
 
-def _acquire_api_hit_counter_lock(lock_path: Path) -> int:
+def _lock_api_hit_counter_file(lock_file: BinaryIO) -> None:
+    if msvcrt is not None:
+        lock_file.seek(0)
+        msvcrt.locking(lock_file.fileno(), msvcrt.LK_NBLCK, 1)
+        return
+    if fcntl is not None:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)  # type: ignore
+        return
+    raise RuntimeError("No supported file locking mechanism is available")
+
+
+def _unlock_api_hit_counter_file(lock_file: BinaryIO) -> None:
+    if msvcrt is not None:
+        lock_file.seek(0)
+        msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+        return
+    if fcntl is not None:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)  # type: ignore
+        return
+
+
+def _acquire_api_hit_counter_lock(lock_path: Path) -> BinaryIO:
     deadline = time.monotonic() + API_HIT_COUNTER_LOCK_TIMEOUT_SECONDS
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_file = lock_path.open("a+b")
+    lock_file.seek(0, os.SEEK_END)
+    if lock_file.tell() == 0:
+        lock_file.write(b"\0")
+        lock_file.flush()
     while True:
         try:
-            return os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_RDWR)
-        except FileExistsError:
+            _lock_api_hit_counter_file(lock_file)
+            return lock_file
+        except BlockingIOError, OSError:
             if time.monotonic() >= deadline:
+                lock_file.close()
                 raise TimeoutError(f"Timed out waiting for API hit counter lock: {lock_path}") from None
             time.sleep(API_HIT_COUNTER_LOCK_POLL_SECONDS)
 
 
-def _release_api_hit_counter_lock(lock_fd: int, lock_path: Path) -> None:
+def _release_api_hit_counter_lock(lock_file: BinaryIO) -> None:
     try:
-        os.close(lock_fd)
+        _unlock_api_hit_counter_file(lock_file)
     finally:
-        with contextlib.suppress(FileNotFoundError):
-            lock_path.unlink()
+        lock_file.close()
 
 
 def _write_api_hit_cache(cache_path: Path, tracker_hits: list[float]) -> None:
@@ -165,14 +204,14 @@ def _reserve_daily_api_hit_sync(base_dir: str, tracker: str, limit: int) -> tupl
     cache_path = _get_api_hit_counter_path(base_dir, tracker)
     cache_path.parent.mkdir(parents=True, exist_ok=True)
     lock_path = _get_api_hit_counter_lock_path(base_dir, tracker)
-    lock_fd = _acquire_api_hit_counter_lock(lock_path)
+    lock_file = _acquire_api_hit_counter_lock(lock_path)
     try:
         tracker_hits: list[Any] = []
         if cache_path.exists():
             try:
                 loaded_cache = json.loads(cache_path.read_text(encoding="utf-8"))
                 if isinstance(loaded_cache, list):
-                    tracker_hits = loaded_cache
+                    tracker_hits = loaded_cache  # type: ignore
             except OSError, json.JSONDecodeError:
                 tracker_hits = []
 
@@ -192,7 +231,7 @@ def _reserve_daily_api_hit_sync(base_dir: str, tracker: str, limit: int) -> tupl
         _write_api_hit_cache(cache_path, recent_hits)
         return True, len(recent_hits)
     finally:
-        _release_api_hit_counter_lock(lock_fd, lock_path)
+        _release_api_hit_counter_lock(lock_file)
 
 
 async def reserve_daily_api_hit(base_dir: str, tracker: str, limit: int) -> tuple[bool, int]:

--- a/src/trackers/USENET/suio.py
+++ b/src/trackers/USENET/suio.py
@@ -109,11 +109,13 @@ class Suio:
         params_list: list[dict[str, str]] = []
         exact_name = await self.get_search_name(meta)
         if exact_name:
-            params_list.append({
-                "t": "search",
-                "q": exact_name,
-                "pw": "0",
-            })
+            params_list.append(
+                {
+                    "t": "search",
+                    "q": exact_name,
+                    "pw": "0",
+                }
+            )
 
         params: dict[str, str] = {
             "cat": get_newznab_search_category_id(meta),
@@ -151,8 +153,7 @@ class Suio:
                     allowed, used_hits = await reserve_daily_api_hit(meta.base_dir, self.tracker, self.daily_api_hit_limit)
                     if not allowed:
                         logger.info(
-                            f"{self.tracker}: [yellow]Duplicate search stopped because the 24-hour API hit limit "
-                            f"({self.daily_api_hit_limit}) has been reached.[/yellow]"
+                            f"{self.tracker}: [yellow]Duplicate search stopped because the 24-hour API hit limit ({self.daily_api_hit_limit}) has been reached.[/yellow]"
                         )
                         break
                     request_params = {
@@ -163,9 +164,7 @@ class Suio:
                         **query_params,
                     }
                     response = await client.get(self.search_url, params=request_params)
-                    logger.debug(
-                        f"{self.tracker}: Duplicate search used API hit {used_hits}/{self.daily_api_hit_limit} in the last 24 hours."
-                    )
+                    logger.debug(f"{self.tracker}: Duplicate search used API hit {used_hits}/{self.daily_api_hit_limit} in the last 24 hours.")
 
                     if response.status_code != 200 or not response.text.strip():
                         logger.info(f"{self.tracker}: [yellow]Duplicate search failed with HTTP {response.status_code}.[/yellow]")

--- a/src/trackers/USENET/suio.py
+++ b/src/trackers/USENET/suio.py
@@ -18,7 +18,13 @@ from cogs.redaction import Redaction
 from src.console import logger
 from src.meta import Meta
 from src.trackers.common import Common
-from src.trackers.USENET.search_helpers import build_newznab_search_query, get_newznab_search_category_id, parse_newznab_dupes
+from src.trackers.USENET.search_helpers import (
+    build_newznab_search_query,
+    get_daily_api_hit_limit,
+    get_newznab_search_category_id,
+    parse_newznab_dupes,
+    reserve_daily_api_hit,
+)
 
 Config = dict[str, Any]
 
@@ -43,6 +49,7 @@ class Suio:
         self.common = Common(config)
         self.tracker_cfg = config.get("TRACKERS", {}).get(self.tracker, {})
         self.api_key = str(self.tracker_cfg.get("api_key", "")).strip()
+        self.daily_api_hit_limit = get_daily_api_hit_limit(self.tracker_cfg)
         base_url = str(self.tracker_cfg.get("base_url", "")).strip().rstrip("/")
         if base_url:
             # Verify the domain matches the expected indexer domain hash to prevent credentials leak
@@ -92,8 +99,11 @@ class Suio:
 
         if not self.search_url:
             return []
-        if not bool(self.tracker_cfg.get("search_api", False)):
-            logger.info(f"{self.tracker}: [yellow]Duplicate search via API is disabled in config.[/yellow]")
+        if not self.api_key:
+            logger.info(f"{self.tracker}: [yellow]Duplicate search skipped due to missing API key.[/yellow]")
+            return []
+        if self.daily_api_hit_limit <= 0:
+            logger.info(f"{self.tracker}: [yellow]Duplicate search via API is disabled because daily_api_hit_limit is 0.[/yellow]")
             return []
 
         params_list: list[dict[str, str]] = []
@@ -138,6 +148,13 @@ class Suio:
             seen_keys: set[str] = set()
             async with httpx.AsyncClient(timeout=10.0) as client:
                 for query_params in params_list:
+                    allowed, used_hits = await reserve_daily_api_hit(meta.base_dir, self.tracker, self.daily_api_hit_limit)
+                    if not allowed:
+                        logger.info(
+                            f"{self.tracker}: [yellow]Duplicate search stopped because the 24-hour API hit limit "
+                            f"({self.daily_api_hit_limit}) has been reached.[/yellow]"
+                        )
+                        break
                     request_params = {
                         "apikey": self.api_key,
                         "limit": "100",
@@ -146,6 +163,9 @@ class Suio:
                         **query_params,
                     }
                     response = await client.get(self.search_url, params=request_params)
+                    logger.debug(
+                        f"{self.tracker}: Duplicate search used API hit {used_hits}/{self.daily_api_hit_limit} in the last 24 hours."
+                    )
 
                     if response.status_code != 200 or not response.text.strip():
                         logger.info(f"{self.tracker}: [yellow]Duplicate search failed with HTTP {response.status_code}.[/yellow]")

--- a/src/trackers/passthepopcorn.py
+++ b/src/trackers/passthepopcorn.py
@@ -618,7 +618,7 @@ class PassThePopcorn:
             if tmdb_type == "movie":
                 try:
                     runtime = (meta.runtime) if meta.runtime is not None else 60
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     runtime = 60
                 ptp_type = "Feature Film" if runtime >= 45 or runtime == 0 else "Short Film"
             if tmdb_type == "miniseries" or "miniseries" in keywords:
@@ -1644,7 +1644,7 @@ class PassThePopcorn:
             torrent_create = f"[{self.tracker}]"
             try:
                 cooldown = int(self.config.get("DEFAULT", {}).get("rehash_cooldown", 0) or 0)
-            except (ValueError, TypeError):
+            except ValueError, TypeError:
                 cooldown = 0
             if cooldown > 0:
                 await asyncio.sleep(cooldown)  # Small cooldown before rehashing

--- a/src/trackersetup.py
+++ b/src/trackersetup.py
@@ -1068,7 +1068,7 @@ class TrackerSetup:
                     logger.info("  [yellow]The trumping torrent for this report seems to be in modq.....[/yellow]")
             try:
                 upload = cli_ui.ask_yes_no("Do you want to proceed with the upload anyway?", default=False)
-            except (EOFError, KeyboardInterrupt):
+            except EOFError, KeyboardInterrupt:
                 logger.info("[yellow]Prompt cancelled; treating as 'no' for safety.[/yellow]")
                 upload = False
 
@@ -1085,7 +1085,7 @@ class TrackerSetup:
             logger.info(f"[yellow]{tracker} requires comparisons to be provided for trump reports.\nAre the comparison images in the description or are you adding links?")
             try:
                 where_compare = cli_ui.ask_string("Enter 'd' if in description, 'L' if you want to paste links, or press Enter to skip trumping:", default="")
-            except (EOFError, KeyboardInterrupt):
+            except EOFError, KeyboardInterrupt:
                 logger.info("[yellow]Prompt cancelled; skipping trump report creation.[/yellow]")
                 return False
 
@@ -1097,7 +1097,7 @@ class TrackerSetup:
                 try:
                     reported_screenshots = cli_ui.ask_string("Paste screenshot links for the reported torrent (comma-separated):", default="")
                     trumping_screenshots = cli_ui.ask_string("Paste screenshot links for the trumping torrent (comma-separated):", default="")
-                except (EOFError, KeyboardInterrupt):
+                except EOFError, KeyboardInterrupt:
                     logger.info("[yellow]Prompt cancelled; skipping trump report creation.[/yellow]")
                     return False
 
@@ -1294,7 +1294,7 @@ class TrackerSetup:
             if not meta.tv_pack:
                 try:
                     user_message = cli_ui.ask_string("Enter a reason for the trump report on LST:")
-                except (EOFError, KeyboardInterrupt):
+                except EOFError, KeyboardInterrupt:
                     logger.info("[yellow]Prompt cancelled; no additional message provided.[/yellow]")
                     user_message = None
                 message = message + ": " + user_message if user_message else message + ": No additional message provided by user"

--- a/src/type_utils.py
+++ b/src/type_utils.py
@@ -24,6 +24,6 @@ def to_int(value: Any, fallback: int = 0) -> int:
     if isinstance(value, str):
         try:
             return int(value)
-        except (ValueError, OverflowError):
+        except ValueError, OverflowError:
             return fallback
     return fallback

--- a/web_ui/server.py
+++ b/web_ui/server.py
@@ -994,7 +994,7 @@ def _verify_remember_token(token: str) -> str | None:
         elif isinstance(expiry_value, str):
             try:
                 expiry = int(expiry_value)
-            except (TypeError, ValueError):
+            except TypeError, ValueError:
                 return None
         else:
             return None
@@ -2456,7 +2456,7 @@ def access_log_entries_api():
         n = int(n)
         if n < 1 or n > 200:
             n = 50
-    except (ValueError, TypeError):
+    except ValueError, TypeError:
         n = 50
 
     try:
@@ -2622,7 +2622,7 @@ def twofa_disable():
 
     try:
         auth_mod.set_twofa_state(None, [])
-    except (OSError, ValueError, TypeError, auth_mod.EncryptionError, json.JSONDecodeError):
+    except OSError, ValueError, TypeError, auth_mod.EncryptionError, json.JSONDecodeError:
         return jsonify({"error": "Failed to disable 2FA", "success": False}), 500
 
     # Update global variable
@@ -2944,7 +2944,15 @@ def api_tokens():
         tokens: list[dict[str, Any]] = []
         for tid, info in store.items():
             info_dict = _as_dict(info) or {}
-            tokens.append({"id": info_dict.get("token_id"), "user": info_dict.get("user"), "label": info_dict.get("label"), "created": info_dict.get("created"), "expiry": info_dict.get("expiry")})
+            tokens.append(
+                {
+                    "id": info_dict.get("token_id"),
+                    "user": info_dict.get("user"),
+                    "label": info_dict.get("label"),
+                    "created": info_dict.get("created"),
+                    "expiry": info_dict.get("expiry"),
+                }
+            )
         read_only = False
         return jsonify({"success": True, "tokens": tokens, "read_only": read_only})
 
@@ -3075,7 +3083,7 @@ def browse_path():
                                 continue
 
                     items.append({"name": item, "path": str(full_path), "type": "folder" if is_dir else "file", "children": [] if is_dir else None})
-                except (PermissionError, OSError):
+                except PermissionError, OSError:
                     continue
 
             console.print(f"Found {len(items)} items in {path}", markup=False)
@@ -3115,7 +3123,7 @@ def browse_search():
         max_results = min(int(request.args.get("max_results", "100")), 500)
         if max_results < 1:
             max_results = 100
-    except (ValueError, TypeError):
+    except ValueError, TypeError:
         max_results = 100
 
     if not query:


### PR DESCRIPTION
## Summary
- replace the boolean duplicate-search toggle with daily_api_hit_limit in the example config
- enforce a rolling 24-hour hit limit for USENET duplicate-search API requests
- share the hit-counter helper between DrunkenSlug and Suio

## Validation
- python -m py_compile data/example_config.py src/trackers/USENET/search_helpers.py src/trackers/USENET/drunkenslug.py src/trackers/USENET/suio.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable daily limits for tracker API requests.
  * API-based duplicate searching now automatically stops when the 24-hour allowance is reached.
  * API usage is monitored during searches to help enforce the daily cap.
* **Configuration**
  * Replaced the previous boolean API duplicate-search toggle with a numeric **daily API hit limit** setting.
  * Setting the limit to `0` disables API-based duplicate searching.
* **Chores / Style**
  * Standardized exception-handling syntax and applied minor formatting-only adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->