### PR TITLE
feat(seedbox): add no-root Linux installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - [Updating](#updating)
 - [CLI Usage](#cli-usage)
 - [Docker Usage](#docker-usage)
+- [Seedbox / Linux Install](docs/seedbox.md)
 - [Attributions](#attributions)
 
 ## Fork Features & Differences from Upstream (Audionut/Upload-Assistant)
@@ -292,6 +293,7 @@ In your terminal, run the command for your operating system and follow the on-sc
 
 **Additional Resources:**
 * Check out our [Wiki Help Page](docs/Home.md).
+* Need a no-root Linux or seedbox setup? See [Seedbox / Linux Install](docs/seedbox.md).
 * Feel free to contact me if you need help, I'm not that hard to find.
 
 

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -4,6 +4,8 @@
 
 [Install tips for Unraid](Install-and-tips-for-Unraid.md)
 
+[Seedbox / Linux Install](seedbox.md)
+
 [Discord Bot](Discord-Bot.md)
 
 [ffmpeg / max worker issues](ffmpeg---max-workers-issues.md)

--- a/docs/seedbox.md
+++ b/docs/seedbox.md
@@ -41,6 +41,7 @@ With optional Discord support:
 --with-discord          Install optional Discord dependencies
 --skip-pyenv-install    Fail instead of installing pyenv automatically
 --force-update          Recreate .venv and reinstall packages
+-h, --help              Show this help
 ```
 
 ## Requirements
@@ -50,7 +51,6 @@ These commands should already exist on the seedbox:
 ```bash
 bash --version
 git --version
-curl --version
 ```
 
 To build Python with `pyenv`, many providers also need common build tooling already installed, such as:

--- a/docs/seedbox.md
+++ b/docs/seedbox.md
@@ -1,0 +1,110 @@
+# Seedbox / Linux Install
+
+This guide covers installing Upload Assistant on a Linux box or seedbox where you do not have root access.
+
+## What this installer does
+
+The bundled installer script:
+
+1. Installs `pyenv` if needed.
+2. Installs Python `3.14.0` by default.
+3. Uses the current checkout if you pass `--ua-dir`, or clones/updates Upload Assistant in `~/tools/ua` by default.
+4. Creates `.venv`.
+5. Installs the base dependencies from `requirements.txt`.
+6. Optionally installs Discord support from `requirements-discord.txt`.
+7. Creates `run-ua.sh` for easier execution.
+
+## Quick start
+
+From a Linux shell:
+
+```bash
+git clone https://github.com/wastaken7/Upload-Assistant.git
+cd Upload-Assistant
+chmod +x scripts/install-seedbox.sh
+./scripts/install-seedbox.sh --ua-dir "$PWD"
+```
+
+If you just want the installer to create or update a separate checkout in `~/tools/ua`, omit `--ua-dir "$PWD"`.
+
+With optional Discord support:
+
+```bash
+./scripts/install-seedbox.sh --with-discord
+```
+
+## Options
+
+```text
+--ua-dir PATH           Installation directory (default: ~/tools/ua)
+--python VERSION        Python version for pyenv (default: 3.14.0)
+--with-discord          Install optional Discord dependencies
+--skip-pyenv-install    Fail instead of installing pyenv automatically
+--force-update          Recreate .venv and reinstall packages
+```
+
+## Requirements
+
+These commands should already exist on the seedbox:
+
+```bash
+bash --version
+git --version
+curl --version
+```
+
+To build Python with `pyenv`, many providers also need common build tooling already installed, such as:
+
+```bash
+gcc --version
+make --version
+```
+
+If your provider compiled the host without the required development libraries, Python modules such as `_sqlite3` may still be unavailable. In that case, the fix is on the provider side, not in Upload Assistant.
+
+## Running Upload Assistant
+
+After installation:
+
+```bash
+cd /path/to/your/ua/checkout
+./run-ua.sh "/path/to/content" --trackers yourtracker
+```
+
+If you prefer the raw environment:
+
+```bash
+cd /path/to/your/ua/checkout
+source .venv/bin/activate
+python upload.py "/path/to/content" --trackers yourtracker
+```
+
+## Updating
+
+Run the installer again:
+
+```bash
+./scripts/install-seedbox.sh
+```
+
+Or update manually:
+
+```bash
+cd /path/to/your/ua/checkout
+git pull --ff-only
+source .venv/bin/activate
+pip install -U pip
+pip install -r requirements.txt
+```
+
+If you use Discord notifications, also run:
+
+```bash
+pip install -r requirements-discord.txt
+```
+
+## Notes about `local_path` / `remote_path`
+
+`local_path` and `remote_path` are only path-mapping settings for torrent client integration.
+
+They do not install UA remotely and they do not move Upload Assistant execution to another machine. If you want the heavy work to run on a remote file-hosting box, run UA on that machine directly or use the Web UI there and control it remotely.

--- a/scripts/install-seedbox.sh
+++ b/scripts/install-seedbox.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PYTHON_VERSION="3.14.0"
+UA_DIR="${HOME}/tools/ua"
+WITH_DISCORD=0
+SKIP_PYENV_INSTALL=0
+FORCE_UPDATE=0
+
+usage() {
+    cat <<'EOF'
+Usage: install-seedbox.sh [options]
+
+Install or update Upload Assistant on a Linux box without requiring root.
+
+Options:
+  --ua-dir PATH           Installation directory (default: ~/tools/ua)
+  --python VERSION        Python version for pyenv (default: 3.14.0)
+  --with-discord          Install optional Discord dependencies
+  --skip-pyenv-install    Fail instead of installing pyenv automatically
+  --force-update          Recreate .venv and reinstall packages
+  -h, --help              Show this help
+EOF
+}
+
+log() {
+    printf '==> %s\n' "$1"
+}
+
+fail() {
+    printf 'Error: %s\n' "$1" >&2
+    exit 1
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || fail "Required command not found: $1"
+}
+
+append_pyenv_init() {
+    local rc_file="$1"
+    if [ ! -f "$rc_file" ]; then
+        touch "$rc_file"
+    fi
+
+    if ! grep -q 'PYENV_ROOT' "$rc_file"; then
+        cat >>"$rc_file" <<'EOF'
+
+export PYENV_ROOT="$HOME/.pyenv"
+export PATH="$PYENV_ROOT/bin:$PATH"
+eval "$(pyenv init -)"
+EOF
+    fi
+}
+
+setup_pyenv_env() {
+    export PYENV_ROOT="${HOME}/.pyenv"
+    export PATH="${PYENV_ROOT}/bin:${PATH}"
+    eval "$(pyenv init -)"
+}
+
+install_pyenv_if_needed() {
+    if command -v pyenv >/dev/null 2>&1; then
+        setup_pyenv_env
+        return
+    fi
+
+    if [ "$SKIP_PYENV_INSTALL" -eq 1 ]; then
+        fail "pyenv is not installed and --skip-pyenv-install was requested"
+    fi
+
+    require_command curl
+    require_command git
+
+    log "Installing pyenv"
+    curl -fsSL https://pyenv.run | bash
+    setup_pyenv_env
+    append_pyenv_init "${HOME}/.bashrc"
+    append_pyenv_init "${HOME}/.profile"
+}
+
+install_python_if_needed() {
+    if ! pyenv versions --bare | grep -qx "$PYTHON_VERSION"; then
+        log "Installing Python ${PYTHON_VERSION} via pyenv"
+        pyenv install "$PYTHON_VERSION"
+    fi
+}
+
+clone_or_update_repo() {
+    mkdir -p "$(dirname "$UA_DIR")"
+
+    if [ ! -d "${UA_DIR}/.git" ]; then
+        log "Cloning Upload Assistant into ${UA_DIR}"
+        git clone https://github.com/wastaken7/Upload-Assistant.git "$UA_DIR"
+        return
+    fi
+
+    log "Updating existing Upload Assistant checkout"
+    git -C "$UA_DIR" pull --ff-only
+}
+
+install_dependencies() {
+    cd "$UA_DIR"
+
+    log "Selecting Python ${PYTHON_VERSION} for this checkout"
+    pyenv local "$PYTHON_VERSION"
+
+    if [ "$FORCE_UPDATE" -eq 1 ] && [ -d ".venv" ]; then
+        log "Removing existing virtual environment"
+        rm -rf "${UA_DIR}/.venv"
+    fi
+
+    if [ ! -d ".venv" ]; then
+        log "Creating virtual environment"
+        python -m venv .venv
+    fi
+
+    # shellcheck disable=SC1091
+    source .venv/bin/activate
+
+    log "Upgrading pip"
+    python -m pip install -U pip
+
+    log "Installing Upload Assistant dependencies"
+    pip install -r requirements.txt
+
+    if [ "$WITH_DISCORD" -eq 1 ]; then
+        log "Installing optional Discord dependencies"
+        pip install -r requirements-discord.txt
+    fi
+}
+
+write_runner() {
+    cat >"${UA_DIR}/run-ua.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# shellcheck disable=SC1091
+source .venv/bin/activate
+exec python upload.py "$@"
+EOF
+    chmod +x "${UA_DIR}/run-ua.sh"
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --ua-dir)
+            [ "$#" -ge 2 ] || fail "--ua-dir requires a path"
+            UA_DIR="$2"
+            shift 2
+            ;;
+        --python)
+            [ "$#" -ge 2 ] || fail "--python requires a version"
+            PYTHON_VERSION="$2"
+            shift 2
+            ;;
+        --with-discord)
+            WITH_DISCORD=1
+            shift
+            ;;
+        --skip-pyenv-install)
+            SKIP_PYENV_INSTALL=1
+            shift
+            ;;
+        --force-update)
+            FORCE_UPDATE=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            fail "Unknown option: $1"
+            ;;
+    esac
+done
+
+require_command git
+require_command bash
+
+install_pyenv_if_needed
+require_command pyenv
+
+install_python_if_needed
+clone_or_update_repo
+install_dependencies
+write_runner
+
+cat <<EOF
+
+Installation complete.
+
+Location:
+  ${UA_DIR}
+
+Run:
+  cd ${UA_DIR}
+  ./run-ua.sh "/path/to/content" --trackers yourtracker
+
+Optional next steps:
+  - Configure UA with: python config-generator.py
+  - Enable Discord later with:
+      source .venv/bin/activate
+      pip install -r requirements-discord.txt
+EOF

--- a/scripts/install-seedbox.sh
+++ b/scripts/install-seedbox.sh
@@ -6,6 +6,9 @@ UA_DIR="${HOME}/tools/ua"
 WITH_DISCORD=0
 SKIP_PYENV_INSTALL=0
 FORCE_UPDATE=0
+PYENV_ROOT_DEFAULT="${HOME}/.pyenv"
+PYENV_GIT_REF="v2.6.7"
+PYENV_REPO_URL="https://github.com/pyenv/pyenv.git"
 
 usage() {
     cat <<'EOF'
@@ -53,7 +56,7 @@ EOF
 }
 
 setup_pyenv_env() {
-    export PYENV_ROOT="${HOME}/.pyenv"
+    export PYENV_ROOT="${PYENV_ROOT_DEFAULT}"
     export PATH="${PYENV_ROOT}/bin:${PATH}"
     eval "$(pyenv init -)"
 }
@@ -68,11 +71,14 @@ install_pyenv_if_needed() {
         fail "pyenv is not installed and --skip-pyenv-install was requested"
     fi
 
-    require_command curl
     require_command git
 
     log "Installing pyenv"
-    curl -fsSL https://pyenv.run | bash
+    if [ -e "${PYENV_ROOT_DEFAULT}" ] && [ ! -d "${PYENV_ROOT_DEFAULT}/.git" ]; then
+        fail "Refusing to install pyenv because ${PYENV_ROOT_DEFAULT} exists and is not a git checkout"
+    fi
+
+    git clone --branch "$PYENV_GIT_REF" --depth 1 "$PYENV_REPO_URL" "${PYENV_ROOT_DEFAULT}"
     setup_pyenv_env
     append_pyenv_init "${HOME}/.bashrc"
     append_pyenv_init "${HOME}/.profile"
@@ -99,7 +105,8 @@ clone_or_update_repo() {
 }
 
 install_dependencies() {
-    cd "$UA_DIR"
+    cd -- "$UA_DIR"
+    UA_DIR="$PWD"
 
     log "Selecting Python ${PYTHON_VERSION} for this checkout"
     pyenv local "$PYTHON_VERSION"
@@ -112,6 +119,18 @@ install_dependencies() {
     if [ ! -d ".venv" ]; then
         log "Creating virtual environment"
         python -m venv .venv
+    elif [ -x ".venv/bin/python" ]; then
+        local venv_python_version
+        venv_python_version="$("./.venv/bin/python" -c 'import sys; print(".".join(map(str, sys.version_info[:3])))')"
+        if [ "$venv_python_version" != "$PYTHON_VERSION" ]; then
+            if [ "$FORCE_UPDATE" -eq 1 ]; then
+                log "Recreating virtual environment for Python ${PYTHON_VERSION}"
+                rm -rf "${UA_DIR}/.venv"
+                python -m venv .venv
+            else
+                fail "Existing .venv uses Python ${venv_python_version}; rerun with --force-update to recreate it for ${PYTHON_VERSION}"
+            fi
+        fi
     fi
 
     # shellcheck disable=SC1091
@@ -197,12 +216,11 @@ Location:
   ${UA_DIR}
 
 Run:
-  cd ${UA_DIR}
+  cd -- "${UA_DIR}"
   ./run-ua.sh "/path/to/content" --trackers yourtracker
 
 Optional next steps:
-  - Configure UA with: python config-generator.py
+  - Configure UA with: ${UA_DIR}/.venv/bin/python ${UA_DIR}/config-generator.py
   - Enable Discord later with:
-      source .venv/bin/activate
-      pip install -r requirements-discord.txt
+      ${UA_DIR}/.venv/bin/python -m pip install -r ${UA_DIR}/requirements-discord.txt
 EOF


### PR DESCRIPTION
Add a seedbox setup flow with pyenv-based Python provisioning, virtualenv bootstrap, and an optional Discord dependency install.

Document the Linux install path in the README and wiki so remote users can get UA running without root access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a rootless “Seedbox / Linux Install” option for installing and running Upload Assistant on Linux/seedboxes.
  * Added an installer/updater that sets up Python (via pyenv when needed), creates a virtual environment, installs required packages, and generates a one-command launch script.
  * Added configurable options for install directory, Python version, enabling Discord support, and update/rebuild behavior.

* **Documentation**
  * Added a new Seedbox / Linux Install documentation page with quick-start commands and usage/update guidance.
  * Updated existing navigation and setup/resources links to point to the new guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->