### PR TITLE
fix(webui): hide trackers while running

### DIFF
--- a/web_ui/static/js/app.js
+++ b/web_ui/static/js/app.js
@@ -3856,7 +3856,7 @@ function AudionutsUAGUI() {
                   <TrashIcon />
                 </button>
               </div>
-              {renderTrackerSelector()}
+              {!isExecuting && renderTrackerSelector()}
             </div>
 
             {/* Terminal output */}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The tracker selector is now hidden on the mobile main panel while an execution is in progress, reducing distractions and preventing unintended changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->