### PR TITLE
fix(samaritano): map TV category to ANIME if meta.anime is True

### DIFF
--- a/src/trackers/UNIT3D/samaritano.py
+++ b/src/trackers/UNIT3D/samaritano.py
@@ -77,6 +77,9 @@ class Samaritano(UNIT3D):
             return {v: k for k, v in cat_map.items()}
 
         resolved_category = category if category is not None and category != "" else meta.category
+        if meta.anime is True and resolved_category == "TV":
+            resolved_category = "ANIME"
+
         if resolved_category == "BOOK":
             if meta.audiobook:
                 resolved_category = "AUDIOBOOK"


### PR DESCRIPTION
Fixes #89. Maps TV anime uploads to the ANIME category on Samaritano tracker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Anime-tagged items previously categorized as TV are now correctly assigned to the ANIME category.
  * Category identifiers now reflect the appropriate anime classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->