### PR TITLE
ci: add manual release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -28,7 +28,13 @@ jobs:
       - name: Validate version
         env:
           NEW_VERSION: ${{ inputs.version }}
+          REF_TYPE: ${{ github.ref_type }}
         run: |
+          if [[ "$REF_TYPE" != "branch" ]]; then
+            echo "Create release must be run from a branch, not a tag." >&2
+            exit 1
+          fi
+
           if [[ ! "$NEW_VERSION" =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
             echo "Version must match vMAJOR.MINOR or vMAJOR.MINOR.PATCH (for example: v2.8)." >&2
             exit 1

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,113 @@
+name: Create release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "New version (for example: v2.8 or v2.8.1)"
+        required: true
+        type: string
+
+permissions:
+  actions: write
+  contents: write
+
+concurrency:
+  group: create-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out the selected branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate version
+        env:
+          NEW_VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$NEW_VERSION" =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+            echo "Version must match vMAJOR.MINOR or vMAJOR.MINOR.PATCH (for example: v2.8)." >&2
+            exit 1
+          fi
+
+          if git rev-parse --verify --quiet "refs/tags/$NEW_VERSION"; then
+            echo "Tag $NEW_VERSION already exists." >&2
+            exit 1
+          fi
+
+      - name: Generate release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW_VERSION: ${{ inputs.version }}
+        run: |
+          gh api --method POST "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+            -f tag_name="$NEW_VERSION" \
+            -f target_commitish="$GITHUB_SHA" \
+            --jq .body > "$RUNNER_TEMP/release-notes.md"
+
+      - name: Update data/version.py
+        env:
+          NEW_VERSION: ${{ inputs.version }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          path = Path("data/version.py")
+          content = path.read_text(encoding="utf-8")
+          notes = Path(os.environ["RUNNER_TEMP"], "release-notes.md").read_text(encoding="utf-8").strip()
+          serialized_notes = json.dumps(notes, ensure_ascii=False)
+          replacement = f'__version__ = "{os.environ["NEW_VERSION"]}"\n\n{serialized_notes}'
+          updated, count = re.subn(
+              r'__version__\s*=\s*"[^"]+"\s*\n\s*(?:""".*?"""|"(?:\\.|[^"\\])*")',
+              lambda _match: replacement,
+              content,
+              count=1,
+              flags=re.DOTALL,
+          )
+          if count != 1:
+              raise SystemExit("Could not find the version and release-notes block in data/version.py")
+          path.write_text(updated, encoding="utf-8")
+          PY
+
+      - name: Commit the version bump
+        env:
+          NEW_VERSION: ${{ inputs.version }}
+          TARGET_BRANCH: ${{ github.ref_name }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/version.py
+          git diff --cached --check
+          git commit -m "bump: version to ${NEW_VERSION#v}"
+          git push origin "HEAD:$TARGET_BRANCH"
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW_VERSION: ${{ inputs.version }}
+        run: |
+          gh release create "$NEW_VERSION" \
+            --target "$(git rev-parse HEAD)" \
+            --title "$NEW_VERSION" \
+            --notes-file "$RUNNER_TEMP/release-notes.md" \
+            --verify-tag=false
+
+      # Releases created by GITHUB_TOKEN do not emit new workflow runs, so
+      # dispatch the existing packaging workflows explicitly.
+      - name: Start release builds
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW_VERSION: ${{ inputs.version }}
+        run: |
+          gh workflow run docker-image.yml --ref "$NEW_VERSION" -f use_latest_tag=true
+          gh workflow run windows-installer.yml --ref "$NEW_VERSION" \
+            -f ref="$NEW_VERSION" \
+            -f version="$NEW_VERSION" \
+            -f release_tag="$NEW_VERSION"

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -15,6 +15,10 @@ on:
         required: true
         default: "development"
         type: string
+      release_tag:
+        description: "Existing release tag to receive the installer (optional)"
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -90,7 +94,8 @@ jobs:
           if-no-files-found: error
 
       - name: Attach installer to release
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || inputs.release_tag != ''
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.release_tag }}
           files: build/output/*.exe

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -30,6 +30,18 @@ jobs:
       PYTHON_MINOR: "3.14"
       FFMPEG_URL: "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip"
     steps:
+      - name: Validate manual release attachment
+        if: github.event_name == 'workflow_dispatch' && inputs.release_tag != ''
+        shell: pwsh
+        env:
+          SOURCE_REF: ${{ inputs.ref }}
+          INSTALLER_VERSION: ${{ inputs.version }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          if ($env:SOURCE_REF -ne $env:RELEASE_TAG -or $env:INSTALLER_VERSION -ne $env:RELEASE_TAG) {
+            throw 'ref, version, and release_tag must match when attaching an installer to a release.'
+          }
+
       - name: Checkout release source
         uses: actions/checkout@v4
         with:

--- a/upload.py
+++ b/upload.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # Upload Assistant © 2025 Audionut & wastaken7 — Licensed under UAPL v1.0
+import ast
 import asyncio
 import contextlib
 import filecmp
@@ -1669,6 +1670,24 @@ def get_remote_version(url: str) -> tuple[str | None, str | None]:
 
 def extract_changelog(content: str, to_version: str) -> str | None:
     """Extracts the changelog entries between the specified versions."""
+    try:
+        module = ast.parse(content)
+        for index, node in enumerate(module.body[:-1]):
+            if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+                continue
+            target = node.targets[0]
+            if not isinstance(target, ast.Name) or target.id != "__version__":
+                continue
+            if not isinstance(node.value, ast.Constant) or node.value.value not in (to_version, to_version.lstrip("v")):
+                continue
+            notes_node = module.body[index + 1]
+            if isinstance(notes_node, ast.Expr) and isinstance(notes_node.value, ast.Constant) and isinstance(notes_node.value.value, str):
+                changelog = notes_node.value.value.strip()
+                return re.sub(r"^# ", "", changelog, flags=re.MULTILINE)
+    except SyntaxError:
+        # Keep compatibility with malformed legacy version files handled below.
+        pass
+
     # Try to find the to_version with 'v' prefix first (current format)
     patterns_to_try = [
         rf'__version__\s*=\s*"{re.escape(to_version)}"\s*\n\s*"""\s*(.*?)\s*"""',  # Try with 'v' prefix


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manual “Create release” workflow with version validation, automated release-note generation, version updates, and GitHub release creation.
  * Added an optional manual dispatch input to the Windows installer workflow to attach the installer to a specified existing release tag.
* **Bug Fixes**
  * Improved changelog extraction by parsing version files more reliably, with a safe fallback when the file can’t be parsed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->