### PR TITLE
feat: use go-bdinfo with scan progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Web UI docs: [docs/web-ui.md](docs/web-ui.md)
 
 ## **Attributions:**
 
-Built with updated BDInfoCLI from <https://github.com/rokibhasansagar/BDInfoCLI-ng>
+Built with [autobrr/go-bdinfo](https://github.com/autobrr/go-bdinfo)
 
 Features automated binary managers for:
 

--- a/bin/get_bdinfo.py
+++ b/bin/get_bdinfo.py
@@ -54,7 +54,7 @@ class BDInfoBinaryManager:
                 "arm64": {"asset": "linux_arm64.tar.gz", "folder": "linux/arm64"},
                 "aarch64": {"asset": "linux_arm64.tar.gz", "folder": "linux/arm64"},
                 "armv7l": {"asset": "linux_arm.tar.gz", "folder": "linux/arm"},
-                "armv6l": {"asset": "linux_arm.tar.gz", "folder": "linux/armv6"},
+                "armv6l": {"asset": "linux_arm.tar.gz", "folder": "linux/arm"},
                 "arm": {"asset": "linux_arm.tar.gz", "folder": "linux/arm"},
             },
         }

--- a/bin/get_bdinfo.py
+++ b/bin/get_bdinfo.py
@@ -27,35 +27,35 @@ except ImportError:
 
 
 class BDInfoBinaryManager:
-    """Download BDInfoCLI-ng binaries for the host architecture.
+    """Download autobrr/go-bdinfo binaries for the host architecture.
 
-    Default version pinned (see https://github.com/Audionut/BDInfoCLI-ng/releases)
+    Default version pinned (see https://github.com/autobrr/go-bdinfo/releases).
     """
 
     @staticmethod
-    async def ensure_bdinfo_binary(base_dir: str | Path, version: str = "v1.0.8") -> str:
+    async def ensure_bdinfo_binary(base_dir: str | Path, version: str = "v0.3.1") -> str:
         system = platform.system().lower()
         machine = platform.machine().lower()
         logger.debug(f"[blue]Detected system: {system}, architecture: {machine}[/blue]")
 
         platform_map: dict[str, dict[str, dict[str, str]]] = {
             "windows": {
-                "x86_64": {"file": "bdinfo-win-x64.zip", "folder": "windows/x86_64"},
-                "amd64": {"file": "bdinfo-win-x64.zip", "folder": "windows/x86_64"},
+                "x86_64": {"asset": "windows_amd64.zip", "folder": "windows/x86_64"},
+                "amd64": {"asset": "windows_amd64.zip", "folder": "windows/x86_64"},
             },
             "darwin": {
-                "arm64": {"file": "bdinfo-osx-arm64.tar.gz", "folder": "macos/arm64"},
-                "x86_64": {"file": "bdinfo-osx-x64.tar.gz", "folder": "macos/x86_64"},
-                "amd64": {"file": "bdinfo-osx-x64.tar.gz", "folder": "macos/x86_64"},
+                "arm64": {"asset": "darwin_arm64.tar.gz", "folder": "macos/arm64"},
+                "x86_64": {"asset": "darwin_amd64.tar.gz", "folder": "macos/x86_64"},
+                "amd64": {"asset": "darwin_amd64.tar.gz", "folder": "macos/x86_64"},
             },
             "linux": {
-                "x86_64": {"file": "bdinfo-linux-x64.tar.gz", "folder": "linux/amd64"},
-                "amd64": {"file": "bdinfo-linux-x64.tar.gz", "folder": "linux/amd64"},
-                "arm64": {"file": "bdinfo-linux-arm64.tar.gz", "folder": "linux/arm64"},
-                "aarch64": {"file": "bdinfo-linux-arm64.tar.gz", "folder": "linux/arm64"},
-                "armv7l": {"file": "bdinfo-linux-arm.tar.gz", "folder": "linux/arm"},
-                "armv6l": {"file": "bdinfo-linux-arm.tar.gz", "folder": "linux/armv6"},
-                "arm": {"file": "bdinfo-linux-arm.tar.gz", "folder": "linux/arm"},
+                "x86_64": {"asset": "linux_amd64.tar.gz", "folder": "linux/amd64"},
+                "amd64": {"asset": "linux_amd64.tar.gz", "folder": "linux/amd64"},
+                "arm64": {"asset": "linux_arm64.tar.gz", "folder": "linux/arm64"},
+                "aarch64": {"asset": "linux_arm64.tar.gz", "folder": "linux/arm64"},
+                "armv7l": {"asset": "linux_arm.tar.gz", "folder": "linux/arm"},
+                "armv6l": {"asset": "linux_arm.tar.gz", "folder": "linux/armv6"},
+                "arm": {"asset": "linux_arm.tar.gz", "folder": "linux/arm"},
             },
         }
 
@@ -63,7 +63,8 @@ class BDInfoBinaryManager:
             raise Exception(f"Unsupported platform: {system} {machine}")
 
         platform_info = platform_map[system][machine]
-        file_pattern = platform_info["file"]
+        release_version = version.removeprefix("v")
+        file_pattern = f"bdinfo_{release_version}_{platform_info['asset']}"
         folder_path = platform_info["folder"]
         logger.debug(f"[blue]Using file pattern: {file_pattern}[/blue]")
         logger.debug(f"[blue]Target folder: {folder_path}[/blue]")
@@ -113,8 +114,8 @@ class BDInfoBinaryManager:
 
         cleanup_old_version_files()
 
-        # Construct download URL using release asset filename
-        download_url = f"https://github.com/Audionut/BDInfoCLI-ng/releases/download/{version}/{file_pattern}"
+        # Construct download URL using autobrr/go-bdinfo release asset filename.
+        download_url = f"https://github.com/autobrr/go-bdinfo/releases/download/{version}/{file_pattern}"
         logger.debug(f"[blue]Download URL: {download_url}[/blue]")
 
         try:
@@ -212,7 +213,7 @@ class BDInfoBinaryManager:
                     binary_path.chmod(binary_path.stat().st_mode | stat.S_IEXEC)
 
                 async with aiofiles.open(version_path, "w", encoding="utf-8") as version_file:
-                    await version_file.write(f"BDInfoCLI-ng version {version} installed successfully.")
+                    await version_file.write(f"autobrr/go-bdinfo version {version} installed successfully.")
                 return str(binary_path)
             finally:
                 try:

--- a/bin/get_bdinfo_docker.py
+++ b/bin/get_bdinfo_docker.py
@@ -27,8 +27,8 @@ except ImportError:
     logger = logging.getLogger(__name__)
 
 
-BDINFO_VERSION = "v1.0.8"
-BASE_RELEASE_URL = "https://github.com/Audionut/BDInfoCLI-ng/releases/download"
+BDINFO_VERSION = "v0.3.1"
+BASE_RELEASE_URL = "https://github.com/autobrr/go-bdinfo/releases/download"
 
 
 def download_file(url: str, output_path: Path) -> None:
@@ -96,17 +96,18 @@ def download_bdinfo_for_docker(base_dir: Path = Path("/Upload-Assistant"), versi
         raise Exception(f"This script is only for Linux containers, got: {system}")
 
     if machine in ("amd64", "x86_64"):
-        file_pattern = "bdinfo-linux-x64.tar.gz"
+        asset = "linux_amd64.tar.gz"
         folder = "linux/amd64"
     elif machine in ("arm64", "aarch64"):
-        file_pattern = "bdinfo-linux-arm64.tar.gz"
+        asset = "linux_arm64.tar.gz"
         folder = "linux/arm64"
     elif machine.startswith("arm"):
-        file_pattern = "bdinfo-linux-arm.tar.gz"
+        asset = "linux_arm.tar.gz"
         folder = "linux/arm"
     else:
         raise Exception(f"Unsupported architecture: {machine}")
 
+    file_pattern = f"bdinfo_{version.removeprefix('v')}_{asset}"
     bin_dir = base_dir / "bin" / "bdinfo" / folder
     bin_dir.mkdir(parents=True, exist_ok=True)
     binary_path = bin_dir / "bdinfo"
@@ -142,7 +143,7 @@ def download_bdinfo_for_docker(base_dir: Path = Path("/Upload-Assistant"), versi
     Path(binary_path).chmod(0o700)
 
     with Path(version_path).open("w", encoding="utf-8") as vf:
-        vf.write(f"BDInfoCLI-ng version {version} installed successfully.")
+        vf.write(f"autobrr/go-bdinfo version {version} installed successfully.")
 
     logger.info(f"Installed bdinfo: {binary_path}", extra={"markup": False})
     return str(binary_path)

--- a/docs/example-config.md
+++ b/docs/example-config.md
@@ -321,6 +321,7 @@ If the tracker configuration in `example_config.py` mentions cookies, they must 
    - By default, name the file after the tracker (e.g., `MAKINGOFF.txt` or `AVISTAZ.txt`).
 
 > [!NOTE]
+>
 > - **BJ-Share:** Two-factor authentication (2FA) must be enabled in your profile settings; otherwise, your session cookies will expire fairly quickly.
 > - **HDTorrents:** Keep in mind that changing the site domain requires exporting the cookies again from the new domain.
 

--- a/src/discparse.py
+++ b/src/discparse.py
@@ -14,11 +14,13 @@ import cli_ui
 import defusedxml.ElementTree as ElementTree
 from langcodes import Language
 from pymediainfo import MediaInfo
+from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn
 
 from bin.get_playlist import MplsParser
-from src.console import logger
+from src.console import console, logger
 from src.exportmi import setup_mediainfo_library
 from src.meta import Meta
+from src.webui_progress import complete_progress, publish_progress
 
 PlaylistItem = dict[str, Any]
 PlaylistInfo = dict[str, Any]
@@ -85,6 +87,58 @@ class DiscParse:
         if self.mediainfo_config and self.mediainfo_config["cli"]:
             return self.mediainfo_config["cli"]
         return None
+
+    async def _run_bdinfo_with_progress(self, command: list[str], progress_id: str) -> int:
+        """Run go-bdinfo and forward its stream-scan progress to CLI and Web UI."""
+        progress_pattern = re.compile(
+            r"Stream scan:\s+(?P<percent>\d+(?:\.\d+)?)%\s+\((?P<done>[^,]+)\s*/\s*(?P<total>[^,]+),\s*files\s*"
+            r"(?P<files_done>\d+)/(?P<files_total>\d+),\s*read\s*(?P<speed>[^,]+),\s*ETA\s*(?P<eta>[^)]+)\)"
+        )
+        command = [*command, "--progress"]
+        process = await asyncio.create_subprocess_exec(*command, stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.PIPE)
+        if process.stderr is None:
+            raise RuntimeError("Unable to read go-bdinfo progress output")
+
+        current = 0.0
+        buffer = ""
+        publish_progress(progress_id, "Scanning Blu-ray", current=0, total=100, detail="Starting go-bdinfo scan")
+        with Progress(
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            TaskProgressColumn(),
+            console=console,
+            transient=False,
+        ) as progress:
+            task = progress.add_task("Scanning Blu-ray...", total=100)
+            while chunk := await process.stderr.read(1024):
+                buffer += chunk.decode("utf-8", errors="replace")
+                updates = re.split(r"[\r\n]+", buffer)
+                buffer = updates.pop()
+                for update in updates:
+                    match = progress_pattern.search(update)
+                    if not match:
+                        continue
+                    current = float(match["percent"])
+                    detail = f"{match['done'].strip()} / {match['total'].strip()} | {match['speed'].strip()} | ETA {match['eta'].strip()}"
+                    progress.update(task, completed=current, description=f"Scanning Blu-ray... {detail}")
+                    publish_progress(progress_id, "Scanning Blu-ray", current=current, total=100, detail=detail)
+
+            if buffer:
+                match = progress_pattern.search(buffer)
+                if match:
+                    current = float(match["percent"])
+                    detail = f"{match['done'].strip()} / {match['total'].strip()} | {match['speed'].strip()} | ETA {match['eta'].strip()}"
+                    progress.update(task, completed=current, description=f"Scanning Blu-ray... {detail}")
+                    publish_progress(progress_id, "Scanning Blu-ray", current=current, total=100, detail=detail)
+
+            returncode = await process.wait()
+            if returncode == 0:
+                progress.update(task, completed=100, description="Scanning Blu-ray complete")
+                complete_progress(progress_id, "Scanning Blu-ray", current=100, total=100)
+            else:
+                publish_progress(progress_id, "Scanning Blu-ray", current=current, total=100, detail=f"go-bdinfo exited with status {returncode}", status="failed")
+
+        return returncode
 
     """
     Get and parse bdinfo
@@ -274,45 +328,38 @@ class DiscParse:
                                     folder = "linux/arm"
                                 bdinfo_path = f"{base_dir}/bin/bdinfo/{folder}/bdinfo"
                                 if Path(bdinfo_path).exists():
-                                    bdinfo_executable = [bdinfo_path, path, "-m", playlist["file"], save_dir]
+                                    bdinfo_executable = [bdinfo_path, path, "--playlist", playlist["file"], "--reportfilename", str(playlist_report_path)]
                             elif system == "darwin":
                                 folder = "macos/arm64" if machine in ("arm64",) else "macos/x86_64"
                                 bdinfo_path = f"{base_dir}/bin/bdinfo/{folder}/bdinfo"
                                 if Path(bdinfo_path).exists():
-                                    bdinfo_executable = [bdinfo_path, path, "-m", playlist["file"], save_dir]
+                                    bdinfo_executable = [bdinfo_path, path, "--playlist", playlist["file"], "--reportfilename", str(playlist_report_path)]
                             elif system == "windows":
                                 # Windows builds are provided as x64
                                 bdinfo_path = f"{base_dir}/bin/bdinfo/windows/x86_64/bdinfo.exe"
                                 if Path(bdinfo_path).exists():
-                                    bdinfo_executable = [bdinfo_path, "-m", playlist["file"], path, save_dir]
+                                    bdinfo_executable = [bdinfo_path, path, "--playlist", playlist["file"], "--reportfilename", str(playlist_report_path)]
 
                             # Fallback to system-installed commands if bundled binary not present
                             if bdinfo_executable is None:
                                 if shutil.which("bdinfo"):
-                                    bdinfo_executable = ["bdinfo", path, "-m", playlist["file"], save_dir]
-                                elif shutil.which("BDInfo"):
-                                    bdinfo_executable = ["BDInfo", path, "-m", playlist["file"], save_dir]
+                                    bdinfo_executable = ["bdinfo", path, "--playlist", playlist["file"], "--reportfilename", str(playlist_report_path)]
                                 else:
-                                    logger.info(
-                                        f"[bold red]BDInfo not found. Please download bdinfo and place it under {base_dir}/bin/bdinfo/ or install a system bdinfo/BDInfo binary[/bold red]"
-                                    )
+                                    logger.info(f"[bold red]go-bdinfo not found. Place it under {base_dir}/bin/bdinfo/ or install a system bdinfo binary[/bold red]")
                                     continue
 
                             if bdinfo_executable:
-                                proc = await asyncio.create_subprocess_exec(*bdinfo_executable)
-                                await proc.wait()
+                                returncode = await self._run_bdinfo_with_progress(bdinfo_executable, f"bdinfo-scan-{folder_id}")
 
-                                if proc.returncode != 0:
-                                    logger.info(f"[bold red]BDInfo failed with return code {proc.returncode}[/bold red]")
+                                if returncode != 0:
+                                    logger.info(f"[bold red]BDInfo failed with return code {returncode}[/bold red]")
                                     continue
 
-                                # Rename the output to playlist_report_path
-                                for file in (p.name for p in Path(save_dir).iterdir()):
-                                    if file.startswith("BDINFO") and file.endswith(".txt"):
-                                        bdinfo_text = Path(save_dir) / file
-                                        shutil.move(bdinfo_text, playlist_report_path)
-                                        bdinfo_text = playlist_report_path  # Update bdinfo_text to the renamed file
-                                        break
+                                if playlist_report_path.is_file():
+                                    bdinfo_text = playlist_report_path
+                                else:
+                                    logger.info(f"[bold red]go-bdinfo did not create report {playlist_report_path}[/bold red]")
+                                    continue
                         except Exception as e:
                             logger.info(f"[bold red]Error scanning playlist {playlist['file']}: {e}")
                             continue

--- a/src/get_disc.py
+++ b/src/get_disc.py
@@ -45,7 +45,7 @@ class DiscInfoManager:
                 raise RuntimeError("BDMV disc checking is not supported in site_check mode.")
             # Ensure bdinfo binary is present for BDMV processing
             try:
-                await BDInfoBinaryManager.ensure_bdinfo_binary(meta.base_dir, "v1.0.8")
+                await BDInfoBinaryManager.ensure_bdinfo_binary(meta.base_dir, "v0.3.1")
             except Exception as e:
                 logger.error(f"[red]Failed to ensure bdinfo binary: {e}[/red]", extra={"markup": False})
                 raise


### PR DESCRIPTION
## Summary
- replace BDInfoCLI-ng downloads with autobrr/go-bdinfo v0.3.1
- adapt playlist report generation to go-bdinfo arguments
- surface Blu-ray scan progress in the CLI and Web UI

## Validation
- Python compilation passed
- Ruff check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live Blu-ray scan progress updates in both the command-line interface and Web UI.
  * Improved playlist report generation during disc scans.

* **Bug Fixes**
  * Updated bundled Blu-ray analysis tools and downloads to use the current go-bdinfo releases across supported platforms.
  * Corrected formatting in the example configuration documentation.

* **Documentation**
  * Updated project attribution to reflect go-bdinfo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->