### PR TITLE
fix(usenet): pass tmdb/imdb/tvdb/mal ids to pesto and nyuu, bump pinned pesto to pesto-v0.3.62

### DIFF
--- a/bin/get_pesto.py
+++ b/bin/get_pesto.py
@@ -27,7 +27,7 @@ class PestoBinaryManager:
     """Download Pesto binaries for the host architecture."""
 
     @staticmethod
-    async def ensure_pesto_binary(base_dir: str | Path, version: str = "v0.3.61") -> str:
+    async def ensure_pesto_binary(base_dir: str | Path, version: str = "pesto-v0.3.62") -> str:
         system = platform.system().lower()
         machine = platform.machine().lower()
         logger.debug(f"[blue]Pesto: Detected system: {system}, architecture: {machine}[/blue]")

--- a/src/usenetcreate.py
+++ b/src/usenetcreate.py
@@ -1120,6 +1120,23 @@ async def prepare_and_upload_usenet(meta: Meta, config: dict[str, Any]) -> str |
         if archive_password and not skip_archive:
             cmd_pesto.extend(["--nzb-password", archive_password])
 
+        # External IDs (pesto >=0.3.62): written as structured <meta type=
+        # "tmdbid"/"imdbid"/"tvdbid"/"malid"> tags in the NZB itself, so any
+        # downstream tool reading the NZB directly (not just Curupira's own
+        # upload API, which UA already calls separately with this same
+        # metadata) sees them too — e.g. a re-index, or an automated import
+        # elsewhere. tmdb_type mirrors curupira.py's own mapping
+        # (meta.category.lower() gated to "movie"/"tv").
+        tmdb_type = meta.category.lower()
+        if meta.tmdb_id and str(meta.tmdb_id).isdigit() and int(meta.tmdb_id) > 0 and tmdb_type in ("movie", "tv"):
+            cmd_pesto.extend(["--tmdb", f"{tmdb_type}/{meta.tmdb_id}"])
+        if meta.imdb_tt:
+            cmd_pesto.extend(["--imdb-id", meta.imdb_tt])
+        if meta.tvdb_id and str(meta.tvdb_id).isdigit() and int(meta.tvdb_id) > 0:
+            cmd_pesto.extend(["--tvdb-id", str(meta.tvdb_id)])
+        if meta.mal_id and str(meta.mal_id).isdigit() and int(meta.mal_id) > 0:
+            cmd_pesto.extend(["--mal-id", str(meta.mal_id)])
+
         # --check: a streaming STAT check that runs concurrently with the
         # upload, confirming each article shortly after it posts. Missing
         # articles are reposted and reverified automatically, internally to
@@ -1229,6 +1246,23 @@ async def prepare_and_upload_usenet(meta: Meta, config: dict[str, Any]) -> str |
             check_retries = usenet_cfg.get("nyuu_check_retries")
             if check_retries is not None and str(check_retries).strip() != "":
                 cmd_nyuu.extend(["--check-tries", str(check_retries)])
+
+        # External IDs: nyuu's -M/--meta is a free-form key/value map (no
+        # fixed tag whitelist, unlike --nzb-title/-tag/-category/-password),
+        # written straight through as <meta type="{key}">{value}</meta> —
+        # same tags pesto writes for --tmdb/--imdb-id/--tvdb-id/--mal-id, so
+        # both uploaders produce an equivalent NZB. Same source/format as the
+        # pesto branch above (tmdb_type via meta.category.lower(), meta.imdb_tt
+        # already zero-padded "tt...").
+        tmdb_type = meta.category.lower()
+        if meta.tmdb_id and str(meta.tmdb_id).isdigit() and int(meta.tmdb_id) > 0 and tmdb_type in ("movie", "tv"):
+            cmd_nyuu.extend(["-M", f"tmdbid: {tmdb_type}/{meta.tmdb_id}"])
+        if meta.imdb_tt:
+            cmd_nyuu.extend(["-M", f"imdbid: {meta.imdb_tt}"])
+        if meta.tvdb_id and str(meta.tvdb_id).isdigit() and int(meta.tvdb_id) > 0:
+            cmd_nyuu.extend(["-M", f"tvdbid: {meta.tvdb_id}"])
+        if meta.mal_id and str(meta.mal_id).isdigit() and int(meta.mal_id) > 0:
+            cmd_nyuu.extend(["-M", f"malid: {meta.mal_id}"])
 
         cmd_nyuu.extend(all_upload_files)
 


### PR DESCRIPTION
## Summary
- `pesto` v0.3.62 added `--tmdb`/`--imdb-id`/`--tvdb-id`/`--mal-id`, writing them as structured `<meta type="tmdbid"/"imdbid"/"tvdbid"/"malid">` tags in the `.nzb`. `nyuu` already supports the same thing generically via its `-M`/`--meta` key/value map (no fixed tag whitelist — writes `<meta type="{key}">{value}</meta>` for any key passed), it just never received these IDs from UA.
- UA already sends this same metadata straight to Curupira's own upload API right after posting, but nothing embedded it in the NZB itself for any other consumer reading the file directly (a re-index, an automated import elsewhere, Sonarr/Radarr-style tools that read `tvdbid`/`imdbid` from NZB meta).
- Both branches derive `tmdb_type` the same way `curupira.py` already does (`meta.category.lower()`, gated to `"movie"`/`"tv"`) and reuse `meta.imdb_tt` (already the zero-padded `"tt..."` string both tools expect) instead of reconstructing it.
- `pesto` also renamed its GitHub release tag scheme from unprefixed `v*` to `pesto-v*` (decoupling its release cadence from `parmesan`/`penne`, which already used their own prefix) — `v0.3.62` only exists under the new `pesto-v0.3.62` tag, so the pinned binary version in `get_pesto.py` had to move, not just bump the number, or the download URL 404s.

## Test plan
- [x] `ruff check` / `ruff format --check` on both touched files
- [x] `python -m py_compile` on both touched files
- [x] Unit-level check of the flag-building logic against synthetic `meta` objects (movie, tv, anime-only-mal, no ids, unsupported category) — matches expected `--tmdb`/`-M tmdbid:` output in every case
- [x] Ran the exact resulting flags against a real `pesto` v0.3.62 binary (`--dry-run`) — confirmed `<meta type="tmdbid"/"imdbid"/"tvdbid"/"malid">` written correctly
- [x] Ran the exact resulting flags against a real `nyuu` v0.4.2 binary — confirmed identical `<meta>` tags written to the NZB

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xZyyaP7YjHnXXNr14XjRt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TMDB, IMDb, TVDB, and MyAnimeList metadata to uploaded content where available.
  * Metadata is now included consistently across supported upload methods, with validation for applicable identifiers.

* **Updates**
  * The default bundled Pesto release has been updated to version 0.3.62.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->