### PR TITLE
fix(capybarabr): preserve original release group

### DIFF
--- a/data/example_config.py
+++ b/data/example_config.py
@@ -778,10 +778,6 @@ config: dict[str, Any] = {
             "anon": True,
             # Send uploads to CAPYBARABR modq for staff approval
             "modq": False,
-            # The tag that identifies you or your group when modifying an existing release.
-            # If set, the script will try to preserve the original group's name.
-            # Example: If set to "MyTag", a release might become: Movie 2003 1080p WEB-DL DDP5.1 H.264-OriginalGroup DUAL-MyTag
-            "tag_for_custom_release": "",
             # Set this to True if you want to allow external subtitles to be included in the upload
             "allow_ext_subtitles": True,
             # The configurations below override the DEFAULT configuration
@@ -2096,10 +2092,6 @@ config: dict[str, Any] = {
             "use_for_search": False,
             "api_key": "",
             "anon": True,
-            # The tag that identifies you or your group when modifying an existing release.
-            # If set, the script will try to preserve the original group's name.
-            # Example: If set to "MyTag", a release might become: Movie 2003 1080p WEB-DL DDP5.1 H.264-OriginalGroup DUAL-MyTag
-            "tag_for_custom_release": "",
             # Set this to True if you want to allow external subtitles to be included in the upload
             "allow_ext_subtitles": True,
             # The configurations below override the DEFAULT configuration

--- a/src/languages.py
+++ b/src/languages.py
@@ -184,9 +184,7 @@ class LanguagesManager:
 
         if "language_checked" not in meta:
             meta.language_checked = False
-        if tracker not in meta.tracker_status:
-            meta.tracker_status[tracker] = {}
-        status_dict = meta.tracker_status[tracker]
+        status_dict = meta.tracker_status.setdefault(tracker, {}) if tracker else {}
         if "unattended_audio_skip" not in meta:
             meta.unattended_audio_skip = False
         if "unattended_subtitle_skip" not in meta:

--- a/src/prep.py
+++ b/src/prep.py
@@ -26,6 +26,7 @@ try:
     from src.get_tracker_data import TrackerDataManager
     from src.getseasonep import SeasonEpisodeManager
     from src.is_scene import SceneManager
+    from src.languages import languages_manager
     from src.metadata_searching import MetadataSearchingManager
     from src.prep_game import gather_game_prep as _gather_game_prep_fn
     from src.prep_game import resolve_game_filelist as _resolve_game_filelist_fn
@@ -132,6 +133,8 @@ class Prep:
 
         # 8. Set Final Metadata and tags
         await prep_helpers.finalize_metadata(self, meta, videopath, bdinfo, mi, filename, untouched_filename, video)
+
+        await languages_manager.process_desc_language(meta)
 
         if meta.category == "BOOK":
             await self.rehost_images_manager.takescreens_manager.prepare_book_cover(videopath, meta.uuid, meta.base_dir, meta)

--- a/src/trackers/UNIT3D/capybarabr.py
+++ b/src/trackers/UNIT3D/capybarabr.py
@@ -224,7 +224,6 @@ class CapybaraBR(UNIT3D):
     async def get_name(self, meta: Meta) -> dict[str, str]:
         category = meta.category
         cbr_name = meta.name
-        name = meta.name
 
         if category == "BOOK":
             book_title = self.common.portuguese_title_capitalization(meta.title)
@@ -297,22 +296,22 @@ class CapybaraBR(UNIT3D):
                         else:
                             audio_tag = ""
 
-                    if audio_tag:
-                        if "-" in cbr_name:
-                            parts = cbr_name.rsplit("-", 1)
+                if not audio_tag and (meta.dual_audio or "dual-audio" in (meta.audio or "").lower()):
+                    audio_tag = " DUAL"
 
-                            custom_tag = dict(dict(self.config.get("TRACKERS", {})).get(self.tracker, {})).get("tag_for_custom_release", "")
-                            if custom_tag and custom_tag in name:
-                                match = re.search(r"-([^.-]+)\.(?:DUAL|MULTI)", meta.uuid)
-                                if match and match.group(1) != meta.tag:
-                                    original_group_tag = match.group(1)
-                                    cbr_name = f"{parts[0]}-{original_group_tag}{audio_tag}-{parts[1]}"
-                                else:
-                                    cbr_name = f"{parts[0]}{audio_tag}-{parts[1]}"
-                            else:
-                                cbr_name = f"{parts[0]}{audio_tag}-{parts[1]}"
+                if audio_tag:
+                    if "-" in cbr_name:
+                        parts = cbr_name.rsplit("-", 1)
+
+                        source_name = str(meta.path or meta.uuid or "")
+                        match = re.search(r"-([^.-]+)\.(?:DUAL|MULTI)(?=-|\.|$)", source_name, re.IGNORECASE)
+                        current_group_tag = (meta.tag or "").lstrip("-")
+                        if match and match.group(1).casefold() != current_group_tag.casefold():
+                            cbr_name = f"{parts[0]}-{match.group(1)}{audio_tag}-{parts[1]}"
                         else:
-                            cbr_name += audio_tag
+                            cbr_name = f"{parts[0]}{audio_tag}-{parts[1]}"
+                    else:
+                        cbr_name += audio_tag
 
             if not meta.tag or any(invalid_tag in tag_lower for invalid_tag in invalid_tags):
                 for invalid_tag in invalid_tags:

--- a/src/trackers/UNIT3D/capybarabr.py
+++ b/src/trackers/UNIT3D/capybarabr.py
@@ -303,8 +303,12 @@ class CapybaraBR(UNIT3D):
                     if "-" in cbr_name:
                         parts = cbr_name.rsplit("-", 1)
 
-                        source_name = str(meta.path or meta.uuid or "")
-                        match = re.search(r"-([^.-]+)\.(?:DUAL|MULTI)(?=-|\.|$)", source_name, re.IGNORECASE)
+                        match = None
+                        for source_name in (meta.path, meta.uuid):
+                            if source_name:
+                                match = re.search(r"-([^.-]+)\.(?:DUAL|MULTI)(?=-|\.|$)", str(source_name), re.IGNORECASE)
+                                if match:
+                                    break
                         current_group_tag = (meta.tag or "").lstrip("-")
                         if match and match.group(1).casefold() != current_group_tag.casefold():
                             cbr_name = f"{parts[0]}-{match.group(1)}{audio_tag}-{parts[1]}"

--- a/upload.py
+++ b/upload.py
@@ -46,7 +46,6 @@ from src.dupe_checking import DupeChecker
 from src.get_desc import gen_desc
 from src.get_name import NameManager
 from src.get_tracker_data import TrackerDataManager
-from src.languages import languages_manager
 from src.qbitwait import Wait
 from src.queuemanage import QueueManager
 from src.takescreens import TakeScreensManager
@@ -926,7 +925,6 @@ async def process_meta(meta: Meta, base_dir: str) -> bool:
         # reset trackers after any removals
         trackers = meta.trackers
 
-        audio_prompted = False
         for tracker in [
             "ASIANCINEMA",
             "AITHER",
@@ -959,17 +957,8 @@ async def process_meta(meta: Meta, base_dir: str) -> bool:
             "ULCX",
         ]:
             if tracker in trackers:
-                if not audio_prompted:
-                    await languages_manager.process_desc_language(meta, tracker=tracker)
-                    audio_prompted = True
-                else:
-                    status_dict = meta.tracker_status
-                    if tracker not in status_dict:
-                        status_dict[tracker] = {}
-                    if meta.unattended_audio_skip or meta.unattended_subtitle_skip:
-                        status_dict[tracker]["skip_upload"] = True
-                    else:
-                        status_dict[tracker]["skip_upload"] = False
+                status_dict = meta.tracker_status.setdefault(tracker, {})
+                status_dict["skip_upload"] = meta.unattended_audio_skip or meta.unattended_subtitle_skip
 
         await asyncio.sleep(0.2)
         async with aiofiles.open(f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/meta.json", "w", encoding="utf-8") as f:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Description language processing is now included automatically during metadata preparation.
  * Tracker-specific status handling is more consistent across preparation and upload workflows.
  * CapybaraBR release names now better identify dual-audio content and preserve existing group tags without duplication.

* **Bug Fixes**
  * Simplified unattended upload decisions to apply the configured audio and subtitle skip settings consistently.
  * Removed obsolete tracker-specific custom release tag configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->