### PR TITLE
feat(tracker): standardize API checks, add music MediaInfo, fix PeerGarden validation

### DIFF
--- a/src/music/prep.py
+++ b/src/music/prep.py
@@ -281,6 +281,23 @@ async def gather_music_prep(meta: Meta, config: dict[str, Any]) -> None:
     meta.name = meta.name_notag
     meta.clean_name = meta.name_notag
 
+    if not meta.edit and release.tracks:
+        try:
+            largest_track = max(release.tracks, key=lambda t: Path(t.path).stat().st_size if Path(t.path).is_file() else 0)
+            from src.exportmi import export_info
+
+            mi = await export_info(
+                largest_track.path,
+                meta.isdir,
+                meta.uuid,
+                meta.base_dir,
+                is_dvd=False,
+            )
+            meta.mediainfo = mi
+        except Exception as e:
+            logger.error(f"[yellow]Warning: MediaInfo export failed for music: {e}[/yellow]")
+            meta.mediainfo = {}
+
     path = Path(meta.base_dir) / "tmp" / str(meta.uuid) / "music_release.json"
     path.parent.mkdir(parents=True, exist_ok=True)
     async with aiofiles.open(path, "w", encoding="utf-8") as file:

--- a/src/trackers/UNIT3D/__init__.py
+++ b/src/trackers/UNIT3D/__init__.py
@@ -297,7 +297,7 @@ class UNIT3D:
         return {"tmdb": str(meta.tmdb) if meta.tmdb is not None else "0"}
 
     async def get_imdb(self, meta: Meta) -> dict[str, str]:
-        return {"imdb": f"{meta.imdb}"}
+        return {"imdb": str(meta.imdb_id or 0)}
 
     async def get_tvdb(self, meta: Meta) -> dict[str, str]:
         tvdb = meta.tvdb_id if meta.category == "TV" else 0

--- a/src/trackers/UNIT3D/emuwarez.py
+++ b/src/trackers/UNIT3D/emuwarez.py
@@ -4,7 +4,6 @@ from typing import Any, cast
 
 import cloudscraper
 
-from src.console import logger
 from src.languages import languages_manager
 from src.meta import Meta
 from src.tmdb import TmdbManager
@@ -527,10 +526,6 @@ class Emuwarez(UNIT3D):
         meta.tracker_status.setdefault(self.tracker, {})
 
         api_key = str(self.config["TRACKERS"][self.tracker].get("api_key", "")).strip()
-        if not api_key:
-            logger.info(f"[bold red]{self.tracker}: Missing API key in config file. Skipping...[/bold red]")
-            meta.skipping = self.tracker
-            return dupes
 
         # For TV use only the season token; for movies leave name empty
         name = ""

--- a/src/trackers/UNIT3D/hawkeuno.py
+++ b/src/trackers/UNIT3D/hawkeuno.py
@@ -309,11 +309,6 @@ class HawkeUno(UNIT3D):
         status_dict = meta.tracker_status[self.tracker]
 
         api_token = str(self.config["TRACKERS"][self.tracker].get("api_key", ""))
-        if not api_token:
-            logger.info(f"[bold red]{self.tracker}: Missing API key in config.[/bold red]")
-            meta.skipping = self.tracker
-            return False
-
         url = f"{self.upload_url}?api_token={api_token}"
 
         if meta.debug:

--- a/src/trackers/UNIT3D/peergarden.py
+++ b/src/trackers/UNIT3D/peergarden.py
@@ -261,3 +261,24 @@ class PeerGarden(UNIT3D):
         return {
             "mod_queue_opt_in": await self.get_flag(meta, "modq"),
         }
+
+    async def get_imdb(self, meta: Meta) -> dict[str, str]:
+        """Resolve IMDB ID, ensuring it is '0' for non-video categories or missing/invalid IDs."""
+        if meta.category not in ("MOVIE", "TV"):
+            return {"imdb": "0"}
+
+        imdb_id = str(meta.imdb or "").strip()
+        if imdb_id.isdigit() and int(imdb_id) > 0:
+            return {"imdb": imdb_id}
+
+        return {"imdb": "0"}
+
+    async def get_data(self, meta: Meta) -> dict[str, Any]:
+        """Build PeerGarden-specific upload payload, filtering out prohibited fields."""
+        data = await super().get_data(meta)
+
+        # Pop prohibited administrative flags
+        for field in ("free", "featured", "doubleup", "sticky"):
+            data.pop(field, None)
+
+        return data

--- a/src/trackers/UNIT3D/peergarden.py
+++ b/src/trackers/UNIT3D/peergarden.py
@@ -262,17 +262,6 @@ class PeerGarden(UNIT3D):
             "mod_queue_opt_in": await self.get_flag(meta, "modq"),
         }
 
-    async def get_imdb(self, meta: Meta) -> dict[str, str]:
-        """Resolve IMDB ID, ensuring it is '0' for non-video categories or missing/invalid IDs."""
-        if meta.category not in ("MOVIE", "TV"):
-            return {"imdb": "0"}
-
-        imdb_id = str(meta.imdb or "").strip()
-        if imdb_id.isdigit() and int(imdb_id) > 0:
-            return {"imdb": imdb_id}
-
-        return {"imdb": "0"}
-
     async def get_data(self, meta: Meta) -> dict[str, Any]:
         """Build PeerGarden-specific upload payload, filtering out prohibited fields."""
         data = await super().get_data(meta)

--- a/src/trackers/USENET/drunkenslug.py
+++ b/src/trackers/USENET/drunkenslug.py
@@ -51,9 +51,6 @@ class DrunkenSlug:
             logger.info(f"{self.tracker}: [yellow]Found local upload cache.[/yellow]")
             return [release_name]
 
-        if not self.api_key:
-            logger.info(f"{self.tracker}: [yellow]Duplicate search skipped due to missing API key.[/yellow]")
-            return []
         if self.daily_api_hit_limit <= 0:
             logger.info(f"{self.tracker}: [yellow]Duplicate search via API is disabled because daily_api_hit_limit is 0.[/yellow]")
             return []

--- a/src/trackers/USENET/suio.py
+++ b/src/trackers/USENET/suio.py
@@ -100,9 +100,6 @@ class Suio:
 
         if not self.search_url:
             return []
-        if not self.api_key:
-            logger.info(f"{self.tracker}: [yellow]Duplicate search skipped due to missing API key.[/yellow]")
-            return []
         if self.daily_api_hit_limit <= 0:
             logger.info(f"{self.tracker}: [yellow]Duplicate search via API is disabled because daily_api_hit_limit is 0.[/yellow]")
             return []

--- a/src/trackersetup.py
+++ b/src/trackersetup.py
@@ -134,11 +134,13 @@ class TrackerSetup:
             if isinstance(example_tracker_config, dict) and isinstance(tracker_config, dict):
                 if "api_key" in example_tracker_config and not tracker_config.get("api_key"):
                     logger.info(f"{tracker_name}: [bold red]Tracker is missing an API key and will be ignored.[/bold red]")
-                    continue
+                    if not meta.debug:
+                        continue
 
                 if "announce_url" in example_tracker_config and not tracker_config.get("announce_url"):
                     logger.info(f"{tracker_name}: [bold red]Tracker is missing an announce URL and will be ignored.[/bold red]")
-                    continue
+                    if not meta.debug:
+                        continue
 
             supported_cats = getattr(tracker_class, "supported_categories", None)
             if supported_cats is None:

--- a/tests/test_music_architecture.py
+++ b/tests/test_music_architecture.py
@@ -763,3 +763,46 @@ def test_orpheus_async_multipart_uses_mapping_and_repeats_list_fields():
     assert body.count(b'name="artists[]"') == 2
     assert body.count(b'name="importance[]"') == 2
     assert b'name="file_input"; filename="release.torrent"' in body
+
+
+def test_gather_music_prep_generates_mediainfo(tmp_path):
+    from src.music.prep import gather_music_prep
+    from src.music.models import AudioTrack, MusicRelease
+    
+    meta = Meta(
+        category="MUSIC",
+        path=str(tmp_path),
+        uuid="dummy-uuid",
+        base_dir=str(tmp_path),
+        edit=False,
+    )
+    
+    release = MusicRelease(root=str(tmp_path))
+    track = AudioTrack(
+        path=str(tmp_path / "01.flac"),
+        relative_path="01.flac",
+        format="FLAC",
+        codec="FLAC",
+    )
+    dummy_file = tmp_path / "01.flac"
+    dummy_file.write_bytes(b"dummy audio content")
+    release.tracks.append(track)
+    
+    mock_mi = {"media": {"track": [{"@type": "General", "Format": "FLAC"}]}}
+    
+    with (
+        patch.object(MusicReleaseAnalyzer, "analyze", return_value=release),
+        patch("src.exportmi.export_info", new=AsyncMock(return_value=mock_mi)) as mock_export_info,
+        patch("src.music.prep.prepare_music_cover", new=AsyncMock(return_value="")),
+    ):
+        asyncio.run(gather_music_prep(meta, {"DEFAULT": {}}))
+        
+    assert meta.mediainfo == mock_mi
+    mock_export_info.assert_awaited_once_with(
+        str(dummy_file),
+        meta.isdir,
+        meta.uuid,
+        meta.base_dir,
+        is_dvd=False,
+    )
+

--- a/tests/test_peergarden.py
+++ b/tests/test_peergarden.py
@@ -22,3 +22,65 @@ def test_peergarden_unknown_resolution_uses_other_id():
     resolution = asyncio.run(tracker.get_resolution_id(Meta(), resolution="unknown"))
 
     assert resolution == {"resolution_id": "10"}
+
+
+def test_peergarden_get_imdb_non_video_category():
+    tracker = PeerGarden({"DEFAULT": {}, "TRACKERS": {"PEERGARDEN": {}}})
+
+    meta = Meta()
+    meta.category = "MUSIC"
+    meta.imdb = "1234567"
+
+    imdb_data = asyncio.run(tracker.get_imdb(meta))
+    assert imdb_data == {"imdb": "0"}
+
+
+def test_peergarden_get_imdb_video_category_missing():
+    tracker = PeerGarden({"DEFAULT": {}, "TRACKERS": {"PEERGARDEN": {}}})
+
+    meta = Meta()
+    meta.category = "MOVIE"
+    meta.imdb = ""
+
+    imdb_data = asyncio.run(tracker.get_imdb(meta))
+    assert imdb_data == {"imdb": "0"}
+
+
+def test_peergarden_get_imdb_video_category_valid():
+    tracker = PeerGarden({"DEFAULT": {}, "TRACKERS": {"PEERGARDEN": {}}})
+
+    meta = Meta()
+    meta.category = "MOVIE"
+    meta.imdb = "1234567"
+
+    imdb_data = asyncio.run(tracker.get_imdb(meta))
+    assert imdb_data == {"imdb": "1234567"}
+
+
+def test_peergarden_get_data_pops_prohibited_fields():
+    from unittest.mock import AsyncMock, patch
+
+    tracker = PeerGarden({"DEFAULT": {}, "TRACKERS": {"PEERGARDEN": {}}})
+
+    mock_data = {
+        "name": "Test",
+        "imdb": "0",
+        "free": "0",
+        "featured": "0",
+        "doubleup": "0",
+        "sticky": "0",
+        "other_field": "val",
+    }
+
+    with patch("src.trackers.UNIT3D.UNIT3D.get_data", new_callable=AsyncMock) as mock_get_data:
+        mock_get_data.return_value = mock_data
+
+        result = asyncio.run(tracker.get_data(Meta()))
+
+        assert "free" not in result
+        assert "featured" not in result
+        assert "doubleup" not in result
+        assert "sticky" not in result
+        assert result["imdb"] == "0"
+        assert result["other_field"] == "val"
+


### PR DESCRIPTION
This PR consolidates tracker API key/announce URL checking, adds MediaInfo export for music files, and fixes the PeerGarden upload validation error by filtering out administrative flags and resolving IMDB IDs properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Music preparation now includes MediaInfo from the largest track in release metadata.
  * PeerGarden submissions now provide category-appropriate IMDb values and exclude unsupported administrative options.

* **Bug Fixes**
  * Tracker searches and uploads can proceed for further validation when API credentials are missing.
  * Tracker setup no longer unnecessarily removes trackers with missing configuration during debug runs.

* **Tests**
  * Added coverage for music MediaInfo generation and PeerGarden submission behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->