### PR TITLE
style(trackers): standardize tracker log prefixes

### DIFF
--- a/src/trackers/AVISTAZ/__init__.py
+++ b/src/trackers/AVISTAZ/__init__.py
@@ -1025,7 +1025,7 @@ class AZTrackerBase:
             meta.tracker_status[self.tracker]["status_message"] = status_message
             return False
 
-        logger.info(f"{self.tracker}: [cyan]Request Data:")
+        logger.info(f"{self.tracker}: Request Data:")
         logger.info(Redaction.redact_private_info(data))
         meta.tracker_status[self.tracker]["status_message"] = "Debug mode enabled, not uploading."
         await self.common.create_torrent_for_upload(meta, f"{self.tracker}" + "_DEBUG", f"{self.tracker}" + "_DEBUG", announce_url="https://fake.tracker")

--- a/src/trackers/AVISTAZ/__init__.py
+++ b/src/trackers/AVISTAZ/__init__.py
@@ -125,7 +125,9 @@ class AZTrackerBase:
                 break
 
             if attempt == 0 and not self.media_code:
-                logger.info(f"\n{self.tracker}: The media [[yellow]IMDB:{imdb_id}[/yellow]] [[blue]TMDB:{tmdb_id}[/blue]] appears to be missing from the site's database.")
+                logger.info(
+                    f"{self.tracker}: \n{self.tracker}: The media [[yellow]IMDB:{imdb_id}[/yellow]] [[blue]TMDB:{tmdb_id}[/blue]] appears to be missing from the site's database."
+                )
                 if cli_ui.ask_yes_no(f"{self.tracker}: Do you want to add it to the site database?\n"):
                     added_successfully = await self.add_media_to_db(meta, title, category, imdb_id, tmdb_id)
                     if not added_successfully:
@@ -171,7 +173,7 @@ class AZTrackerBase:
             Path(failure_path).parent.mkdir(parents=True, exist_ok=True)
             async with aiofiles.open(failure_path, "w", encoding="utf-8") as f:
                 await f.write(response.text)
-            logger.info(f"The server response was saved to {failure_path} for analysis.")
+            logger.info(f"{self.tracker}: The server response was saved to {failure_path} for analysis.")
             return False
 
         except Exception as e:
@@ -204,7 +206,7 @@ class AZTrackerBase:
 
         if meta.type not in ["WEBDL"] and self.tracker == "PRIVATEHD" and meta.tag in ["FGT", "EVO"]:
             if not meta.unattended or (meta.unattended and meta.unattended_confirm):
-                logger.info(f"[bold red]Group {meta.tag} is only allowed for web-dl[/bold red]")
+                logger.info(f"{self.tracker}: [bold red]Group {meta.tag} is only allowed for web-dl[/bold red]")
                 if not cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
                     return False
             else:
@@ -318,15 +320,15 @@ class AZTrackerBase:
                 if pre_tag:
                     return pre_tag.get_text("\n", strip=True)
 
-            logger.info(f"[yellow]{self.tracker}: MediaInfo/BDInfo block not found at {torrent_link}[/yellow]")
+            logger.info(f"{self.tracker}: [yellow]MediaInfo/BDInfo block not found at {torrent_link}[/yellow]")
             return ""
 
         except httpx.HTTPStatusError as e:
-            logger.info(f"[red]{self.tracker}: HTTP error {e.response.status_code} from {torrent_link}[/red]")
+            logger.info(f"{self.tracker}: [red]HTTP error {e.response.status_code} from {torrent_link}[/red]")
         except httpx.RequestError as e:
-            logger.info(f"[red]{self.tracker}: Request failed to {torrent_link}. {e}[/red]")
+            logger.info(f"{self.tracker}: [red]Request failed to {torrent_link}. {e}[/red]")
         except Exception as e:
-            logger.error(f"[red]{self.tracker}: Unexpected error parsing {torrent_link}. {e}[/red]")
+            logger.error(f"{self.tracker}: [red]Unexpected error parsing {torrent_link}. {e}[/red]")
 
         return ""
 
@@ -406,8 +408,8 @@ class AZTrackerBase:
                             missing_audio_languages.append(track)
 
                 if missing_audio_languages:
-                    logger.info("No audio language/s found.")
-                    logger.info("You must enter (comma-separated) languages for all audio tracks, eg: English, Spanish: ")
+                    logger.info(f"{self.tracker}: No audio language/s found.")
+                    logger.info(f"{self.tracker}: You must enter (comma-separated) languages for all audio tracks, eg: English, Spanish: ")
                     user_input_raw = cli_ui.ask_string("[bold yellow]Enter languages: [/bold yellow]")
                     user_input = (user_input_raw or "").strip()
                     langs = [lang.strip() for lang in user_input.split(",")]
@@ -417,9 +419,9 @@ class AZTrackerBase:
                             audio_ids.add(target_id)
 
             except FileNotFoundError:
-                logger.warning(f"Warning: MediaInfo.json not found for uuid {meta.uuid}. No languages will be processed.", extra={"markup": False})
+                logger.warning(f"{self.tracker}: Warning: MediaInfo.json not found for uuid {meta.uuid}. No languages will be processed.", extra={"markup": False})
             except (json.JSONDecodeError, KeyError, TypeError) as e:
-                logger.info(f"Error processing MediaInfo.json for uuid {meta.uuid}: {e}", extra={"markup": False})
+                logger.info(f"{self.tracker}: Error processing MediaInfo.json for uuid {meta.uuid}: {e}", extra={"markup": False})
 
         final_subtitle_ids = sorted(subtitle_ids)
         final_audio_ids = sorted(audio_ids)
@@ -481,7 +483,7 @@ class AZTrackerBase:
                     image_bytes = await f.read()
                 return await self.img_host(meta, upload_referer, image_bytes, path.name)
             except Exception as e:
-                logger.info(f"Failed to process local screenshot {path}: {e}", extra={"markup": False})
+                logger.info(f"{self.tracker}: Failed to process local screenshot {path}: {e}", extra={"markup": False})
                 return None
 
         async def upload_remote_file(url: str):
@@ -494,7 +496,7 @@ class AZTrackerBase:
                     filename = f"{filename}.png"
                 return await self.img_host(meta, upload_referer, image_bytes, filename)
             except Exception as e:
-                logger.info(f"Failed to process screenshot from URL {url}: {e}", extra={"markup": False})
+                logger.info(f"{self.tracker}: Failed to process screenshot from URL {url}: {e}", extra={"markup": False})
                 return None
 
         # Upload menu images
@@ -607,7 +609,7 @@ class AZTrackerBase:
                         return 0
 
         except Exception as e:
-            logger.info(f"An unexpected error occurred while processing the tag '{word}': {e}", extra={"markup": False})
+            logger.info(f"{self.tracker}: An unexpected error occurred while processing the tag '{word}': {e}", extra={"markup": False})
 
         return 0
 
@@ -1022,7 +1024,7 @@ class AZTrackerBase:
             meta.tracker_status[self.tracker]["status_message"] = status_message
             return False
 
-        logger.info(f"[cyan]{self.tracker} Request Data:")
+        logger.info(f"{self.tracker}: [cyan]Request Data:")
         logger.info(Redaction.redact_private_info(data))
         meta.tracker_status[self.tracker]["status_message"] = "Debug mode enabled, not uploading."
         await self.common.create_torrent_for_upload(meta, f"{self.tracker}" + "_DEBUG", f"{self.tracker}" + "_DEBUG", announce_url="https://fake.tracker")

--- a/src/trackers/AVISTAZ/__init__.py
+++ b/src/trackers/AVISTAZ/__init__.py
@@ -125,9 +125,7 @@ class AZTrackerBase:
                 break
 
             if attempt == 0 and not self.media_code:
-                logger.info(
-                    f"{self.tracker}: \n{self.tracker}: The media [[yellow]IMDB:{imdb_id}[/yellow]] [[blue]TMDB:{tmdb_id}[/blue]] appears to be missing from the site's database."
-                )
+                logger.info(f"{self.tracker}: \nThe media [[yellow]IMDB:{imdb_id}[/yellow]] [[blue]TMDB:{tmdb_id}[/blue]] appears to be missing from the site's database.")
                 if cli_ui.ask_yes_no(f"{self.tracker}: Do you want to add it to the site database?\n"):
                     added_successfully = await self.add_media_to_db(meta, title, category, imdb_id, tmdb_id)
                     if not added_successfully:
@@ -327,8 +325,11 @@ class AZTrackerBase:
             logger.info(f"{self.tracker}: [red]HTTP error {e.response.status_code} from {torrent_link}[/red]")
         except httpx.RequestError as e:
             logger.info(f"{self.tracker}: [red]Request failed to {torrent_link}. {e}[/red]")
+        except (AttributeError, TypeError, ValueError) as e:
+            logger.info(f"{self.tracker}: [red]Parsing failed for {torrent_link}. {e}[/red]")
         except Exception as e:
-            logger.error(f"{self.tracker}: [red]Unexpected error parsing {torrent_link}. {e}[/red]")
+            logger.error(f"{self.tracker}: [red]Unexpected error parsing {torrent_link}. {e}[/red]", exc_info=True)
+            raise
 
         return ""
 

--- a/src/trackers/NEXUSPHP/__init__.py
+++ b/src/trackers/NEXUSPHP/__init__.py
@@ -57,7 +57,7 @@ class NEXUSPHP:
 
     async def search_existing(self, meta: Meta) -> list[dict[str, str]]:
         if not self.announce_url:
-            logger.info(f"[red]Announce URL is not set for {self.tracker}[/red]", extra={"markup": True})
+            logger.info(f"{self.tracker}: [red]Announce URL is not set for {self.tracker}[/red]", extra={"markup": True})
             meta.skipping = self.tracker
             return []
 
@@ -145,7 +145,7 @@ class NEXUSPHP:
             return ""
 
         except Exception as e:
-            logger.info(f"Error getting BDInfo for torrent {torrent_id}: {e}", extra={"markup": False})
+            logger.info(f"{self.tracker}: Error getting BDInfo for torrent {torrent_id}: {e}", extra={"markup": False})
             return ""
 
     async def validate_credentials(self, meta: Meta) -> bool:

--- a/src/trackers/UNIT3D/__init__.py
+++ b/src/trackers/UNIT3D/__init__.py
@@ -169,7 +169,7 @@ class UNIT3D:
                             }
                         dupes.append(result)
                 else:
-                    logger.info(f"[bold red]Failed to search torrents. HTTP Status: {response.status_code}")
+                    logger.info(f"{self.tracker}: [bold red]Failed to search torrents. HTTP Status: {response.status_code}")
 
         return dupes
 
@@ -297,7 +297,8 @@ class UNIT3D:
         return {"tmdb": str(meta.tmdb) if meta.tmdb is not None else "0"}
 
     async def get_imdb(self, meta: Meta) -> dict[str, str]:
-        return {"imdb": str(meta.imdb_id or 0)}
+        imdb = meta.imdb_id if meta.category in ("TV", "MOVIE") else 0
+        return {"imdb": str(imdb or 0)}
 
     async def get_tvdb(self, meta: Meta) -> dict[str, str]:
         tvdb = meta.tvdb_id if meta.category == "TV" else 0
@@ -431,7 +432,7 @@ class UNIT3D:
                     if cover_bytes:
                         files["torrent-cover"] = ("cover.jpg", cover_bytes, "image/jpeg")
                 except Exception as e:
-                    logger.info(f"[yellow]Failed to process cover: {e}[/yellow]")
+                    logger.info(f"{self.tracker}: [yellow]Failed to process cover: {e}[/yellow]")
 
             banner_path = meta.banner_path
             if banner_path and Path(banner_path).exists():
@@ -440,7 +441,7 @@ class UNIT3D:
                     if banner_bytes:
                         files["torrent-banner"] = ("banner.jpg", banner_bytes, "image/jpeg")
                 except Exception as e:
-                    logger.info(f"[yellow]Failed to process banner: {e}[/yellow]")
+                    logger.info(f"{self.tracker}: [yellow]Failed to process banner: {e}[/yellow]")
 
         return files
 
@@ -478,7 +479,7 @@ class UNIT3D:
                         if not response_data.get("success"):
                             error_msg = response_data.get("message", "Unknown error")
                             meta.tracker_status[self.tracker]["status_message"] = f"API error: {error_msg}"
-                            logger.info(f"[yellow]Upload to {self.tracker} failed: {error_msg}[/yellow]")
+                            logger.info(f"{self.tracker}: [yellow]Upload to {self.tracker} failed: {error_msg}[/yellow]")
                             return False
 
                         meta.tracker_status[self.tracker]["status_message"] = await self.process_response_data(response_data)
@@ -506,7 +507,7 @@ class UNIT3D:
                         # Retry other HTTP errors
                         if attempt < max_retries - 1:
                             logger.info(
-                                f"[yellow]{self.tracker}: HTTP {e.response.status_code} error, retrying in {retry_delay} seconds... (attempt {attempt + 1}/{max_retries})[/yellow]"
+                                f"{self.tracker}: [yellow]HTTP {e.response.status_code} error, retrying in {retry_delay} seconds... (attempt {attempt + 1}/{max_retries})[/yellow]"
                             )
                             await asyncio.sleep(retry_delay)
                             continue
@@ -520,7 +521,7 @@ class UNIT3D:
                     if attempt < max_retries - 1:
                         timeout = timeout * 1.5  # Increase timeout by 50% for next retry
                         logger.info(
-                            f"[yellow]{self.tracker}: Request timed out, retrying in {retry_delay} seconds with {timeout}s timeout... (attempt {attempt + 1}/{max_retries})[/yellow]"
+                            f"{self.tracker}: [yellow]Request timed out, retrying in {retry_delay} seconds with {timeout}s timeout... (attempt {attempt + 1}/{max_retries})[/yellow]"
                         )
                         await asyncio.sleep(retry_delay)
                         continue
@@ -528,7 +529,7 @@ class UNIT3D:
                     return False  # Timeout after all retries
                 except httpx.RequestError as e:
                     if attempt < max_retries - 1:
-                        logger.info(f"[yellow]{self.tracker}: Request error, retrying in {retry_delay} seconds... (attempt {attempt + 1}/{max_retries})[/yellow]")
+                        logger.info(f"{self.tracker}: [yellow]Request error, retrying in {retry_delay} seconds... (attempt {attempt + 1}/{max_retries})[/yellow]")
                         await asyncio.sleep(retry_delay)
                         continue
                     meta.tracker_status[self.tracker]["status_message"] = f"data error: Unable to upload. Error: {e}.\nResponse: {response_data}"
@@ -542,7 +543,7 @@ class UNIT3D:
                 await self.common.download_tracker_torrent(meta, self.tracker, headers=headers, downurl=download_url)
                 return True
         else:
-            logger.info(f"[cyan]{self.tracker} Request Data:")
+            logger.info(f"{self.tracker}: [cyan]Request Data:")
             logger.info(Redaction.redact_private_info(data))
             meta.tracker_status[self.tracker]["status_message"] = f"Debug mode enabled, not uploading: {self.tracker}."
             await self.common.create_torrent_for_upload(
@@ -563,7 +564,7 @@ class UNIT3D:
             if match:
                 torrent_id = match.group(1)
         except IndexError, KeyError:
-            logger.info("Could not parse torrent_id from response data.")
+            logger.info(f"{self.tracker}: Could not parse torrent_id from response data.")
         return torrent_id
 
     async def process_response_data(self, response_data: dict[str, Any]) -> str:

--- a/src/trackers/UNIT3D/__init__.py
+++ b/src/trackers/UNIT3D/__init__.py
@@ -543,7 +543,7 @@ class UNIT3D:
                 await self.common.download_tracker_torrent(meta, self.tracker, headers=headers, downurl=download_url)
                 return True
         else:
-            logger.info(f"{self.tracker}: [cyan]Request Data:")
+            logger.info(f"{self.tracker}: Request Data:")
             logger.info(Redaction.redact_private_info(data))
             meta.tracker_status[self.tracker]["status_message"] = f"Debug mode enabled, not uploading: {self.tracker}."
             await self.common.create_torrent_for_upload(

--- a/src/trackers/UNIT3D/aither.py
+++ b/src/trackers/UNIT3D/aither.py
@@ -43,7 +43,7 @@ class Aither(UNIT3D):
             return False
 
         if meta.valid_mi is False:
-            logger.info(f"[bold red]No unique ID in mediainfo, skipping {self.tracker} upload.")
+            logger.info(f"{self.tracker}: [bold red]No unique ID in mediainfo, skipping {self.tracker} upload.")
             return False
 
         return should_continue

--- a/src/trackers/UNIT3D/aura4k.py
+++ b/src/trackers/UNIT3D/aura4k.py
@@ -73,12 +73,12 @@ class Aura4K(UNIT3D):
         should_continue = True
         if meta.resolution not in ["2160p", "4320p"]:
             if not meta.unattended:
-                logger.info(f"[red]{self.tracker} only accepts 4K uploads.")
+                logger.info(f"{self.tracker}: [red]only accepts 4K uploads.")
             return False
 
         if meta.type not in ["DISC", "REMUX", "WEBDL", "ENCODE"]:
             if not meta.unattended:
-                logger.info(f"[red]{self.tracker} only accepts DISC, REMUX, WEBDL, and ENCODE uploads.")
+                logger.info(f"{self.tracker}: [red]only accepts DISC, REMUX, WEBDL, and ENCODE uploads.")
             return False
 
         if meta.is_disc not in ["BDMV", "DVD"] and not await self.common.check_language_requirements(
@@ -105,16 +105,16 @@ class Aura4K(UNIT3D):
                                 bit_rate_kbps = bit_rate_num / 1000
                                 if meta.category == "MOVIE" and bit_rate_kbps < 15000:
                                     if not meta.unattended:
-                                        logger.info(f"Video bitrate too low: {bit_rate_kbps:.0f} kbps for AURA4K movie uploads.")
+                                        logger.info(f"{self.tracker}: Video bitrate too low: {bit_rate_kbps:.0f} kbps for AURA4K movie uploads.")
                                     return False
                                 if meta.category == "TV" and bit_rate_kbps < 10000:
                                     if not meta.unattended:
-                                        logger.info(f"Video bitrate too low: {bit_rate_kbps:.0f} kbps for AURA4K TV uploads.")
+                                        logger.info(f"{self.tracker}: Video bitrate too low: {bit_rate_kbps:.0f} kbps for AURA4K TV uploads.")
                                     return False
                             else:
                                 if not meta.unattended or (meta.unattended and meta.unattended_confirm):
-                                    logger.info(f"[bold red]Could not determine video bitrate from mediainfo for {self.tracker} upload.[/bold red]")
-                                    logger.info("[yellow]Bitrate must be above 15000 kbps for movies and 10000 kbps for TV shows.[/yellow]")
+                                    logger.info(f"{self.tracker}: [bold red]Could not determine video bitrate from mediainfo for {self.tracker} upload.[/bold red]")
+                                    logger.info(f"{self.tracker}: [yellow]Bitrate must be above 15000 kbps for movies and 10000 kbps for TV shows.[/yellow]")
                                     if cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
                                         pass
                                     else:
@@ -123,8 +123,8 @@ class Aura4K(UNIT3D):
                                     return False
                         else:
                             if not meta.unattended or (meta.unattended and meta.unattended_confirm):
-                                logger.info(f"[bold red]Could not determine video bitrate from mediainfo for {self.tracker} upload.[/bold red]")
-                                logger.info("[yellow]Bitrate must be above 15000 kbps for movies and 10000 kbps for TV shows.[/yellow]")
+                                logger.info(f"{self.tracker}: [bold red]Could not determine video bitrate from mediainfo for {self.tracker} upload.[/bold red]")
+                                logger.info(f"{self.tracker}: [yellow]Bitrate must be above 15000 kbps for movies and 10000 kbps for TV shows.[/yellow]")
                                 if cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
                                     pass
                                 else:
@@ -133,8 +133,8 @@ class Aura4K(UNIT3D):
                                 return False
                     else:
                         if not meta.unattended or (meta.unattended and meta.unattended_confirm):
-                            logger.info(f"[bold red]Could not determine video bitrate from mediainfo for {self.tracker} upload.[/bold red]")
-                            logger.info("[yellow]Bitrate must be above 15000 kbps for movies and 10000 kbps for TV shows.[/yellow]")
+                            logger.info(f"{self.tracker}: [bold red]Could not determine video bitrate from mediainfo for {self.tracker} upload.[/bold red]")
+                            logger.info(f"{self.tracker}: [yellow]Bitrate must be above 15000 kbps for movies and 10000 kbps for TV shows.[/yellow]")
                             if cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
                                 pass
                             else:
@@ -176,5 +176,5 @@ class Aura4K(UNIT3D):
             foreign_lang = audio_languages[0].upper()
             if meta.is_disc != "BDMV":
                 a4k_name = a4k_name.replace(meta.resolution, f"{foreign_lang} {meta.resolution}", 1)
-        logger.info(f"[yellow]Generated name for {self.tracker}: [bold]{a4k_name}[/bold][/yellow]")
+        logger.info(f"{self.tracker}: [yellow]Generated name for {self.tracker}: [bold]{a4k_name}[/bold][/yellow]")
         return {"name": a4k_name}

--- a/src/trackers/UNIT3D/blutopia.py
+++ b/src/trackers/UNIT3D/blutopia.py
@@ -133,12 +133,14 @@ class Blutopia(UNIT3D):
                 allowed.append("mp4")
 
             if container not in allowed:
-                logger.info(f"[bold red]For this release, {self.tracker} requires one of the following containers: {', '.join([a.upper() for a in allowed])}[/bold red]")
+                logger.info(
+                    f"{self.tracker}: [bold red]For this release, {self.tracker} requires one of the following containers: {', '.join([a.upper() for a in allowed])}[/bold red]"
+                )
                 return False
 
         if meta.type in ["ENCODE", "REMUX"] and "HDR" in meta.hdr and "DV" in meta.hdr and (not meta.unattended or (meta.unattended and meta.unattended_confirm)):
-            logger.info("[bold red]Releases using a Dolby Vision layer from a different source have specific description requirements.[/bold red]")
-            logger.info("[bold red]See rule 12.5. You must have a correct pre-formatted description if this release has a derived layer[/bold red]")
+            logger.info(f"{self.tracker}: [bold red]Releases using a Dolby Vision layer from a different source have specific description requirements.[/bold red]")
+            logger.info(f"{self.tracker}: [bold red]See rule 12.5. You must have a correct pre-formatted description if this release has a derived layer[/bold red]")
             if not cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
                 return False
             if cli_ui.ask_yes_no("Is this a derived layer release?", default=False):
@@ -146,7 +148,7 @@ class Blutopia(UNIT3D):
 
         if meta.type not in ["WEBDL"] and not meta.is_disc and meta.tag in ["AOC", "CMRG", "EVO", "TERMiNAL", "ViSION"]:
             if not meta.unattended or (meta.unattended and meta.unattended_confirm):
-                logger.info(f"[bold red]Group {meta.tag} is only allowed for raw type content[/bold red]")
+                logger.info(f"{self.tracker}: [bold red]Group {meta.tag} is only allowed for raw type content[/bold red]")
                 if cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
                     pass
                 else:
@@ -155,7 +157,7 @@ class Blutopia(UNIT3D):
                 return False
 
         if not meta.valid_mi_settings:
-            logger.info(f"[bold red]No encoding settings in mediainfo, skipping {self.tracker} upload.[/bold red]")
+            logger.info(f"{self.tracker}: [bold red]No encoding settings in mediainfo, skipping {self.tracker} upload.[/bold red]")
             return False
 
         return should_continue

--- a/src/trackers/UNIT3D/cinematik.py
+++ b/src/trackers/UNIT3D/cinematik.py
@@ -1,5 +1,6 @@
 # Upload Assistant © 2025 Audionut & wastaken7 — Licensed under UAPL v1.0
 import re
+import urllib.error
 import urllib.request
 from pathlib import Path
 from typing import Any, cast
@@ -8,6 +9,8 @@ from urllib.parse import urlparse
 import aiofiles
 import cli_ui
 import click
+import httpx
+from rich.markup import escape
 
 from src.console import logger
 from src.get_desc import DescriptionBuilder
@@ -207,9 +210,9 @@ class Cinematik(UNIT3D):
                 if parsed_url.scheme not in ("http", "https"):
                     raise ValueError(f"Invalid URL scheme: {parsed_url.scheme}")
                 urllib.request.urlretrieve(poster_url, poster_path)  # noqa: S310
-                logger.info(f"{self.tracker}: [green]Cover downloaded to {poster_path}[/green]")
-            except Exception as e:
-                logger.error(f"{self.tracker}: [red]Error downloading poster: {e}[/red]")
+                logger.info(f"{self.tracker}: [green]Cover downloaded to {escape(str(poster_path))}[/green]")
+            except (urllib.error.URLError, OSError, ValueError) as e:
+                logger.error(f"{self.tracker}: [red]Error downloading poster: {escape(str(e))}[/red]")
 
         # Upload the downloaded or existing poster image once
         if Path(poster_path).exists():
@@ -221,8 +224,8 @@ class Cinematik(UNIT3D):
                 poster_urls = new_poster_url
                 if len(poster_urls) > 0:
                     poster_url = str(poster_urls[0].get("raw_url", poster_url))
-            except Exception as e:
-                logger.error(f"{self.tracker}: [red]Error uploading poster: {e}[/red]")
+            except (httpx.HTTPError, ValueError, KeyError) as e:
+                logger.error(f"{self.tracker}: [red]Error uploading poster: {escape(str(e))}[/red]")
         else:
             logger.info(f"{self.tracker}: [red]Cover file not found, cannot upload.[/red]")
 

--- a/src/trackers/UNIT3D/cinematik.py
+++ b/src/trackers/UNIT3D/cinematik.py
@@ -41,7 +41,7 @@ class Cinematik(UNIT3D):
 
     async def get_additional_checks(self, meta: Meta) -> bool:
         if not meta.is_disc:
-            logger.info("[red]Only disc-based content allowed at Cinematik")
+            logger.info(f"{self.tracker}: [red]Only disc-based content allowed at Cinematik")
             return False
 
         return True
@@ -140,7 +140,7 @@ class Cinematik(UNIT3D):
         type_id_map = {"Custom": "1", "BD100": "3", "BD66": "4", "BD50": "5", "BD25": "6", "NTSC DVD9": "7", "NTSC DVD5": "8", "PAL DVD9": "9", "PAL DVD5": "10", "3D": "11"}
 
         if not disctype:
-            logger.info("[red]You must specify a --disctype")
+            logger.info(f"{self.tracker}: [red]You must specify a --disctype")
             # Raise an exception since we can't proceed without disctype
             raise ValueError("disctype is required for Cinematik tracker but was not provided")
 
@@ -170,7 +170,7 @@ class Cinematik(UNIT3D):
         if meta.description_link or meta.description_file:
             desc = await DescriptionBuilder(self.tracker, self.config).unit3d_edit_desc(meta)
 
-            logger.info(f"Custom Description Link/File Path: {desc}", extra={"markup": False})
+            logger.info(f"{self.tracker}: Custom Description Link/File Path: {desc}", extra={"markup": False})
             return {"description": desc}
 
         discs = cast(list[dict[str, Any]], meta.discs)
@@ -195,10 +195,10 @@ class Cinematik(UNIT3D):
         # Check if either poster.jpg or poster.png already exists
         if Path(poster_jpg_path).exists():
             poster_path = poster_jpg_path
-            logger.info("[green]Cover already exists as poster.jpg, skipping download.[/green]")
+            logger.info(f"{self.tracker}: [green]Cover already exists as poster.jpg, skipping download.[/green]")
         elif Path(poster_png_path).exists():
             poster_path = poster_png_path
-            logger.info("[green]Cover already exists as poster.png, skipping download.[/green]")
+            logger.info(f"{self.tracker}: [green]Cover already exists as poster.png, skipping download.[/green]")
         else:
             # No poster file exists, download the poster image
             poster_path = poster_jpg_path  # Default to saving as poster.jpg
@@ -207,14 +207,14 @@ class Cinematik(UNIT3D):
                 if parsed_url.scheme not in ("http", "https"):
                     raise ValueError(f"Invalid URL scheme: {parsed_url.scheme}")
                 urllib.request.urlretrieve(poster_url, poster_path)  # noqa: S310
-                logger.info(f"[green]Cover downloaded to {poster_path}[/green]")
+                logger.info(f"{self.tracker}: [green]Cover downloaded to {poster_path}[/green]")
             except Exception as e:
-                logger.error(f"[red]Error downloading poster: {e}[/red]")
+                logger.error(f"{self.tracker}: [red]Error downloading poster: {e}[/red]")
 
         # Upload the downloaded or existing poster image once
         if Path(poster_path).exists():
             try:
-                logger.info("Uploading standard poster to image host....")
+                logger.info(f"{self.tracker}: Uploading standard poster to image host....")
                 new_poster_url, _ = await self.uploadscreens_manager.upload_screens(meta, 1, 1, 0, 1, [poster_path], {})
 
                 # Ensure that the new poster URL is assigned only once
@@ -222,9 +222,9 @@ class Cinematik(UNIT3D):
                 if len(poster_urls) > 0:
                     poster_url = str(poster_urls[0].get("raw_url", poster_url))
             except Exception as e:
-                logger.error(f"[red]Error uploading poster: {e}[/red]")
+                logger.error(f"{self.tracker}: [red]Error uploading poster: {e}[/red]")
         else:
-            logger.info("[red]Cover file not found, cannot upload.[/red]")
+            logger.info(f"{self.tracker}: [red]Cover file not found, cannot upload.[/red]")
 
         # Generate the description text
         desc_text: list[str] = []
@@ -383,17 +383,17 @@ class Cinematik(UNIT3D):
         description = "".join(desc_text)
 
         # Ask user if they want to edit or keep the description
-        logger.info(f"Current description: {description}", extra={"markup": False})
-        logger.info("[cyan]Do you want to edit or keep the description?[/cyan]")
+        logger.info(f"{self.tracker}: Current description: {description}", extra={"markup": False})
+        logger.info(f"{self.tracker}: [cyan]Do you want to edit or keep the description?[/cyan]")
         edit_choice = cli_ui.ask_string("Enter 'e' to edit, or press Enter to keep it as is: ")
 
         if (edit_choice or "").lower() == "e":
             edited_description = cast(str | None, click.edit(description))  # pyrefly: ignore [bad-argument-type]
             if edited_description:
                 description = edited_description.strip()
-            logger.info(f"Final description after editing: {description}", extra={"markup": False})
+            logger.info(f"{self.tracker}: Final description after editing: {description}", extra={"markup": False})
         else:
-            logger.info("[green]Keeping the original description.[/green]")
+            logger.info(f"{self.tracker}: [green]Keeping the original description.[/green]")
 
         # Write the final description to the file
         async with aiofiles.open(f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/[{self.tracker}]DESCRIPTION.txt", "w", encoding="utf-8") as desc_file:

--- a/src/trackers/UNIT3D/darkpeers.py
+++ b/src/trackers/UNIT3D/darkpeers.py
@@ -100,7 +100,7 @@ class DarkPeers(UNIT3D):
         should_continue = True
         if meta.keep_folder:
             if not meta.unattended or (meta.unattended and meta.unattended_confirm):
-                logger.info(f"[bold red]{self.tracker} does not allow single files in a folder.")
+                logger.info(f"{self.tracker}: [bold red]does not allow single files in a folder.")
                 if cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
                     pass
                 else:
@@ -114,11 +114,11 @@ class DarkPeers(UNIT3D):
 
         if meta.type not in ["WEBDL"] and meta.tag in ["EVO"]:
             if not meta.unattended:
-                logger.info(f"[bold red]{self.tracker} does not allow EVO for non-WEBDL types, skipping upload.")
+                logger.info(f"{self.tracker}: [bold red]does not allow EVO for non-WEBDL types, skipping upload.")
             return False
 
         if meta.hardcoded_subs and not meta.unattended:
-            logger.info(f"[bold red]{self.tracker} does not allow hardcoded subtitles.")
+            logger.info(f"{self.tracker}: [bold red]does not allow hardcoded subtitles.")
             return False
 
         return should_continue

--- a/src/trackers/UNIT3D/hawkeuno.py
+++ b/src/trackers/UNIT3D/hawkeuno.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import aiofiles
 import httpx
+from rich.markup import escape
 
 from cogs.redaction import Redaction
 from src.console import logger
@@ -342,9 +343,13 @@ class HawkeUno(UNIT3D):
         except httpx.HTTPStatusError as e:
             msg = f"HTTP {e.response.status_code} - {e.response.text}"
             status_dict["status_message"] = f"data error: {msg}"
-            logger.info(f"{self.tracker}: [bold red]Upload error: {msg}[/bold red]")
+            logger.info(f"{self.tracker}: [bold red]Upload error: {escape(str(msg))}[/bold red]")
+            return False
+        except (httpx.RequestError, ValueError, KeyError) as e:
+            status_dict["status_message"] = f"data error: {e}"
+            logger.info(f"{self.tracker}: [bold red]Upload connection/parsing error: {escape(str(e))}[/bold red]")
             return False
         except Exception as e:
             status_dict["status_message"] = f"data error: {e}"
-            logger.info(f"{self.tracker}: [bold red]Upload unexpected error: {e}[/bold red]")
-            return False
+            logger.info(f"{self.tracker}: [bold red]Upload unexpected error: {escape(str(e))}[/bold red]")
+            raise

--- a/src/trackers/UNIT3D/hawkeuno.py
+++ b/src/trackers/UNIT3D/hawkeuno.py
@@ -126,14 +126,14 @@ class HawkeUno(UNIT3D):
                     if encoding_settings:
                         crf_match = re.search(r"crf[ =:]+([\d.]+)", encoding_settings, re.IGNORECASE)
                         if crf_match:
-                            logger.debug(f"Found CRF value: {crf_match.group(1)}")
+                            logger.debug(f"{self.tracker}: Found CRF value: {crf_match.group(1)}")
                             crf_value = float(crf_match.group(1))
                             if crf_value > 22:
                                 if not meta.unattended:
-                                    logger.info(f"CRF value too high: {crf_value} for HawkeUno")
+                                    logger.info(f"{self.tracker}: CRF value too high: {crf_value} for HawkeUno")
                                 return False
                         else:
-                            logger.debug("No CRF value found in encoding settings.")
+                            logger.debug(f"{self.tracker}: No CRF value found in encoding settings.")
                             bit_rate = track.get("BitRate")
                             if bit_rate and "Animation" not in meta.genre:
                                 try:
@@ -146,7 +146,7 @@ class HawkeUno(UNIT3D):
 
                                     if bit_rate_kbps < 3000:
                                         if not meta.unattended:
-                                            logger.info(f"Video bitrate too low: {bit_rate_kbps:.0f} kbps for HawkeUno")
+                                            logger.info(f"{self.tracker}: Video bitrate too low: {bit_rate_kbps:.0f} kbps for HawkeUno")
                                         return False
 
         return should_continue
@@ -312,7 +312,7 @@ class HawkeUno(UNIT3D):
         url = f"{self.upload_url}?api_token={api_token}"
 
         if meta.debug:
-            logger.debug(f"[cyan]{self.tracker} Request Data:")
+            logger.debug(f"{self.tracker}: [cyan]Request Data:")
             logger.debug(Redaction.redact_private_info(data))
             status_dict["status_message"] = "Debug mode enabled, not uploading."
             await self.common.create_torrent_for_upload(meta, f"{self.tracker}_DEBUG", f"{self.tracker}_DEBUG", announce_url="https://fake.tracker")
@@ -336,15 +336,15 @@ class HawkeUno(UNIT3D):
                     return True
                 error_msg = response_json.get("message", "Unknown error")
                 status_dict["status_message"] = f"data error: API error: {error_msg}"
-                logger.info(f"[yellow]Upload to {self.tracker} failed: {error_msg}[/yellow]")
+                logger.info(f"{self.tracker}: [yellow]Upload to {self.tracker} failed: {error_msg}[/yellow]")
                 return False
 
         except httpx.HTTPStatusError as e:
             msg = f"HTTP {e.response.status_code} - {e.response.text}"
             status_dict["status_message"] = f"data error: {msg}"
-            logger.info(f"[bold red]{self.tracker} Upload error: {msg}[/bold red]")
+            logger.info(f"{self.tracker}: [bold red]Upload error: {msg}[/bold red]")
             return False
         except Exception as e:
             status_dict["status_message"] = f"data error: {e}"
-            logger.info(f"[bold red]{self.tracker} Upload unexpected error: {e}[/bold red]")
+            logger.info(f"{self.tracker}: [bold red]Upload unexpected error: {e}[/bold red]")
             return False

--- a/src/trackers/UNIT3D/homiehelpdesk.py
+++ b/src/trackers/UNIT3D/homiehelpdesk.py
@@ -85,7 +85,7 @@ class HomieHelpDesk(UNIT3D):
     async def get_additional_checks(self, meta: Meta) -> bool:
         should_continue = True
         if meta.type == "DVDRIP":
-            logger.info(f"{self.tracker}: [bold red]DVDRIP uploads are not allowed on HomieHelpDesk.[/bold red]")
+            logger.info(f"{self.tracker}: [bold red]DVDRIP uploads are not allowed on {self.tracker}.[/bold red]")
             return False
 
         return should_continue

--- a/src/trackers/UNIT3D/homiehelpdesk.py
+++ b/src/trackers/UNIT3D/homiehelpdesk.py
@@ -85,7 +85,7 @@ class HomieHelpDesk(UNIT3D):
     async def get_additional_checks(self, meta: Meta) -> bool:
         should_continue = True
         if meta.type == "DVDRIP":
-            logger.info("[bold red]DVDRIP uploads are not allowed on HomieHelpDesk.[/bold red]")
+            logger.info(f"{self.tracker}: [bold red]DVDRIP uploads are not allowed on HomieHelpDesk.[/bold red]")
             return False
 
         return should_continue

--- a/src/trackers/UNIT3D/infinityhd.py
+++ b/src/trackers/UNIT3D/infinityhd.py
@@ -152,12 +152,12 @@ class InfinityHD(UNIT3D):
     async def get_additional_checks(self, meta: Meta) -> bool:
         if meta.resolution not in ["4320p", "2160p", "1440p", "1080p", "1080i"]:
             if not meta.unattended or meta.debug:
-                logger.info(f"[bold red]Uploads must be at least 1080 resolution for {self.tracker}.[/bold red]")
+                logger.info(f"{self.tracker}: [bold red]Uploads must be at least 1080 resolution for {self.tracker}.[/bold red]")
             return False
 
         if not meta.valid_mi_settings:
             if not meta.unattended or meta.debug:
-                logger.info(f"[bold red]No encoding settings in mediainfo, skipping {self.tracker} upload.[/bold red]")
+                logger.info(f"{self.tracker}: [bold red]No encoding settings in mediainfo, skipping {self.tracker} upload.[/bold red]")
             return False
 
         if meta.is_disc != "BDMV":
@@ -183,7 +183,7 @@ class InfinityHD(UNIT3D):
             # Require at least one English audio/subtitle track or an original language audio track
             if not (original_language or has_eng_audio or has_eng_subs):
                 if not meta.unattended or meta.debug:
-                    logger.info(f"[bold red]{self.tracker} requires at least one English audio or subtitle track or an original language audio track.")
+                    logger.info(f"{self.tracker}: [bold red]requires at least one English audio or subtitle track or an original language audio track.")
                 return False
 
         return self.common.check_and_confirm_adult_media_upload(meta, self.tracker)

--- a/src/trackers/UNIT3D/itatorrents.py
+++ b/src/trackers/UNIT3D/itatorrents.py
@@ -146,11 +146,11 @@ class ItaTorrents(UNIT3D):
         try:
             itt_name = " ".join(itt_name.split())
         except Exception:
-            logger.info("[bold red]Unable to generate name. Please re-run and correct any of the following args if needed.")
-            logger.info(f"--category [yellow]{meta.category}")
-            logger.info(f"--type [yellow]{meta.type}")
-            logger.info(f"--source [yellow]{meta.source}")
-            logger.info("[bold green]If you specified type, try also specifying source")
+            logger.info(f"{self.tracker}: [bold red]Unable to generate name. Please re-run and correct any of the following args if needed.")
+            logger.info(f"{self.tracker}: --category [yellow]{meta.category}")
+            logger.info(f"{self.tracker}: --type [yellow]{meta.type}")
+            logger.info(f"{self.tracker}: --source [yellow]{meta.source}")
+            logger.info(f"{self.tracker}: [bold green]If you specified type, try also specifying source")
 
             exit()
         name_notag = itt_name
@@ -178,6 +178,6 @@ class ItaTorrents(UNIT3D):
         # Translates to "Films and TV series that do not include Italian dubbing are not permitted."
         italian_languages = ["italian", "italiano"]
         if not await self.common.check_language_requirements(meta, self.tracker, languages_to_check=italian_languages, check_audio=True):
-            logger.info("Upload Rules: https://itatorrents.xyz/wikis/5")
+            logger.info(f"{self.tracker}: Upload Rules: https://itatorrents.xyz/wikis/5")
             return False
         return True

--- a/src/trackers/UNIT3D/itatorrents.py
+++ b/src/trackers/UNIT3D/itatorrents.py
@@ -2,6 +2,8 @@
 import re
 from typing import Any
 
+from rich.markup import escape
+
 from src.console import logger
 from src.languages import languages_manager
 from src.meta import Meta
@@ -147,9 +149,9 @@ class ItaTorrents(UNIT3D):
             itt_name = " ".join(itt_name.split())
         except Exception:
             logger.info(f"{self.tracker}: [bold red]Unable to generate name. Please re-run and correct any of the following args if needed.")
-            logger.info(f"{self.tracker}: --category [yellow]{meta.category}")
-            logger.info(f"{self.tracker}: --type [yellow]{meta.type}")
-            logger.info(f"{self.tracker}: --source [yellow]{meta.source}")
+            logger.info(f"{self.tracker}: --category [yellow]{escape(str(meta.category))}")
+            logger.info(f"{self.tracker}: --type [yellow]{escape(str(meta.type))}")
+            logger.info(f"{self.tracker}: --source [yellow]{escape(str(meta.source))}")
             logger.info(f"{self.tracker}: [bold green]If you specified type, try also specifying source")
 
             exit()

--- a/src/trackers/UNIT3D/lst.py
+++ b/src/trackers/UNIT3D/lst.py
@@ -39,7 +39,7 @@ class LST(UNIT3D):
 
         should_continue = True
         if not meta.valid_mi_settings:
-            logger.info(f"[bold red]No encoding settings in mediainfo, skipping {self.tracker} upload.[/bold red]")
+            logger.info(f"{self.tracker}: [bold red]No encoding settings in mediainfo, skipping {self.tracker} upload.[/bold red]")
             return False
 
         if meta.is_disc not in ["BDMV", "DVD"] and not await self.common.check_language_requirements(

--- a/src/trackers/UNIT3D/luminarr.py
+++ b/src/trackers/UNIT3D/luminarr.py
@@ -45,7 +45,7 @@ class Luminarr(UNIT3D):
 
         if meta.is_disc not in ["BDMV", "DVD"] and meta.resolution not in ["8640p", "4320p", "2160p", "1440p", "1080p", "1080i", "720p"]:
             if not meta.unattended or (meta.unattended and meta.unattended_confirm):
-                logger.info(f"[bold red]{self.tracker} only allows SD releases when the content does not have a higher resolution release.[/bold red]")
+                logger.info(f"{self.tracker}: [bold red]only allows SD releases when the content does not have a higher resolution release.[/bold red]")
                 if cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
                     pass
                 else:
@@ -54,11 +54,11 @@ class Luminarr(UNIT3D):
                 return False
 
         if not meta.is_disc and meta.container != "mkv":
-            logger.info(f"[bold red]{self.tracker} only allows MKV containers for non-disc uploads.[/bold red]")
+            logger.info(f"{self.tracker}: [bold red]only allows MKV containers for non-disc uploads.[/bold red]")
             return False
 
         if not meta.valid_mi_settings:
-            logger.info(f"[bold red]No encoding settings in mediainfo, skipping {self.tracker} upload.[/bold red]")
+            logger.info(f"{self.tracker}: [bold red]No encoding settings in mediainfo, skipping {self.tracker} upload.[/bold red]")
             return False
 
         return self.common.check_and_confirm_adult_media_upload(meta, self.tracker)

--- a/src/trackers/UNIT3D/oldtoonsworld.py
+++ b/src/trackers/UNIT3D/oldtoonsworld.py
@@ -112,7 +112,7 @@ class OldToonsWorld(UNIT3D):
 
         if not any(genre in combined_genres for genre in ["Animation", "Family"]):
             if not meta.unattended or (meta.unattended and meta.unattended_confirm):
-                logger.info("[bold red]Genre does not match Animation or Family for OldToonsWorld.")
+                logger.info(f"{self.tracker}: [bold red]Genre does not match Animation or Family for OldToonsWorld.")
                 if cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
                     pass
                 else:
@@ -126,7 +126,7 @@ class OldToonsWorld(UNIT3D):
         adult_keywords = ["xxx", "erotic", "porn", "adult", "orgy", "hentai", "adult animation", "softcore"]
         if any(re.search(rf"(^|,\s*){re.escape(keyword)}(\s*,|$)", genres, re.IGNORECASE) for keyword in adult_keywords):
             if not meta.unattended or (meta.unattended and meta.unattended_confirm):
-                logger.info("[bold red]Adult animation not allowed at OldToonsWorld.")
+                logger.info(f"{self.tracker}: [bold red]Adult animation not allowed at OldToonsWorld.")
                 if cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
                     pass
                 else:
@@ -137,7 +137,7 @@ class OldToonsWorld(UNIT3D):
         game_show_keywords = ["reality", "game show", "game-show", "reality tv", "reality television"]
         if any(re.search(rf"(^|,\s*){re.escape(keyword)}(\s*,|$)", genres, re.IGNORECASE) for keyword in game_show_keywords):
             if not meta.unattended or (meta.unattended and meta.unattended_confirm):
-                logger.info("[bold red]Reality / Game Show content not allowed at OldToonsWorld.")
+                logger.info(f"{self.tracker}: [bold red]Reality / Game Show content not allowed at OldToonsWorld.")
                 if cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
                     pass
                 else:
@@ -147,7 +147,7 @@ class OldToonsWorld(UNIT3D):
 
         if meta.type not in ["WEBDL"] and not meta.is_disc and meta.tag in ["CMRG", "EVO", "TERMiNAL", "ViSION"]:
             if not meta.unattended or (meta.unattended and meta.unattended_confirm):
-                logger.info(f"[bold red]Group {meta.tag} is only allowed for raw type content at OldToonsWorld[/bold red]")
+                logger.info(f"{self.tracker}: [bold red]Group {meta.tag} is only allowed for raw type content at OldToonsWorld[/bold red]")
                 if cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
                     pass
                 else:

--- a/src/trackers/UNIT3D/onlyencodes.py
+++ b/src/trackers/UNIT3D/onlyencodes.py
@@ -238,7 +238,7 @@ class OnlyEncodes(UNIT3D):
                     desc = desc + str(tonemapped_header)
                     desc = desc + "\n\n"
             except Exception as e:
-                logger.warning(f"[yellow]Warning: Error setting tonemapped header: {e!s}[/yellow]")
+                logger.warning(f"{self.tracker}: [yellow]Warning: Error setting tonemapped header: {e!s}[/yellow]")
             desc = desc.replace("[img]", "[img=300]")
             await descfile.write(desc)
             images_value = meta.get(f"{self.tracker}_images_key", meta.image_list)

--- a/src/trackers/UNIT3D/seedpool.py
+++ b/src/trackers/UNIT3D/seedpool.py
@@ -112,7 +112,7 @@ class Seedpool(UNIT3D):
     async def get_additional_checks(self, meta: Meta) -> bool:
         resolution = meta.resolution
         if resolution not in ["8640p", "4320p", "2160p", "1440p", "1080p", "1080i"]:
-            logger.info(f"[bold red]Only 1080 or higher resolutions allowed at {self.tracker}.[/bold red]")
+            logger.info(f"{self.tracker}: [bold red]Only 1080 or higher resolutions allowed at {self.tracker}.[/bold red]")
             if not meta.unattended or (bool(meta.unattended) and meta.unattended_confirm):
                 if cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
                     pass
@@ -131,7 +131,7 @@ class Seedpool(UNIT3D):
             combined_genres = [str(g) for g in cast(list[Any], combined_genres_val)]
         if any(keyword.lower() in disallowed_keywords for keyword in keywords) or any(genre.lower() in disallowed_genres for genre in combined_genres):
             if not meta.unattended or (bool(meta.unattended) and meta.unattended_confirm):
-                logger.info(f"[bold red]Porn/xxx is not allowed at {self.tracker}.[/bold red]")
+                logger.info(f"{self.tracker}: [bold red]Porn/xxx is not allowed at {self.tracker}.[/bold red]")
                 if cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
                     pass
                 else:

--- a/src/trackers/UNIT3D/shareisland.py
+++ b/src/trackers/UNIT3D/shareisland.py
@@ -295,7 +295,7 @@ class ShareIsland(UNIT3D):
                     region_name = region_name.strip().upper() if region_name else None
                     if region_name:
                         break
-                    logger.info("Region code is required.", extra={"markup": False})
+                    logger.info(f"{self.tracker}: Region code is required.", extra={"markup": False})
 
             # Validate region name was provided
             if not region_name:
@@ -748,7 +748,7 @@ class ShareIsland(UNIT3D):
                         if not logo_url and fallback_logo:
                             logo_url = f"https://image.tmdb.org/t/p/w300{fallback_logo}"
         except Exception as e:
-            logger.info(f"[DEBUG] TMDb fetch error: {e}", extra={"markup": False})
+            logger.info(f"{self.tracker}: [DEBUG] TMDb fetch error: {e}", extra={"markup": False})
 
         return summary, logo_url
 
@@ -924,7 +924,7 @@ class ShareIsland(UNIT3D):
                 "subs": subs,
             }
         except Exception as e:
-            logger.info(f"[DEBUG] Mediainfo extraction error: {e}", extra={"markup": False})
+            logger.info(f"{self.tracker}: [DEBUG] Mediainfo extraction error: {e}", extra={"markup": False})
             import traceback
 
             traceback.print_exc()

--- a/src/trackers/UNIT3D/skipthecommercials.py
+++ b/src/trackers/UNIT3D/skipthecommercials.py
@@ -57,14 +57,14 @@ class SkipTheCommercials(UNIT3D):
     async def get_additional_checks(self, meta: Meta) -> bool:
         if str(meta.category) != "TV":
             if not meta.unattended:
-                logger.info(f"[bold red]Only TV uploads allowed at {self.tracker}.[/bold red]")
+                logger.info(f"{self.tracker}: [bold red]Only TV uploads allowed at {self.tracker}.[/bold red]")
             return False
 
         genres = f"{', '.join(meta.keywords)} {meta.combined_genres}"
         adult_keywords = ["xxx", "erotic", "porn", "adult", "orgy", "hentai", "adult animation", "softcore"]
         if any(re.search(rf"(^|,\s*){re.escape(keyword)}(\s*,|$)", genres, re.IGNORECASE) for keyword in adult_keywords):
             if not meta.unattended or (bool(meta.unattended) and meta.unattended_confirm):
-                logger.info(f"[bold red]Porn is not allowed at {self.tracker}.[/bold red]")
+                logger.info(f"{self.tracker}: [bold red]Porn is not allowed at {self.tracker}.[/bold red]")
                 if cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
                     pass
                 else:

--- a/src/trackers/UNIT3D/theldu.py
+++ b/src/trackers/UNIT3D/theldu.py
@@ -175,7 +175,7 @@ class LastDigitalUnderground(UNIT3D):
                         non_eng_audio = True
                     break
                 except (LookupError, AttributeError, ValueError) as e:
-                    logger.info(f"[bold red]Error extracting audio language: {e}[/bold red]")
+                    logger.info(f"{self.tracker}: [bold red]Error extracting audio language: {e}[/bold red]")
 
         if meta.no_subs:
             iso_subtitle = "NoSubs"
@@ -192,7 +192,7 @@ class LastDigitalUnderground(UNIT3D):
                         iso_subtitle = f"Subs {lang.upper()}"
                         break
                     except (LookupError, AttributeError, ValueError) as e:
-                        logger.info(f"[bold red]Error extracting subtitle language: {e}[/bold red]")
+                        logger.info(f"{self.tracker}: [bold red]Error extracting subtitle language: {e}[/bold red]")
 
         if cat_id == "18" and iso_subtitle:
             ldu_name = f"{ldu_name} [{iso_subtitle}]"

--- a/src/trackers/UNIT3D/theldu.py
+++ b/src/trackers/UNIT3D/theldu.py
@@ -3,6 +3,7 @@ import re
 from typing import Any, cast
 
 import langcodes
+from rich.markup import escape
 
 from src.console import logger
 from src.languages import languages_manager
@@ -175,7 +176,7 @@ class LastDigitalUnderground(UNIT3D):
                         non_eng_audio = True
                     break
                 except (LookupError, AttributeError, ValueError) as e:
-                    logger.info(f"{self.tracker}: [bold red]Error extracting audio language: {e}[/bold red]")
+                    logger.info(f"{self.tracker}: [bold red]Error extracting audio language: {escape(str(e))}[/bold red]")
 
         if meta.no_subs:
             iso_subtitle = "NoSubs"
@@ -192,7 +193,7 @@ class LastDigitalUnderground(UNIT3D):
                         iso_subtitle = f"Subs {lang.upper()}"
                         break
                     except (LookupError, AttributeError, ValueError) as e:
-                        logger.info(f"{self.tracker}: [bold red]Error extracting subtitle language: {e}[/bold red]")
+                        logger.info(f"{self.tracker}: [bold red]Error extracting subtitle language: {escape(str(e))}[/bold red]")
 
         if cat_id == "18" and iso_subtitle:
             ldu_name = f"{ldu_name} [{iso_subtitle}]"

--- a/src/trackers/UNIT3D/theoldschool.py
+++ b/src/trackers/UNIT3D/theoldschool.py
@@ -121,7 +121,7 @@ class TheOldSchool(UNIT3D):
             require_both=False,
             original_language=True,
         ):
-            logger.info(f"[bold red]Language requirements not met for {self.tracker}.[/bold red]")
+            logger.info(f"{self.tracker}: [bold red]Language requirements not met for {self.tracker}.[/bold red]")
             return False
 
         # Check if it's a Scene release without NFO - TheOldSchool requires NFO for Scene releases
@@ -129,6 +129,6 @@ class TheOldSchool(UNIT3D):
         has_nfo = meta.nfo or meta.auto_nfo
 
         if is_scene and not has_nfo:
-            logger.info(f"[red]{self.tracker}: Scene release detected but no NFO file found. TheOldSchool requires NFO files for Scene releases.[/red]")
+            logger.info(f"{self.tracker}: [red]Scene release detected but no NFO file found. TheOldSchool requires NFO files for Scene releases.[/red]")
             return False
         return True

--- a/src/trackers/UNIT3D/theoldschool.py
+++ b/src/trackers/UNIT3D/theoldschool.py
@@ -129,6 +129,6 @@ class TheOldSchool(UNIT3D):
         has_nfo = meta.nfo or meta.auto_nfo
 
         if is_scene and not has_nfo:
-            logger.info(f"{self.tracker}: [red]Scene release detected but no NFO file found. TheOldSchool requires NFO files for Scene releases.[/red]")
+            logger.info(f"{self.tracker}: [red]Scene release detected but no NFO file found. {self.tracker} requires NFO files for Scene releases.[/red]")
             return False
         return True

--- a/src/trackers/UNIT3D/torrenteros.py
+++ b/src/trackers/UNIT3D/torrenteros.py
@@ -45,9 +45,9 @@ class Torrenteros(UNIT3D):
 
         def ask_spanish_type(kind: str) -> str:
             logger.info(f"{self.tracker}: [green]Found Spanish {kind} track.[/green] [yellow]Is it Castellano or Latino?[/yellow]")
-            logger.info("1 = Castellano")
-            logger.info("2 = Latino")
-            logger.info("3 = Castellano Latino")
+            logger.info(f"{self.tracker}: 1 = Castellano")
+            logger.info(f"{self.tracker}: 2 = Latino")
+            logger.info(f"{self.tracker}: 3 = Castellano Latino")
             return str(cli_ui.ask_string("Enter choice (1-3): "))
 
         def get_spanish_type(lang_code: str) -> str | None:
@@ -135,7 +135,7 @@ class Torrenteros(UNIT3D):
 
         if "Spanish" not in (meta.audio_languages or []):
             if "Spanish" not in (meta.subtitle_languages or []):
-                logger.info("[bold red]Torrenteros requires at least one Spanish audio or subtitle track.")
+                logger.info(f"{self.tracker}: [bold red]requires at least one Spanish audio or subtitle track.")
                 return False
             if meta.unattended:
                 if not meta.unattended_confirm:

--- a/src/trackers/UNIT3D/yuscene.py
+++ b/src/trackers/UNIT3D/yuscene.py
@@ -86,7 +86,7 @@ class YUSCENE(UNIT3D):
         adult_keywords = ["xxx", "erotic", "porn", "adult", "orgy", "hentai", "adult animation", "softcore"]
         if any(re.search(rf"(^|,\s*){re.escape(keyword)}(\s*,|$)", genres, re.IGNORECASE) for keyword in adult_keywords):
             if not meta.unattended or (meta.unattended and meta.unattended_confirm):
-                logger.info(f"{self.tracker}: [bold red]Porn/xxx is not allowed at YUSCENE.")
+                logger.info(f"{self.tracker}: [bold red]Porn/xxx is not allowed at {self.tracker}.[/bold red]")
                 if cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
                     pass
                 else:

--- a/src/trackers/UNIT3D/yuscene.py
+++ b/src/trackers/UNIT3D/yuscene.py
@@ -86,7 +86,7 @@ class YUSCENE(UNIT3D):
         adult_keywords = ["xxx", "erotic", "porn", "adult", "orgy", "hentai", "adult animation", "softcore"]
         if any(re.search(rf"(^|,\s*){re.escape(keyword)}(\s*,|$)", genres, re.IGNORECASE) for keyword in adult_keywords):
             if not meta.unattended or (meta.unattended and meta.unattended_confirm):
-                logger.info("[bold red]Porn/xxx is not allowed at YUSCENE.")
+                logger.info(f"{self.tracker}: [bold red]Porn/xxx is not allowed at YUSCENE.")
                 if cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
                     pass
                 else:

--- a/src/trackers/USENET/curupira.py
+++ b/src/trackers/USENET/curupira.py
@@ -319,7 +319,7 @@ class Curupira:
                 async with aiofiles.open(info_file_path, encoding="utf-8") as f:
                     return await f.read()
             except Exception as e:
-                logger.info(f"[bold red]Erro ao ler o arquivo de info em {info_file_path}: {e}[/bold red]")
+                logger.info(f"{self.tracker}: [bold red]Erro ao ler o arquivo de info em {info_file_path}: {e}[/bold red]")
                 return ""
         else:
             logger.info(f"[bold red]Arquivo de info não encontrado: {info_file_path}[/bold red]")
@@ -446,19 +446,19 @@ class Curupira:
 
         files = await self._prepare_files(meta)
         if not files:
-            logger.error(f"[red]Error: NZB file not found for {self.tracker}.[/red]")
+            logger.error(f"{self.tracker}: [red]Error: NZB file not found for {self.tracker}.[/red]")
             status_dict["status_message"] = "data error: NZB file not found"
             return False
 
         data = await self._prepare_data(meta)
 
         if meta.debug:
-            logger.debug("[cyan]Curupira Upload (DEBUG MODE):[/cyan]")
-            logger.debug(f"URL: {self.upload_url}")
-            logger.debug(f"Category ID: {self.get_category_id(meta)}")
-            logger.debug("Fields:")
+            logger.debug(f"{self.tracker}: [cyan]Upload (DEBUG MODE):[/cyan]")
+            logger.debug(f"{self.tracker}: URL: {self.upload_url}")
+            logger.debug(f"{self.tracker}: Category ID: {self.get_category_id(meta)}")
+            logger.debug(f"{self.tracker}: Fields:")
             logger.debug(Redaction.redact_private_info(data))
-            logger.debug("Files:")
+            logger.debug(f"{self.tracker}: Files:")
             logger.debug({k: v[0] for k, v in files.items()})
 
             status_dict["status_message"] = "Debug mode enabled, skipping upload."

--- a/src/trackers/USENET/suio.py
+++ b/src/trackers/USENET/suio.py
@@ -72,7 +72,7 @@ class Suio:
                     self.upload_url = None
                     self.torrent_url = None
                     self.search_url = None
-                    logger.info(f"{self.tracker} [red]base_url from config.py does not match the expected domain. Skipping...[/red]")
+                    logger.info(f"{self.tracker}: [red]base_url from config.py does not match the expected domain. Skipping...[/red]")
             except Exception:
                 self.upload_url = None
                 self.torrent_url = None
@@ -417,7 +417,7 @@ class Suio:
         status_dict = status_map[self.tracker]
 
         if not self.upload_url:
-            logger.info(f"[red]{self.tracker}: base_url missing. Cannot upload.[/red]")
+            logger.info(f"{self.tracker}: [red]base_url missing. Cannot upload.[/red]")
             status_dict["status_message"] = "data error: base_url missing"
             return False
 
@@ -430,11 +430,11 @@ class Suio:
 
         data = await self._prepare_data(meta)
         if meta.debug:
-            logger.debug(f"[cyan]{self.tracker} Upload (DEBUG MODE):[/cyan]")
-            logger.debug(f"User: {username}")
-            logger.debug("Fields:")
+            logger.debug(f"{self.tracker}: [cyan]Upload (DEBUG MODE):[/cyan]")
+            logger.debug(f"{self.tracker}: User: {username}")
+            logger.debug(f"{self.tracker}: Fields:")
             logger.debug(Redaction.redact_private_info(data))
-            logger.debug("Files:")
+            logger.debug(f"{self.tracker}: Files:")
             logger.debug({k: v[0] for k, v in files.items()})
             status_dict["status_message"] = "Debug mode enabled, skipping upload."
             return True

--- a/src/trackers/alpharatio.py
+++ b/src/trackers/alpharatio.py
@@ -185,8 +185,8 @@ class AlphaRatio:
                     full_mediainfo = await mi_file.read()
                 description += f"[hide=FULL MEDIAINFO][code]{full_mediainfo}[/code][/hide]\n"
             else:
-                logger.info("[bold red]Couldn't find the MediaInfo template")
-                logger.info("[green]Using normal MediaInfo for the description.")
+                logger.info(f"{self.tracker}: [bold red]Couldn't find the MediaInfo template")
+                logger.info(f"{self.tracker}: [green]Using normal MediaInfo for the description.")
 
                 async with aiofiles.open(f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/MEDIAINFO_CLEANPATH.txt", encoding="utf-8") as mi_file:
                     cleaned_mediainfo = await mi_file.read()
@@ -231,7 +231,7 @@ class AlphaRatio:
                         if not has_eng_audio:
                             audio_lang = mi["media"]["track"][2].get("Language_String", "").upper()
             except Exception as e:
-                logger.error(f"[red]Error: {e}")
+                logger.error(f"{self.tracker}: [red]Error: {e}")
         else:
             for audio in meta.bdinfo["audio"]:
                 if audio["language"] == "English":
@@ -258,14 +258,14 @@ class AlphaRatio:
         title = meta.title.strip()
         year = str(meta.year).strip() if meta.year is not None else ""
         if not title:
-            logger.info("[red]Title is missing.")
+            logger.info(f"{self.tracker}: [red]Title is missing.")
             return dupes
 
         search_query = f"{title} {year}".strip()
         search_query_encoded = urllib.parse.quote(search_query)
         search_url = f"{self.base_url}/ajax.php?action=browse&searchstr={search_query_encoded}"
 
-        logger.debug(f"[blue]{search_url}")
+        logger.debug(f"{self.tracker}: [blue]{search_url}")
 
         headers = {"User-Agent": f"{meta.ua_name} {(meta.current_version if meta.current_version is not None else 'github.com/wastaken7/Upload-Assistant')}"}
 
@@ -338,7 +338,7 @@ class AlphaRatio:
                             logger.info(f"{self.tracker}: [green]Auth key saved for future use[/green]")
                         return auth_key
         except Exception as e:
-            logger.error(f"[red]Error extracting auth key: {e}")
+            logger.error(f"{self.tracker}: [red]Error extracting auth key: {e}")
 
         return None
 
@@ -365,7 +365,7 @@ class AlphaRatio:
         while cover is None and not meta.unattended:
             cover = Prompt.ask("No Cover was found. Please input a link to a cover:", default="")
             if not re.match(r"https?://.*\.(jpg|png|gif)$", cover):
-                logger.info("[red]Invalid image link. Please enter a link that ends with .jpg, .png, or .gif.")
+                logger.info(f"{self.tracker}: [red]Invalid image link. Please enter a link that ends with .jpg, .png, or .gif.")
                 cover = None
 
         # Tag Compilation

--- a/src/trackers/amigosshare.py
+++ b/src/trackers/amigosshare.py
@@ -621,7 +621,7 @@ class AmigosShare:
                 filename = first_content.strip() if isinstance(first_content, str) else first_content.get_text(strip=True)
 
         except Exception as e:
-            logger.info(f"[bold red]Falha ao obter nome do arquivo para ID {torrent_id}: {e}[/bold red]")
+            logger.info(f"{self.tracker}: [bold red]Falha ao obter nome do arquivo para ID {torrent_id}: {e}[/bold red]")
 
         return {"name": filename, "size": size, "link": torrent_link}
 
@@ -1080,7 +1080,7 @@ class AmigosShare:
             return results
 
         except Exception as e:
-            logger.info(f"[bold red]Ocorreu um erro ao buscar pedido(s) no {self.tracker}: {e}[/bold red]")
+            logger.info(f"{self.tracker}: [bold red]Ocorreu um erro ao buscar pedido(s) no {self.tracker}: {e}[/bold red]")
             import traceback
 
             logger.info(traceback.format_exc())

--- a/src/trackers/anthelion.py
+++ b/src/trackers/anthelion.py
@@ -8,6 +8,7 @@ from typing import Any
 import aiofiles
 import cli_ui
 import httpx
+from rich.markup import escape
 
 from cogs.redaction import Redaction
 from src.console import logger
@@ -367,8 +368,8 @@ class Anthelion:
             error_type = type(e).__name__
             error_msg = str(e) if str(e) else "No error message"
             traceback_str = traceback.format_exc()
-            logger.info(f"{self.tracker}: [bold red]upload exception ({error_type}): {error_msg}[/bold red]")
-            logger.info(f"{self.tracker}: [red]Traceback:\n{traceback_str}[/red]")
+            logger.info(f"{self.tracker}: [bold red]upload exception ({error_type}): {escape(error_msg)}[/bold red]")
+            logger.info(f"{self.tracker}: [red]Traceback:\n{escape(traceback_str)}[/red]")
             meta.tracker_status[self.tracker]["status_message"] = "data error: double check if it uploaded"
             return False
 
@@ -462,7 +463,7 @@ class Anthelion:
 
             for each in data.get("item", []):
                 if target_resolution and each.get("resolution", "").lower() != target_resolution.lower():
-                    logger.debug(f"{self.tracker}: [yellow]Skipping {each.get('fileName')} - resolution mismatch: {each.get('resolution')} vs {target_resolution}")
+                    logger.debug(f"{self.tracker}: [yellow]Skipping {escape(each.get('fileName'))} - resolution mismatch: {each.get('resolution')} vs {target_resolution}")
                     continue
 
                 largest_file = None
@@ -486,7 +487,7 @@ class Anthelion:
                 }
                 dupes.append(result)
 
-                logger.debug(f"{self.tracker}: [green]Found potential dupe: {result['name']} ({result['size']} bytes)")
+                logger.debug(f"{self.tracker}: [green]Found potential dupe: {escape(result['name'])} ({result['size']} bytes)")
 
         return dupes
 
@@ -556,7 +557,7 @@ class Anthelion:
                             if tmdb_id and str(tmdb_id).isdigit() and int(tmdb_id) != 0:
                                 imdb_tmdb_list.append({"tmdb_id": int(tmdb_id)})
                     except json.JSONDecodeError:
-                        logger.info(f"{self.tracker}: [bold yellow]Error parsing JSON response from ANTHELION")
+                        logger.info(f"{self.tracker}: [bold yellow]Error parsing JSON response from {self.tracker}")
                         imdb_tmdb_list = []
                 else:
                     logger.info(f"{self.tracker}: [bold red]Failed to search torrents. HTTP Status: {response.status_code}")
@@ -565,10 +566,10 @@ class Anthelion:
             logger.info(f"{self.tracker}: [bold red]Request timed out after 5 seconds")
             imdb_tmdb_list = []
         except httpx.RequestError as e:
-            logger.info(f"{self.tracker}: [bold red]Unable to search for existing torrents: {e}")
+            logger.info(f"{self.tracker}: [bold red]Unable to search for existing torrents: {escape(str(e))}")
             imdb_tmdb_list = []
         except Exception as e:
-            logger.error(f"{self.tracker}: [bold red]Unexpected error: {e}")
+            logger.error(f"{self.tracker}: [bold red]Unexpected error: {escape(str(e))}")
             imdb_tmdb_list = []
 
         return imdb_tmdb_list

--- a/src/trackers/anthelion.py
+++ b/src/trackers/anthelion.py
@@ -186,18 +186,18 @@ class Anthelion:
             tags = [tag for tag in tags if tag.lower() in allowed_tags]
 
             if tags:
-                logger.info(f"[green]{self.tracker}: Using IMDb genres for tagging: {', '.join(tags)}")
+                logger.info(f"{self.tracker}: [green]Using IMDb genres for tagging: {', '.join(tags)}")
                 logger.info(
-                    "[yellow]ANTHELION api will accept this upload, but no tag will be added.\nYou must manually add at least one tag from the approved list when uploaded."
+                    f"{self.tracker}: [yellow]api will accept this upload, but no tag will be added.\nYou must manually add at least one tag from the approved list when uploaded."
                 )
                 await asyncio.sleep(3)
                 meta.ant_user_tags = True
 
         if not tags:
-            logger.info(f"[yellow]{self.tracker}: No genres found for tagging. Tag required.")
-            logger.info("[yellow]Only use a tag in the approved list found in the site search box.")
+            logger.info(f"{self.tracker}: [yellow]No genres found for tagging. Tag required.")
+            logger.info(f"{self.tracker}: [yellow]Only use a tag in the approved list found in the site search box.")
             logger.info(
-                "[yellow]ANTHELION api will accept this upload, but no tag will be added.\nYou must manually add at least one tag from the approved list when uploaded."
+                f"{self.tracker}: [yellow]api will accept this upload, but no tag will be added.\nYou must manually add at least one tag from the approved list when uploaded."
             )
             await asyncio.sleep(3)
             user_tag = cli_ui.ask_string("Please enter at least one tag (genre) to use for the upload", default="")
@@ -240,7 +240,7 @@ class Anthelion:
                 type_map = {"Feature Film": 0, "Short Film": 1, "Miniseries": 2, "Other": 3}
                 ant_type = type_map.get(choice, 0)
             else:
-                logger.debug(f"[bold red]{self.tracker} type could not be determined automatically in unattended mode.")
+                logger.debug(f"{self.tracker}: [bold red]type could not be determined automatically in unattended mode.")
                 ant_type = 0  # Default to Feature Film in unattended mode
 
         return ant_type
@@ -255,7 +255,7 @@ class Anthelion:
 
         # Trigger regeneration automatically if size constraints aren't met
         if torrent_file_size_kib > 250:  # 250 KiB
-            logger.info("[yellow]Existing .torrent exceeds 250 KiB and will be regenerated to fit constraints.")
+            logger.info(f"{self.tracker}: [yellow]Existing .torrent exceeds 250 KiB and will be regenerated to fit constraints.")
             meta.max_piece_size = 128  # 128 MiB
             await TorrentCreator.create_torrent(meta, str(Path(str(meta.path))), "ANTHELION", tracker_url=tracker_url)
             torrent_filename = "ANTHELION"
@@ -264,7 +264,7 @@ class Anthelion:
         flags = await self.get_flags(meta)
         audioformat = await self.get_audio(meta)
         if not audioformat:
-            logger.info(f"[bold red]{self.tracker} upload aborted due to unsupported audio format.")
+            logger.info(f"{self.tracker}: [bold red]upload aborted due to unsupported audio format.")
             meta.tracker_status[self.tracker]["status_message"] = "data error: upload aborted: unsupported audio format"
             return False
 
@@ -308,7 +308,7 @@ class Anthelion:
 
         if meta.adult_media:
             if not meta.unattended or (meta.unattended and meta.unattended_confirm):
-                logger.info("[bold red]Adult content detected[/bold red]")
+                logger.info(f"{self.tracker}: [bold red]Adult content detected[/bold red]")
                 if cli_ui.ask_yes_no("Are the screenshots safe?", default=False):
                     data.update({"screenshots": "\n".join([x["raw_url"] for x in meta.image_list][:4])})
                     if not meta.ant_user_tags:
@@ -350,7 +350,7 @@ class Anthelion:
                     meta.tracker_status[self.tracker]["status_message"] = f"data error - {response_data}"
                     return False
             else:
-                logger.info("[cyan]ANTHELION Request Data:")
+                logger.info(f"{self.tracker}: [cyan]Request Data:")
                 logger.info(Redaction.redact_private_info(data))
                 meta.tracker_status[self.tracker]["status_message"] = "Debug mode enabled, not uploading."
                 await self.common.create_torrent_for_upload(meta, f"{self.tracker}" + "_DEBUG", f"{self.tracker}" + "_DEBUG", announce_url="https://fake.tracker")
@@ -367,8 +367,8 @@ class Anthelion:
             error_type = type(e).__name__
             error_msg = str(e) if str(e) else "No error message"
             traceback_str = traceback.format_exc()
-            logger.info(f"[bold red]ANTHELION upload exception ({error_type}): {error_msg}[/bold red]")
-            logger.info(f"[red]Traceback:\n{traceback_str}[/red]")
+            logger.info(f"{self.tracker}: [bold red]upload exception ({error_type}): {error_msg}[/bold red]")
+            logger.info(f"{self.tracker}: [red]Traceback:\n{traceback_str}[/red]")
             meta.tracker_status[self.tracker]["status_message"] = "data error: double check if it uploaded"
             return False
 
@@ -432,7 +432,7 @@ class Anthelion:
     async def get_additional_checks(self, meta: Meta) -> bool:
         if meta.valid_mi is False:
             if not meta.unattended:
-                logger.info(f"[bold red]No unique ID in mediainfo, skipping {self.tracker} upload.")
+                logger.info(f"{self.tracker}: [bold red]No unique ID in mediainfo, skipping {self.tracker} upload.")
             return False
 
         return True
@@ -462,7 +462,7 @@ class Anthelion:
 
             for each in data.get("item", []):
                 if target_resolution and each.get("resolution", "").lower() != target_resolution.lower():
-                    logger.debug(f"[yellow]Skipping {each.get('fileName')} - resolution mismatch: {each.get('resolution')} vs {target_resolution}")
+                    logger.debug(f"{self.tracker}: [yellow]Skipping {each.get('fileName')} - resolution mismatch: {each.get('resolution')} vs {target_resolution}")
                     continue
 
                 largest_file = None
@@ -486,7 +486,7 @@ class Anthelion:
                 }
                 dupes.append(result)
 
-                logger.debug(f"[green]Found potential dupe: {result['name']} ({result['size']} bytes)")
+                logger.debug(f"{self.tracker}: [green]Found potential dupe: {result['name']} ({result['size']} bytes)")
 
         return dupes
 
@@ -497,14 +497,14 @@ class Anthelion:
 
         filelist: list[str] = meta.filelist
         if not filelist:
-            logger.debug(f"[yellow]{self.tracker}: No files in filelist, skipping file-based search.")
+            logger.debug(f"{self.tracker}: [yellow]No files in filelist, skipping file-based search.")
             return imdb_tmdb_list
 
         filename: str = Path(filelist[0]).name
 
         api_key = self.tracker_config.get("api_key")
         if not api_key or not isinstance(api_key, str) or not api_key.strip():
-            logger.debug(f"[yellow]{self.tracker}: API key not configured, skipping file-based search.")
+            logger.debug(f"{self.tracker}: [yellow]API key not configured, skipping file-based search.")
             return imdb_tmdb_list
 
         headers = {"X-API-Key": api_key.strip(), "User-Agent": f"Upload Assistant/2.4 ({platform.system()} {platform.release()})"}
@@ -544,7 +544,7 @@ class Anthelion:
                                     break
 
                             if not matched_item:
-                                logger.debug("[yellow]Could not match filename, returning empty list")
+                                logger.debug(f"{self.tracker}: [yellow]Could not match filename, returning empty list")
                                 imdb_tmdb_list = []
 
                         if matched_item:
@@ -556,19 +556,19 @@ class Anthelion:
                             if tmdb_id and str(tmdb_id).isdigit() and int(tmdb_id) != 0:
                                 imdb_tmdb_list.append({"tmdb_id": int(tmdb_id)})
                     except json.JSONDecodeError:
-                        logger.info("[bold yellow]Error parsing JSON response from ANTHELION")
+                        logger.info(f"{self.tracker}: [bold yellow]Error parsing JSON response from ANTHELION")
                         imdb_tmdb_list = []
                 else:
-                    logger.info(f"[bold red]Failed to search torrents. HTTP Status: {response.status_code}")
+                    logger.info(f"{self.tracker}: [bold red]Failed to search torrents. HTTP Status: {response.status_code}")
                     imdb_tmdb_list = []
         except httpx.TimeoutException:
-            logger.info("[bold red]ANTHELION Request timed out after 5 seconds")
+            logger.info(f"{self.tracker}: [bold red]Request timed out after 5 seconds")
             imdb_tmdb_list = []
         except httpx.RequestError as e:
-            logger.info(f"[bold red]Unable to search for existing torrents: {e}")
+            logger.info(f"{self.tracker}: [bold red]Unable to search for existing torrents: {e}")
             imdb_tmdb_list = []
         except Exception as e:
-            logger.error(f"[bold red]Unexpected error: {e}")
+            logger.error(f"{self.tracker}: [bold red]Unexpected error: {e}")
             imdb_tmdb_list = []
 
         return imdb_tmdb_list

--- a/src/trackers/anthelion.py
+++ b/src/trackers/anthelion.py
@@ -351,7 +351,7 @@ class Anthelion:
                     meta.tracker_status[self.tracker]["status_message"] = f"data error - {response_data}"
                     return False
             else:
-                logger.info(f"{self.tracker}: [cyan]Request Data:")
+                logger.info(f"{self.tracker}: Request Data:")
                 logger.info(Redaction.redact_private_info(data))
                 meta.tracker_status[self.tracker]["status_message"] = "Debug mode enabled, not uploading."
                 await self.common.create_torrent_for_upload(meta, f"{self.tracker}" + "_DEBUG", f"{self.tracker}" + "_DEBUG", announce_url="https://fake.tracker")

--- a/src/trackers/beyondhd.py
+++ b/src/trackers/beyondhd.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 import aiofiles
 import cli_ui
 import httpx
+from rich.markup import escape
 
 from cogs.redaction import Redaction
 from src.console import logger
@@ -170,14 +171,14 @@ class BEYONDHD:
                     response = await client.post(url=url, files=files, data=data, headers=headers)
                     response_json = cast(dict[str, Any], response.json())
                     if int(response_json["status_code"]) == 0:
-                        logger.info(f"{self.tracker}: [red]{response_json['status_message']}")
+                        logger.info(f"{self.tracker}: [red]{escape(response_json['status_message'])}")
                         if response_json["status_message"].startswith("Invalid imdb_id"):
                             logger.info(f"{self.tracker}: [yellow]RETRYING UPLOAD")
                             data["imdb_id"] = 1
                             response = await client.post(url=url, files=files, data=data, headers=headers)
                             response_json = cast(dict[str, Any], response.json())
                         elif response_json["status_message"].startswith("Invalid name value"):
-                            logger.info(f"{self.tracker}: [bold yellow]Submitted Name: {bhd_name}")
+                            logger.info(f"{self.tracker}: [bold yellow]Submitted Name: {escape(bhd_name)}")
 
                     if "status_message" in response_json:
                         match = re.search(rf"{re.escape(self.base_url)}/torrent/download/.*\.(\d+)\.", response_json["status_message"])
@@ -331,7 +332,7 @@ class BEYONDHD:
                     await desc.write(tonemapped_header)
                     await desc.write("\n\n")
             except Exception as e:
-                logger.warning(f"{self.tracker}: [yellow]Warning: Error setting tonemapped header: {e!s}[/yellow]")
+                logger.warning(f"{self.tracker}: [yellow]Warning: Error setting tonemapped header: {escape(str(e))}[/yellow]")
             images = cast(list[dict[str, Any]], meta.get(f"{self.tracker}_images_key") or meta.image_list or [])
             if len(images) > 0:
                 await desc.write("[align=center]")
@@ -375,7 +376,7 @@ class BEYONDHD:
             )
         ):
             if not meta.unattended or (meta.unattended and meta.unattended_confirm):
-                logger.info(f"{self.tracker}: [bold red]This is an internal BEYONDHD release, skipping upload[/bold red]")
+                logger.info(f"{self.tracker}: [bold red]This is an internal {self.tracker} release, skipping upload[/bold red]")
                 if cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
                     pass
                 else:
@@ -388,12 +389,14 @@ class BEYONDHD:
             return False
 
         if meta.type in ["REMUX", "ENCODE", "WEBDL", "WEBRIP"] and meta.container not in ["mkv", "mp4"]:
-            logger.info(f"{self.tracker}: [bold red]Container '{meta.container}' is not allowed for {meta.type}. Only MKV and MP4 are permitted. Skipping upload.[/bold red]")
+            logger.info(
+                f"{self.tracker}: [bold red]Container '{escape(str(meta.container))}' is not allowed for {escape(str(meta.type))}. Only MKV and MP4 are permitted. Skipping upload.[/bold red]"
+            )
             return False
 
         if meta.type not in ["WEBDL"] and meta.tag and any(x in meta.tag for x in ["EVO"]):
             if not meta.unattended or (meta.unattended and meta.unattended_confirm):
-                logger.info(f"{self.tracker}: [bold red]Group {meta.tag} is only allowed for raw type content at BEYONDHD[/bold red]")
+                logger.info(f"{self.tracker}: [bold red]Group {escape(str(meta.tag))} is only allowed for raw type content at {self.tracker}[/bold red]")
                 if cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
                     pass
                 else:

--- a/src/trackers/beyondhd.py
+++ b/src/trackers/beyondhd.py
@@ -170,14 +170,14 @@ class BEYONDHD:
                     response = await client.post(url=url, files=files, data=data, headers=headers)
                     response_json = cast(dict[str, Any], response.json())
                     if int(response_json["status_code"]) == 0:
-                        logger.info(f"[red]{response_json['status_message']}")
+                        logger.info(f"{self.tracker}: [red]{response_json['status_message']}")
                         if response_json["status_message"].startswith("Invalid imdb_id"):
-                            logger.info("[yellow]RETRYING UPLOAD")
+                            logger.info(f"{self.tracker}: [yellow]RETRYING UPLOAD")
                             data["imdb_id"] = 1
                             response = await client.post(url=url, files=files, data=data, headers=headers)
                             response_json = cast(dict[str, Any], response.json())
                         elif response_json["status_message"].startswith("Invalid name value"):
-                            logger.info(f"[bold yellow]Submitted Name: {bhd_name}")
+                            logger.info(f"{self.tracker}: [bold yellow]Submitted Name: {bhd_name}")
 
                     if "status_message" in response_json:
                         match = re.search(rf"{re.escape(self.base_url)}/torrent/download/.*\.(\d+)\.", response_json["status_message"])
@@ -197,7 +197,7 @@ class BEYONDHD:
                 meta.tracker_status[self.tracker]["status_message"] = f"data error: {e}"
                 return False
         else:
-            logger.info("[cyan]BEYONDHD Request Data:")
+            logger.info(f"{self.tracker}: [cyan]Request Data:")
             logger.info(Redaction.redact_private_info(data))
             meta.tracker_status[self.tracker]["status_message"] = "Debug mode enabled, not uploading."
             await common.create_torrent_for_upload(meta, f"{self.tracker}" + "_DEBUG", f"{self.tracker}" + "_DEBUG", announce_url="https://fake.tracker")
@@ -208,7 +208,7 @@ class BEYONDHD:
                 await common.create_torrent_ready_to_seed(meta, self.tracker, self.source_flag, self.config["TRACKERS"][self.tracker].get("announce_url"), details_link)
                 return True
             except Exception as e:
-                logger.info(f"Error while editing the torrent file: {e}")
+                logger.info(f"{self.tracker}: Error while editing the torrent file: {e}")
                 return False
         else:
             return False
@@ -331,7 +331,7 @@ class BEYONDHD:
                     await desc.write(tonemapped_header)
                     await desc.write("\n\n")
             except Exception as e:
-                logger.warning(f"[yellow]Warning: Error setting tonemapped header: {e!s}[/yellow]")
+                logger.warning(f"{self.tracker}: [yellow]Warning: Error setting tonemapped header: {e!s}[/yellow]")
             images = cast(list[dict[str, Any]], meta.get(f"{self.tracker}_images_key") or meta.image_list or [])
             if len(images) > 0:
                 await desc.write("[align=center]")
@@ -375,7 +375,7 @@ class BEYONDHD:
             )
         ):
             if not meta.unattended or (meta.unattended and meta.unattended_confirm):
-                logger.info("[bold red]This is an internal BEYONDHD release, skipping upload[/bold red]")
+                logger.info(f"{self.tracker}: [bold red]This is an internal BEYONDHD release, skipping upload[/bold red]")
                 if cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
                     pass
                 else:
@@ -384,16 +384,16 @@ class BEYONDHD:
                 return False
 
         if not meta.valid_mi_settings:
-            logger.info(f"[bold red]No encoding settings in mediainfo, skipping {self.tracker} upload.[/bold red]")
+            logger.info(f"{self.tracker}: [bold red]No encoding settings in mediainfo, skipping {self.tracker} upload.[/bold red]")
             return False
 
         if meta.type in ["REMUX", "ENCODE", "WEBDL", "WEBRIP"] and meta.container not in ["mkv", "mp4"]:
-            logger.info(f"[bold red]Container '{meta.container}' is not allowed for {meta.type}. Only MKV and MP4 are permitted. Skipping upload.[/bold red]")
+            logger.info(f"{self.tracker}: [bold red]Container '{meta.container}' is not allowed for {meta.type}. Only MKV and MP4 are permitted. Skipping upload.[/bold red]")
             return False
 
         if meta.type not in ["WEBDL"] and meta.tag and any(x in meta.tag for x in ["EVO"]):
             if not meta.unattended or (meta.unattended and meta.unattended_confirm):
-                logger.info(f"[bold red]Group {meta.tag} is only allowed for raw type content at BEYONDHD[/bold red]")
+                logger.info(f"{self.tracker}: [bold red]Group {meta.tag} is only allowed for raw type content at BEYONDHD[/bold red]")
                 if cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
                     pass
                 else:

--- a/src/trackers/beyondhd.py
+++ b/src/trackers/beyondhd.py
@@ -198,7 +198,7 @@ class BEYONDHD:
                 meta.tracker_status[self.tracker]["status_message"] = f"data error: {e}"
                 return False
         else:
-            logger.info(f"{self.tracker}: [cyan]Request Data:")
+            logger.info(f"{self.tracker}: Request Data:")
             logger.info(Redaction.redact_private_info(data))
             meta.tracker_status[self.tracker]["status_message"] = "Debug mode enabled, not uploading."
             await common.create_torrent_for_upload(meta, f"{self.tracker}" + "_DEBUG", f"{self.tracker}" + "_DEBUG", announce_url="https://fake.tracker")

--- a/src/trackers/bithdtv.py
+++ b/src/trackers/bithdtv.py
@@ -96,7 +96,7 @@ class BitHDTV:
                     parsed = response.json()
                     meta.tracker_status[self.tracker]["status_message"] = parsed
                 except Exception:
-                    logger.info("[cyan]It may have uploaded, go check")
+                    logger.info(f"{self.tracker}: [cyan]It may have uploaded, go check")
                     logger.info(Redaction.redact_private_info(data))
                     traceback.print_exc()
 
@@ -109,7 +109,7 @@ class BitHDTV:
                     return True
             return False
 
-        logger.info("[cyan]BITHDTV Request Data:")
+        logger.info(f"{self.tracker}: [cyan]Request Data:")
         logger.info(Redaction.redact_private_info(data))
         meta.tracker_status[self.tracker]["status_message"] = "Debug mode enabled, not uploading."
         await common.create_torrent_for_upload(meta, f"{self.tracker}" + "_DEBUG", f"{self.tracker}" + "_DEBUG", announce_url="https://fake.tracker")

--- a/src/trackers/bithdtv.py
+++ b/src/trackers/bithdtv.py
@@ -109,7 +109,7 @@ class BitHDTV:
                     return True
             return False
 
-        logger.info(f"{self.tracker}: [cyan]Request Data:")
+        logger.info(f"{self.tracker}: Request Data:")
         logger.info(Redaction.redact_private_info(data))
         meta.tracker_status[self.tracker]["status_message"] = "Debug mode enabled, not uploading."
         await common.create_torrent_for_upload(meta, f"{self.tracker}" + "_DEBUG", f"{self.tracker}" + "_DEBUG", announce_url="https://fake.tracker")

--- a/src/trackers/bjshare.py
+++ b/src/trackers/bjshare.py
@@ -1042,7 +1042,7 @@ class BJShare:
         if category in ("MOVIE", "TV"):
             cover_path = self.main_tmdb_data.get("poster_path") or meta.tmdb_poster
             if not cover_path:
-                logger.info("Nenhum poster_path encontrado nos dados do TMDB.", extra={"markup": False})
+                logger.info(f"{self.tracker}: Nenhum poster_path encontrado nos dados do TMDB.", extra={"markup": False})
                 return None
 
             cover_tmdb_url = f"https://image.tmdb.org/t/p/w500{cover_path}"
@@ -1096,7 +1096,7 @@ class BJShare:
                 filename = Path(urlparse(url).path).name or "screenshot.png"
                 return await self.img_host(image_bytes, filename)
             except Exception as e:
-                logger.info(f"Failed to process screenshot from URL {url}: {e}", extra={"markup": False})
+                logger.info(f"{self.tracker}: Failed to process screenshot from URL {url}: {e}", extra={"markup": False})
                 return None
 
         results: list[str] = []
@@ -1378,7 +1378,7 @@ class BJShare:
             return results
 
         except Exception as e:
-            logger.info(f"[bold red]Ocorreu um erro ao buscar pedido(s) no {self.tracker}: {e}[/bold red]")
+            logger.info(f"{self.tracker}: [bold red]Ocorreu um erro ao buscar pedido(s) no {self.tracker}: {e}[/bold red]")
             import traceback
 
             logger.info(traceback.format_exc())

--- a/src/trackers/brasiltracker.py
+++ b/src/trackers/brasiltracker.py
@@ -843,7 +843,7 @@ class BrasilTracker:
                 async with aiofiles.open(info_file_path, encoding="utf-8") as f:
                     return await f.read()
             except Exception as e:
-                logger.info(f"[bold red]Erro ao ler o arquivo de info em {info_file_path}: {e}[/bold red]")
+                logger.info(f"{self.tracker}: [bold red]Erro ao ler o arquivo de info em {info_file_path}: {e}[/bold red]")
                 return ""
         else:
             logger.info(f"[bold red]Arquivo de info não encontrado: {info_file_path}[/bold red]")

--- a/src/trackers/brasiltracker.py
+++ b/src/trackers/brasiltracker.py
@@ -15,6 +15,7 @@ import langcodes
 import rarfile
 from bs4 import BeautifulSoup
 from langcodes.tag_parser import LanguageTagError
+from rich.markup import escape
 
 from src.console import logger
 from src.cookie_auth import CookieAuthUploader, CookieValidator
@@ -843,10 +844,10 @@ class BrasilTracker:
                 async with aiofiles.open(info_file_path, encoding="utf-8") as f:
                     return await f.read()
             except Exception as e:
-                logger.info(f"{self.tracker}: [bold red]Erro ao ler o arquivo de info em {info_file_path}: {e}[/bold red]")
+                logger.info(f"{self.tracker}: [bold red]Erro ao ler o arquivo de info em {escape(str(info_file_path))}: {escape(str(e))}[/bold red]")
                 return ""
         else:
-            logger.info(f"[bold red]Arquivo de info não encontrado: {info_file_path}[/bold red]")
+            logger.info(f"{self.tracker}: [bold red]Arquivo de info não encontrado: {escape(str(info_file_path))}[/bold red]")
             return ""
 
     async def get_edition(self, meta: Meta) -> str:

--- a/src/trackers/digitalcore.py
+++ b/src/trackers/digitalcore.py
@@ -293,7 +293,7 @@ class DigitalCore:
                 return False
 
         else:
-            logger.info("[cyan]DIGITALCORE Request Data:")
+            logger.info(f"{self.tracker}: [cyan]Request Data:")
             logger.info(Redaction.redact_private_info(data))
             meta.tracker_status[self.tracker]["status_message"] = "Debug mode enabled, not uploading"
             await self.common.create_torrent_for_upload(meta, f"{self.tracker}" + "_DEBUG", f"{self.tracker}" + "_DEBUG", announce_url="https://fake.tracker")

--- a/src/trackers/digitalcore.py
+++ b/src/trackers/digitalcore.py
@@ -293,7 +293,7 @@ class DigitalCore:
                 return False
 
         else:
-            logger.info(f"{self.tracker}: [cyan]Request Data:")
+            logger.info(f"{self.tracker}: Request Data:")
             logger.info(Redaction.redact_private_info(data))
             meta.tracker_status[self.tracker]["status_message"] = "Debug mode enabled, not uploading"
             await self.common.create_torrent_for_upload(meta, f"{self.tracker}" + "_DEBUG", f"{self.tracker}" + "_DEBUG", announce_url="https://fake.tracker")

--- a/src/trackers/filelist.py
+++ b/src/trackers/filelist.py
@@ -10,6 +10,7 @@ import aiofiles
 import cli_ui
 import httpx
 from bs4 import BeautifulSoup
+from rich.markup import escape
 from unidecode import unidecode
 
 from cogs.redaction import Redaction
@@ -146,7 +147,7 @@ class FileList:
                             if len(line_fields) >= 7:
                                 cookies[line_fields[5]] = line_fields[6]
             except Exception as e:
-                logger.error(f"{self.tracker}: [red]Error parsing FILELIST Netscape cookie file: {e}[/red]")
+                logger.error(f"{self.tracker}: [red]Error parsing {self.tracker} Netscape cookie file: {escape(str(e))}[/red]")
             return cookies
 
         # If it's a pickle file (ends with .pkl or .pickle)
@@ -350,10 +351,10 @@ class FileList:
             index = f"{self.base_url}/index.php"
             response = await client.get(index)
             if response.text.find("Logout") != -1:
-                logger.info(f"{self.tracker}: [green]Successfully logged into FILELIST")
+                logger.info(f"{self.tracker}: [green]Successfully logged into {self.tracker}")
                 self.cookie_validator._save_cookies_secure(client.cookies.jar, cookiefile)  # pyright: ignore[reportPrivateUsage]
             else:
-                logger.info(f"{self.tracker}: [bold red]Something went wrong while trying to log into FILELIST")
+                logger.info(f"{self.tracker}: [bold red]Something went wrong while trying to log into {self.tracker}")
                 logger.info(response.url)
         return
 
@@ -365,7 +366,7 @@ class FileList:
             async with aiofiles.open(torrent_path, "wb") as tor:
                 await tor.write(r.content)
         else:
-            logger.info(f"{self.tracker}: [red]There was an issue downloading the new .torrent from FILELIST")
+            logger.info(f"{self.tracker}: [red]There was an issue downloading the new .torrent from {self.tracker}")
             logger.info(r.text)
         return
 

--- a/src/trackers/filelist.py
+++ b/src/trackers/filelist.py
@@ -146,7 +146,7 @@ class FileList:
                             if len(line_fields) >= 7:
                                 cookies[line_fields[5]] = line_fields[6]
             except Exception as e:
-                logger.error(f"[red]Error parsing FILELIST Netscape cookie file: {e}[/red]")
+                logger.error(f"{self.tracker}: [red]Error parsing FILELIST Netscape cookie file: {e}[/red]")
             return cookies
 
         # If it's a pickle file (ends with .pkl or .pickle)
@@ -161,7 +161,7 @@ class FileList:
                 self.cookie_validator._save_cookies_secure(session_cookies, str(json_path))  # pyright: ignore[reportPrivateUsage]
                 return {cookie.name: cookie.value for cookie in session_cookies}
             except Exception as e:
-                logger.error(f"[red]Failed to migrate legacy cookies from pickle: {e}[/red]")
+                logger.error(f"{self.tracker}: [red]Failed to migrate legacy cookies from pickle: {e}[/red]")
                 return {}
 
         # Default to loading as JSON
@@ -180,7 +180,7 @@ class FileList:
                             return {name: str(item.get("value", "")) for name, item in data.items()}
                     return {name: str(val) for name, val in data.items()}
             except Exception as e:
-                logger.error(f"[yellow]Warning: Error parsing cookie file: {e}[/yellow]")
+                logger.error(f"{self.tracker}: [yellow]Warning: Error parsing cookie file: {e}[/yellow]")
             return {}
 
     async def upload(self, meta: Meta) -> bool:
@@ -198,8 +198,8 @@ class FileList:
             if fl_confirm is not True:
                 fl_name_manually = cli_ui.ask_string("Please enter a proper name", default="")
                 if fl_name_manually == "":
-                    logger.info("No proper name given")
-                    logger.info("Aborting...")
+                    logger.info(f"{self.tracker}: No proper name given")
+                    logger.info(f"{self.tracker}: Aborting...")
                     return False
                 fl_name = fl_name_manually
 
@@ -263,7 +263,7 @@ class FileList:
             await self.download_new_torrent(cookies, torrent_id, torrent_path)
             return True
         logger.info(data)
-        logger.info("\n\n")
+        logger.info(f"{self.tracker}: \n\n")
         logger.info(up.text)
         raise UploadError(f"Upload to FILELIST Failed: result URL {up.url} ({up.status_code}) was not expected", "red")  # noqa F405
 
@@ -305,7 +305,7 @@ class FileList:
             await self.login(cookiefile)
         vcookie = await self.validate_cookies(meta, cookiefile)
         if vcookie is not True:
-            logger.error("[red]Failed to validate cookies. Please confirm that the site is up and your passkey is valid.")
+            logger.error(f"{self.tracker}: [red]Failed to validate cookies. Please confirm that the site is up and your passkey is valid.")
             recreate = cli_ui.ask_yes_no("Log in again and create new session?")
             if recreate is True:
                 if Path(cookiefile).exists():
@@ -350,10 +350,10 @@ class FileList:
             index = f"{self.base_url}/index.php"
             response = await client.get(index)
             if response.text.find("Logout") != -1:
-                logger.info("[green]Successfully logged into FILELIST")
+                logger.info(f"{self.tracker}: [green]Successfully logged into FILELIST")
                 self.cookie_validator._save_cookies_secure(client.cookies.jar, cookiefile)  # pyright: ignore[reportPrivateUsage]
             else:
-                logger.info("[bold red]Something went wrong while trying to log into FILELIST")
+                logger.info(f"{self.tracker}: [bold red]Something went wrong while trying to log into FILELIST")
                 logger.info(response.url)
         return
 
@@ -365,7 +365,7 @@ class FileList:
             async with aiofiles.open(torrent_path, "wb") as tor:
                 await tor.write(r.content)
         else:
-            logger.info("[red]There was an issue downloading the new .torrent from FILELIST")
+            logger.info(f"{self.tracker}: [red]There was an issue downloading the new .torrent from FILELIST")
             logger.info(r.text)
         return
 

--- a/src/trackers/funfile.py
+++ b/src/trackers/funfile.py
@@ -176,7 +176,7 @@ class FunFile:
             return results
 
         except Exception as e:
-            logger.info(f"An error occurred while fetching requests: {e}", extra={"markup": False})
+            logger.info(f"{self.tracker}: An error occurred while fetching requests: {e}", extra={"markup": False})
             return []
 
     async def generate_description(self, meta: Meta) -> str:

--- a/src/trackers/greatposterwall.py
+++ b/src/trackers/greatposterwall.py
@@ -412,7 +412,7 @@ class GreatPosterWall:
             response = await client.get(url)
             response.raise_for_status()
         except httpx.HTTPStatusError as e:
-            logger.info(f"Error on request: {e.response.status_code} - {e.response.reason_phrase}", extra={"markup": False})
+            logger.info(f"{self.tracker}: Error on request: {e.response.status_code} - {e.response.reason_phrase}", extra={"markup": False})
             return
 
         soup = BeautifulSoup(response.text, "html.parser")
@@ -455,8 +455,8 @@ class GreatPosterWall:
             if final_slots:
                 final_slots = final_slots.replace("Slot", "").replace("Empty slots:", "").strip()
                 if resolution == meta.resolution:
-                    logger.info(f"\n[green]Available Slots for[/green] {resolution}:")
-                    logger.info(f"{final_slots}\n")
+                    logger.info(f"{self.tracker}: \n[green]Available Slots for[/green] {resolution}:")
+                    logger.info(f"{self.tracker}: {final_slots}\n")
 
     async def get_media_info(self, meta: Meta) -> str:
         info_file_path = ""
@@ -471,10 +471,10 @@ class GreatPosterWall:
                 async with aiofiles.open(info_file_path, encoding="utf-8") as f:
                     return await f.read()
             except Exception as e:
-                logger.info(f"[bold red]Error reading info file at {info_file_path}: {e}[/bold red]")
+                logger.info(f"{self.tracker}: [bold red]Error reading info file at {info_file_path}: {e}[/bold red]")
                 return ""
         else:
-            logger.info(f"[bold red]Info file not found: {info_file_path}[/bold red]")
+            logger.info(f"{self.tracker}: [bold red]Info file not found: {info_file_path}[/bold red]")
             return ""
 
     def get_edition(self, meta: Meta) -> str:
@@ -625,16 +625,16 @@ class GreatPosterWall:
                 response.raise_for_status()
 
         except httpx.RequestError as e:
-            logger.info(f"[bold red]Network error fetching groupid: {e}[/bold red]")
+            logger.info(f"{self.tracker}: [bold red]Network error fetching groupid: {e}[/bold red]")
             return False
         except httpx.HTTPStatusError as e:
-            logger.info(f"[bold red]HTTP error when fetching groupid: Status {e.response.status_code}[/bold red]")
+            logger.info(f"{self.tracker}: [bold red]HTTP error when fetching groupid: Status {e.response.status_code}[/bold red]")
             return False
 
         try:
             data: dict[str, Any] = response.json()
         except Exception as e:
-            logger.info(f"[bold red]Error decoding JSON from groupid response: {e}[/bold red]")
+            logger.info(f"{self.tracker}: [bold red]Error decoding JSON from groupid response: {e}[/bold red]")
             return False
 
         if data.get("status") == 200 and "response" in data and "ID" in data["response"]:
@@ -673,7 +673,7 @@ class GreatPosterWall:
                 if new_images:
                     return str(new_images[0].get("raw_url", ""))
             except Exception as e:
-                logger.error(f"[red]Error uploading poster: {e}[/red]")
+                logger.error(f"{self.tracker}: [red]Error uploading poster: {e}[/red]")
 
         return ""
 
@@ -688,7 +688,7 @@ class GreatPosterWall:
                 poster_url = (poster_url_raw or "").strip()
                 if any(host in poster_url for host in self.approved_image_hosts):
                     break
-                logger.info("[red]Invalid host. Please use a URL from the allowed hosts.[/red]")
+                logger.info(f"{self.tracker}: [red]Invalid host. Please use a URL from the allowed hosts.[/red]")
 
         imdb_identifier = str(meta.imdb_info.get("imdbID") or meta.imdb or "").strip()
         tmdb_identifier = str(meta.tmdb_id or "").strip()
@@ -815,14 +815,14 @@ class GreatPosterWall:
                 imdb_id_raw = await asyncio.to_thread(cli_ui.ask_string, "Enter Director IMDb ID (e.g., nm0000138): ")
                 imdb_id = (imdb_id_raw or "").strip()
                 if not re.match(r"^nm\d+$", imdb_id):
-                    logger.info("[red]Invalid IMDb person ID. Format must be like nm0000138.[/red]")
+                    logger.info(f"{self.tracker}: [red]Invalid IMDb person ID. Format must be like nm0000138.[/red]")
 
             english_name = ""
             while not english_name:
                 english_name_raw = await asyncio.to_thread(cli_ui.ask_string, "Enter Director English name: ")
                 english_name = (english_name_raw or "").strip()
                 if not english_name:
-                    logger.info("[red]Director English name cannot be empty.[/red]")
+                    logger.info(f"{self.tracker}: [red]Director English name cannot be empty.[/red]")
 
             chinese_name_raw = await asyncio.to_thread(cli_ui.ask_string, "Enter Director Chinese name (optional, press Enter to skip): ")
             chinese_name = (chinese_name_raw or "").strip()
@@ -937,7 +937,7 @@ class GreatPosterWall:
                         if score >= 10:
                             return response_data
             except Exception as e:
-                logger.debug(f"Failed to process response payload on GREATPOSTERWALL: {e}", exc_info=True)
+                logger.debug(f"{self.tracker}: Failed to process response payload on GREATPOSTERWALL: {e}", exc_info=True)
                 continue
 
         return best_response
@@ -1169,7 +1169,7 @@ class GreatPosterWall:
                 return False
 
         else:
-            logger.info("[cyan]GREATPOSTERWALL Request Data:")
+            logger.info(f"{self.tracker}: [cyan]Request Data:")
             logger.info(Redaction.redact_private_info(data))
             meta.tracker_status[self.tracker]["status_message"] = "Debug mode enabled, not uploading."
             await self.common.create_torrent_for_upload(meta, f"{self.tracker}" + "_DEBUG", f"{self.tracker}" + "_DEBUG", announce_url="https://fake.tracker")

--- a/src/trackers/greatposterwall.py
+++ b/src/trackers/greatposterwall.py
@@ -1170,7 +1170,7 @@ class GreatPosterWall:
                 return False
 
         else:
-            logger.info(f"{self.tracker}: [cyan]Request Data:")
+            logger.info(f"{self.tracker}: Request Data:")
             logger.info(Redaction.redact_private_info(data))
             meta.tracker_status[self.tracker]["status_message"] = "Debug mode enabled, not uploading."
             await self.common.create_torrent_for_upload(meta, f"{self.tracker}" + "_DEBUG", f"{self.tracker}" + "_DEBUG", announce_url="https://fake.tracker")

--- a/src/trackers/greatposterwall.py
+++ b/src/trackers/greatposterwall.py
@@ -9,6 +9,7 @@ import aiofiles
 import cli_ui
 import httpx
 from bs4 import BeautifulSoup
+from rich.markup import escape
 
 from cogs.redaction import Redaction
 from src.console import logger
@@ -633,7 +634,7 @@ class GreatPosterWall:
 
         try:
             data: dict[str, Any] = response.json()
-        except Exception as e:
+        except ValueError as e:
             logger.info(f"{self.tracker}: [bold red]Error decoding JSON from groupid response: {e}[/bold red]")
             return False
 
@@ -936,8 +937,8 @@ class GreatPosterWall:
                             best_score = score
                         if score >= 10:
                             return response_data
-            except Exception as e:
-                logger.debug(f"{self.tracker}: Failed to process response payload on GREATPOSTERWALL: {e}", exc_info=True)
+            except (ValueError, KeyError, TypeError, IndexError) as e:
+                logger.debug(f"{self.tracker}: Failed to process response payload on {self.tracker}: {escape(str(e))}", exc_info=True)
                 continue
 
         return best_response

--- a/src/trackers/hdbits.py
+++ b/src/trackers/hdbits.py
@@ -8,6 +8,7 @@ from urllib.parse import quote, urlparse
 
 import aiofiles
 import httpx
+from rich.markup import escape
 from unidecode import unidecode
 
 from cogs.redaction import Redaction
@@ -243,7 +244,7 @@ class HDBits:
 
         for each in (cat_id, codec_id, medium_id):
             if each == 0:
-                logger.info(f"{self.tracker}: [bold red]Something didn't map correctly, or this content is not allowed on HDBITS")
+                logger.info(f"{self.tracker}: [bold red]Something didn't map correctly, or this content is not allowed on {self.tracker}")
                 return None
         if "Dual-Audio" in meta.audio and not (meta.anime or not meta.is_disc):
             logger.info(f"{self.tracker}: [bold red]Dual-Audio Encodes are not allowed for non-anime and non-disc content")
@@ -257,7 +258,7 @@ class HDBits:
 
         # Check if the piece size exceeds 16 MiB and regenerate the torrent if needed
         if base_piece_mb > 16 and not meta.nohash:
-            logger.info(f"{self.tracker}: [red]Piece size is OVER 16M and does not work on HDBITS. Generating a new .torrent")
+            logger.info(f"{self.tracker}: [red]Piece size is OVER 16M and does not work on {self.tracker}. Generating a new .torrent")
             hdb_config = self.config.get("TRACKERS", {}).get("HDBITS", {})
             hdb_config_dict = cast(dict[str, Any], hdb_config) if isinstance(hdb_config, dict) else {}
             tracker_url = str(hdb_config_dict.get("announce_url", "https://fake.tracker")).strip()
@@ -398,7 +399,7 @@ class HDBits:
 
         # Otherwise, search for each term
         for search_term in search_terms:
-            logger.info(f"{self.tracker}: [yellow]Searching HDBITS for: {search_term}")
+            logger.info(f"{self.tracker}: [yellow]Searching {self.tracker} for: {escape(str(search_term))}")
             data["search"] = search_term
 
             async with httpx.AsyncClient(timeout=5.0) as client:
@@ -596,7 +597,7 @@ class HDBits:
                 logger.info(f"{self.tracker}: [red]Comparison path not found: {comparison_path}")
                 return None
 
-            logger.info(f"{self.tracker}: [green]Uploading comparison images from {comparison_path} to HDBITS Image Host")
+            logger.info(f"{self.tracker}: [green]Uploading comparison images from {escape(str(comparison_path))} to {self.tracker} Image Host")
 
             group_images: dict[str, list[str]] = {}
             max_images_per_group = 0
@@ -699,7 +700,7 @@ class HDBits:
             upload_count = 3 if meta.category == "TV" and meta.tv_pack == 0 else 6
             upload_count = min(len(all_image_files), upload_count)
 
-        logger.debug(f"{self.tracker}: [cyan]Uploading {upload_count} images to HDBITS Image Host")
+        logger.debug(f"{self.tracker}: [cyan]Uploading {upload_count} images to {self.tracker} Image Host")
 
         upload_files: dict[str, tuple[str, bytes, str]] = {}
         for i in range(upload_count):
@@ -709,9 +710,9 @@ class HDBits:
                 async with aiofiles.open(file_path, "rb") as file_handle:
                     file_bytes = await file_handle.read()
                 upload_files[f"images_files[{i}]"] = (filename, file_bytes, "image/png")
-                logger.debug(f"{self.tracker}: [cyan]Added file {filename} as images_files[{i}]")
+                logger.debug(f"{self.tracker}: [cyan]Added file {escape(str(filename))} as images_files[{i}]")
             except (OSError, ValueError) as e:
-                logger.error(f"{self.tracker}: [red]Failed to open {file_path}: {e}")
+                logger.error(f"{self.tracker}: [red]Failed to open {escape(str(file_path))}: {escape(str(e))}")
                 continue
 
         try:
@@ -719,7 +720,7 @@ class HDBits:
                 logger.info(f"{self.tracker}: [red]No files to upload")
                 return None
 
-            logger.debug(f"{self.tracker}: [green]Uploading {len(upload_files)} images to HDBITS...")
+            logger.debug(f"{self.tracker}: [green]Uploading {len(upload_files)} images to {self.tracker}...")
 
             upload_success = True
             if meta.comparison:
@@ -831,10 +832,13 @@ class HDBits:
                     logger.info(f"{self.tracker}: [red]API returned error status {status_code}: {message}[/red]")
 
         except httpx.RequestError as e:
-            logger.info(f"{self.tracker}: [red]Request error: {e}[/red]")
+            logger.info(f"{self.tracker}: [red]Request error: {escape(str(e))}[/red]")
+        except (ValueError, KeyError, IndexError, TypeError) as e:
+            logger.error(f"{self.tracker}: [red]Failed to parse HDBITS response. Error: {escape(str(e))}[/red]")
         except Exception as e:
-            logger.error(f"{self.tracker}: [red]Unexpected error: {e}[/red]")
+            logger.error(f"{self.tracker}: [red]Unexpected error: {escape(str(e))}[/red]")
             console.print_exception()
+            raise
 
         return hdb_imdb, hdb_tvdb, hdb_name, hdb_torrenthash, hdb_description
 
@@ -865,7 +869,7 @@ class HDBits:
                         "limit": 100,
                         "search": bd_summary,  # Using the Disc Title for search with uuid fallback
                     }
-                    logger.info(f"{self.tracker}: [green]Searching HDBITS for title: [bold yellow]{bd_summary}[/bold yellow]")
+                    logger.info(f"{self.tracker}: [green]Searching {self.tracker} for title: [bold yellow]{escape(str(bd_summary))}[/bold yellow]")
                     # console.print(f"[yellow]Using this data: {data}")
                 else:
                     return hdb_imdb, hdb_tvdb, hdb_name, hdb_torrenthash, hdb_description, hdb_id
@@ -876,7 +880,7 @@ class HDBits:
 
         else:  # Handling non-disc case
             data = {"username": self.username, "passkey": self.passkey, "limit": 100, "file_in_torrent": Path(search_term).name}
-            logger.info(f"{self.tracker}: [green]Searching HDBITS for file: [bold yellow]{Path(search_term).name}[/bold yellow]")
+            logger.info(f"{self.tracker}: [green]Searching {self.tracker} for file: [bold yellow]{escape(str(Path(search_term).name))}[/bold yellow]")
             # console.print(f"[yellow]Using this data: {data}")
 
         try:
@@ -888,7 +892,9 @@ class HDBits:
                     # console.print(f"[green]HDBITS API response: {response_json}[/green]")
 
                     if "data" not in response_json:
-                        logger.error(f"{self.tracker}: [red]Error: 'data' key not found or empty in HDBITS API response. Full response: {response_json}[/red]")
+                        logger.error(
+                            f"{self.tracker}: [red]Error: 'data' key not found or empty in {self.tracker} API response. Full response: {escape(str(response_json))}[/red]"
+                        )
                         return hdb_imdb, hdb_tvdb, hdb_name, hdb_torrenthash, hdb_id
 
                     for each in response_json["data"]:
@@ -899,20 +905,24 @@ class HDBits:
                         hdb_id = each.get("id", None)
                         hdb_description = each.get("descr")
 
-                        logger.info(f"{self.tracker}: [bold green]Matched release with HDBITS ID: [yellow]{self.base_url}/details.php?id={hdb_id}[/yellow][/bold green]")
+                        logger.info(
+                            f"{self.tracker}: [bold green]Matched release with {self.tracker} ID: [yellow]{self.base_url}/details.php?id={hdb_id}[/yellow][/bold green]"
+                        )
 
                         return hdb_imdb, hdb_tvdb, hdb_name, hdb_torrenthash, hdb_description, hdb_id
 
-                    logger.info(f"{self.tracker}: [yellow]No data found in the HDBITS API response[/yellow]")
+                    logger.info(f"{self.tracker}: [yellow]No data found in the {self.tracker} API response[/yellow]")
 
                 except (ValueError, KeyError, TypeError) as e:
                     console.print_exception()
-                    logger.error(f"{self.tracker}: [red]Failed to parse HDBITS API response. Error: {e!s}[/red]")
+                    logger.error(f"{self.tracker}: [red]Failed to parse {self.tracker} API response. Error: {escape(str(e))}[/red]")
             else:
-                logger.error(f"{self.tracker}: [red]Failed to get info from HDBITS. Status code: {response.status_code}, Reason: {response.reason_phrase}[/red]")
+                logger.error(
+                    f"{self.tracker}: [red]Failed to get info from {self.tracker}. Status code: {response.status_code}, Reason: {escape(str(response.reason_phrase))}[/red]"
+                )
 
         except httpx.RequestError as e:
-            logger.info(f"{self.tracker}: [red]Request error: {e!s}[/red]")
+            logger.info(f"{self.tracker}: [red]Request error: {escape(str(e))}[/red]")
 
-        logger.info(f"{self.tracker}: [yellow]Could not find a matching release on HDBITS[/yellow]")
+        logger.info(f"{self.tracker}: [yellow]Could not find a matching release on {self.tracker}[/yellow]")
         return hdb_imdb, hdb_tvdb, hdb_name, hdb_torrenthash, hdb_description, hdb_id

--- a/src/trackers/hdbits.py
+++ b/src/trackers/hdbits.py
@@ -183,7 +183,7 @@ class HDBits:
         if "Atmos" in audio:
             tags.append(5)
         if meta.silent is True:
-            logger.info("[yellow]zxx audio track found, suggesting you tag as silent")  # 57
+            logger.info(f"{self.tracker}: [yellow]zxx audio track found, suggesting you tag as silent")  # 57
 
         # Video Metadata
         # HDR10, HDR10+, Dolby Vision, 10-bit,
@@ -243,10 +243,10 @@ class HDBits:
 
         for each in (cat_id, codec_id, medium_id):
             if each == 0:
-                logger.info("[bold red]Something didn't map correctly, or this content is not allowed on HDBITS")
+                logger.info(f"{self.tracker}: [bold red]Something didn't map correctly, or this content is not allowed on HDBITS")
                 return None
         if "Dual-Audio" in meta.audio and not (meta.anime or not meta.is_disc):
-            logger.info("[bold red]Dual-Audio Encodes are not allowed for non-anime and non-disc content")
+            logger.info(f"{self.tracker}: [bold red]Dual-Audio Encodes are not allowed for non-anime and non-disc content")
             return None
 
         async with aiofiles.open(f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/[{self.tracker}]DESCRIPTION.txt", encoding="utf-8") as desc_file:
@@ -257,7 +257,7 @@ class HDBits:
 
         # Check if the piece size exceeds 16 MiB and regenerate the torrent if needed
         if base_piece_mb > 16 and not meta.nohash:
-            logger.info("[red]Piece size is OVER 16M and does not work on HDBITS. Generating a new .torrent")
+            logger.info(f"{self.tracker}: [red]Piece size is OVER 16M and does not work on HDBITS. Generating a new .torrent")
             hdb_config = self.config.get("TRACKERS", {}).get("HDBITS", {})
             hdb_config_dict = cast(dict[str, Any], hdb_config) if isinstance(hdb_config, dict) else {}
             tracker_url = str(hdb_config_dict.get("announce_url", "https://fake.tracker")).strip()
@@ -337,7 +337,7 @@ class HDBits:
                 await self.download_new_torrent(id, torrent_file_path)
             return True
         logger.info(data)
-        logger.info("\n\n")
+        logger.info(f"{self.tracker}: \n\n")
         logger.info(up.text)
         raise UploadError(f"Upload to HDBITS Failed: result URL {up.url} ({up.status_code}) was not expected", "red")  # noqa F405
 
@@ -363,8 +363,8 @@ class HDBits:
         has_valid_ids = (meta.category == "TV" and meta.tvdb_id == 0 and meta.imdb_id == 0) or (meta.category == "MOVIE" and meta.imdb_id == 0)
 
         if has_valid_ids:
-            logger.info("[yellow]No IMDb or TVDB ID found, trying other options...")
-            logger.info("[yellow]Double check that the upload does not already exist...")
+            logger.info(f"{self.tracker}: [yellow]No IMDb or TVDB ID found, trying other options...")
+            logger.info(f"{self.tracker}: [yellow]Double check that the upload does not already exist...")
             if meta.filename:
                 search_terms.append(meta.filename)
             if meta.aka:
@@ -393,12 +393,12 @@ class HDBits:
                             }
                             dupes.append(result)
                 else:
-                    logger.info(f"[bold red]HTTP request failed. Status: {response.status_code}")
+                    logger.info(f"{self.tracker}: [bold red]HTTP request failed. Status: {response.status_code}")
             return dupes
 
         # Otherwise, search for each term
         for search_term in search_terms:
-            logger.info(f"[yellow]Searching HDBITS for: {search_term}")
+            logger.info(f"{self.tracker}: [yellow]Searching HDBITS for: {search_term}")
             data["search"] = search_term
 
             async with httpx.AsyncClient(timeout=5.0) as client:
@@ -418,14 +418,14 @@ class HDBits:
                             }
                             dupes.append(result)
                 else:
-                    logger.info(f"[bold red]HTTP request failed. Status: {response.status_code}")
+                    logger.info(f"{self.tracker}: [bold red]HTTP request failed. Status: {response.status_code}")
 
         return dupes
 
     async def validate_credentials(self, meta: Meta) -> bool:
         vcookie = await self.validate_cookies(meta)
         if vcookie is not True:
-            logger.error("[red]Failed to validate cookies. Please confirm that the site is up and your passkey is valid.")
+            logger.error(f"{self.tracker}: [red]Failed to validate cookies. Please confirm that the site is up and your passkey is valid.")
             return False
         return True
 
@@ -440,7 +440,7 @@ class HDBits:
             async with httpx.AsyncClient(cookies=cookies, timeout=30.0) as client:
                 resp = await client.get(url=url)
             return resp.text.find("""<a href="/logout.php">Logout</a>""") != -1
-        logger.info("[bold red]Missing Cookie File. (data/cookies/HDBITS.txt)")
+        logger.info(f"{self.tracker}: [bold red]Missing Cookie File. (data/cookies/HDBITS.txt)")
         return False
 
     async def download_new_torrent(self, id: str, torrent_path: str) -> None:
@@ -534,7 +534,7 @@ class HDBits:
         desc_parts.append(desc)
 
         if self.rehost_images is True:
-            logger.info("[green]Rehosting Images...")
+            logger.info(f"{self.tracker}: [green]Rehosting Images...")
             hdbimg_bbcode = await self.hdbimg_upload(meta)
             if hdbimg_bbcode is not None:
                 if meta.comparison:
@@ -593,10 +593,10 @@ class HDBits:
         if meta.comparison:
             comparison_path = meta.comparison
             if not comparison_path or not Path(comparison_path).is_dir():
-                logger.info(f"[red]Comparison path not found: {comparison_path}")
+                logger.info(f"{self.tracker}: [red]Comparison path not found: {comparison_path}")
                 return None
 
-            logger.info(f"[green]Uploading comparison images from {comparison_path} to HDBITS Image Host")
+            logger.info(f"{self.tracker}: [green]Uploading comparison images from {comparison_path} to HDBITS Image Host")
 
             group_images: dict[str, list[str]] = {}
             max_images_per_group = 0
@@ -661,9 +661,9 @@ class HDBits:
             for image_idx in range(max_images_per_group):
                 all_image_files.extend(group_images[group_idx][image_idx] for group_idx in sorted_group_indices if image_idx < len(group_images[group_idx]))
 
-            logger.debug("[cyan]Images will be uploaded in this order:")
+            logger.debug(f"{self.tracker}: [cyan]Images will be uploaded in this order:")
             for i, path in enumerate(all_image_files):
-                logger.debug(f"[cyan]{i}: {Path(path).name}")
+                logger.debug(f"{self.tracker}: [cyan]{i}: {Path(path).name}")
         else:
             thumb_size = "w300"
             screenshot_dir = f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}"
@@ -685,7 +685,7 @@ class HDBits:
 
         # At this point, all_image_files contains paths to all images we want to upload
         if not all_image_files:
-            logger.info("[red]No images found for upload")
+            logger.info(f"{self.tracker}: [red]No images found for upload")
             return None
 
         url = "https://img.hdbits.org/upload_api.php"
@@ -699,7 +699,7 @@ class HDBits:
             upload_count = 3 if meta.category == "TV" and meta.tv_pack == 0 else 6
             upload_count = min(len(all_image_files), upload_count)
 
-        logger.debug(f"[cyan]Uploading {upload_count} images to HDBITS Image Host")
+        logger.debug(f"{self.tracker}: [cyan]Uploading {upload_count} images to HDBITS Image Host")
 
         upload_files: dict[str, tuple[str, bytes, str]] = {}
         for i in range(upload_count):
@@ -709,17 +709,17 @@ class HDBits:
                 async with aiofiles.open(file_path, "rb") as file_handle:
                     file_bytes = await file_handle.read()
                 upload_files[f"images_files[{i}]"] = (filename, file_bytes, "image/png")
-                logger.debug(f"[cyan]Added file {filename} as images_files[{i}]")
+                logger.debug(f"{self.tracker}: [cyan]Added file {filename} as images_files[{i}]")
             except (OSError, ValueError) as e:
-                logger.error(f"[red]Failed to open {file_path}: {e}")
+                logger.error(f"{self.tracker}: [red]Failed to open {file_path}: {e}")
                 continue
 
         try:
             if not upload_files:
-                logger.info("[red]No files to upload")
+                logger.info(f"{self.tracker}: [red]No files to upload")
                 return None
 
-            logger.debug(f"[green]Uploading {len(upload_files)} images to HDBITS...")
+            logger.debug(f"{self.tracker}: [green]Uploading {len(upload_files)} images to HDBITS...")
 
             upload_success = True
             if meta.comparison:
@@ -748,7 +748,7 @@ class HDBits:
                 if current_chunk:
                     chunks.append(current_chunk)
 
-                logger.debug(f"[cyan]Split into {len(chunks)} chunks based on 100 MiB limit")
+                logger.debug(f"{self.tracker}: [cyan]Split into {len(chunks)} chunks based on 100 MiB limit")
 
                 # Upload each chunk
                 for chunk_idx, chunk in enumerate(chunks):
@@ -758,22 +758,22 @@ class HDBits:
 
                     if meta.debug:
                         chunk_size_mb = sum(Path(all_image_files[int(key.split("[")[1].split("]")[0])]).stat().st_size for key, _ in chunk) / (1024 * 1024)
-                        logger.debug(f"[cyan]Uploading chunk {chunk_idx + 1}/{len(chunks)} ({len(file_list)} images, {chunk_size_mb:.2f} MiB)")
+                        logger.debug(f"{self.tracker}: [cyan]Uploading chunk {chunk_idx + 1}/{len(chunks)} ({len(file_list)} images, {chunk_size_mb:.2f} MiB)")
 
                     async with httpx.AsyncClient(timeout=30.0) as client:
                         response = await client.post(url, data=data, files=file_list)
                     if response.status_code == 200:
-                        logger.info(f"[green]Chunk {chunk_idx + 1}/{len(chunks)} upload successful!")
+                        logger.info(f"{self.tracker}: [green]Chunk {chunk_idx + 1}/{len(chunks)} upload successful!")
                         bbcode += response.text
                     else:
-                        logger.info(f"[red]Chunk {chunk_idx + 1}/{len(chunks)} upload failed with status code {response.status_code}")
+                        logger.info(f"{self.tracker}: [red]Chunk {chunk_idx + 1}/{len(chunks)} upload failed with status code {response.status_code}")
                         upload_success = False
                         break
             else:
                 async with httpx.AsyncClient(timeout=30.0) as client:
                     response = await client.post(url, data=data, files=upload_files)
                 if response.status_code == 200:
-                    logger.info("[green]Upload successful!")
+                    logger.info(f"{self.tracker}: [green]Upload successful!")
                     bbcode = response.text
                 else:
                     upload_success = False
@@ -793,16 +793,16 @@ class HDBits:
 
                     bbcode = formatted_bbcode
 
-                    logger.debug(f"[cyan]Response formatted with {num_groups} images per line")
+                    logger.debug(f"{self.tracker}: [cyan]Response formatted with {num_groups} images per line")
 
                 return bbcode
             if response is None:
-                logger.info("[red]Upload failed without a response")
+                logger.info(f"{self.tracker}: [red]Upload failed without a response")
             else:
-                logger.info(f"[red]Upload failed with status code {response.status_code}")
+                logger.info(f"{self.tracker}: [red]Upload failed with status code {response.status_code}")
             return None
         except httpx.RequestError as e:
-            logger.info(f"[red]HTTP Request failed: {e}")
+            logger.info(f"{self.tracker}: [red]HTTP Request failed: {e}")
             return None
 
     async def get_info_from_torrent_id(self, hdb_id: int) -> tuple[int | None, int | None, str | None, str | None, str | None]:
@@ -828,12 +828,12 @@ class HDBits:
                 else:
                     status_code = response_json.get("status", "unknown")
                     message = response_json.get("message", "No error message provided")
-                    logger.info(f"[red]API returned error status {status_code}: {message}[/red]")
+                    logger.info(f"{self.tracker}: [red]API returned error status {status_code}: {message}[/red]")
 
         except httpx.RequestError as e:
-            logger.info(f"[red]Request error: {e}[/red]")
+            logger.info(f"{self.tracker}: [red]Request error: {e}[/red]")
         except Exception as e:
-            logger.error(f"[red]Unexpected error: {e}[/red]")
+            logger.error(f"{self.tracker}: [red]Unexpected error: {e}[/red]")
             console.print_exception()
 
         return hdb_imdb, hdb_tvdb, hdb_name, hdb_torrenthash, hdb_description
@@ -865,18 +865,18 @@ class HDBits:
                         "limit": 100,
                         "search": bd_summary,  # Using the Disc Title for search with uuid fallback
                     }
-                    logger.info(f"[green]Searching HDBITS for title: [bold yellow]{bd_summary}[/bold yellow]")
+                    logger.info(f"{self.tracker}: [green]Searching HDBITS for title: [bold yellow]{bd_summary}[/bold yellow]")
                     # console.print(f"[yellow]Using this data: {data}")
                 else:
                     return hdb_imdb, hdb_tvdb, hdb_name, hdb_torrenthash, hdb_description, hdb_id
 
             except FileNotFoundError:
-                logger.error(f"[red]Error: File not found at {bd_summary_path}[/red]")
+                logger.error(f"{self.tracker}: [red]Error: File not found at {bd_summary_path}[/red]")
                 return hdb_imdb, hdb_tvdb, hdb_name, hdb_torrenthash, hdb_description, hdb_id
 
         else:  # Handling non-disc case
             data = {"username": self.username, "passkey": self.passkey, "limit": 100, "file_in_torrent": Path(search_term).name}
-            logger.info(f"[green]Searching HDBITS for file: [bold yellow]{Path(search_term).name}[/bold yellow]")
+            logger.info(f"{self.tracker}: [green]Searching HDBITS for file: [bold yellow]{Path(search_term).name}[/bold yellow]")
             # console.print(f"[yellow]Using this data: {data}")
 
         try:
@@ -888,7 +888,7 @@ class HDBits:
                     # console.print(f"[green]HDBITS API response: {response_json}[/green]")
 
                     if "data" not in response_json:
-                        logger.error(f"[red]Error: 'data' key not found or empty in HDBITS API response. Full response: {response_json}[/red]")
+                        logger.error(f"{self.tracker}: [red]Error: 'data' key not found or empty in HDBITS API response. Full response: {response_json}[/red]")
                         return hdb_imdb, hdb_tvdb, hdb_name, hdb_torrenthash, hdb_id
 
                     for each in response_json["data"]:
@@ -899,20 +899,20 @@ class HDBits:
                         hdb_id = each.get("id", None)
                         hdb_description = each.get("descr")
 
-                        logger.info(f"[bold green]Matched release with HDBITS ID: [yellow]{self.base_url}/details.php?id={hdb_id}[/yellow][/bold green]")
+                        logger.info(f"{self.tracker}: [bold green]Matched release with HDBITS ID: [yellow]{self.base_url}/details.php?id={hdb_id}[/yellow][/bold green]")
 
                         return hdb_imdb, hdb_tvdb, hdb_name, hdb_torrenthash, hdb_description, hdb_id
 
-                    logger.info("[yellow]No data found in the HDBITS API response[/yellow]")
+                    logger.info(f"{self.tracker}: [yellow]No data found in the HDBITS API response[/yellow]")
 
                 except (ValueError, KeyError, TypeError) as e:
                     console.print_exception()
-                    logger.error(f"[red]Failed to parse HDBITS API response. Error: {e!s}[/red]")
+                    logger.error(f"{self.tracker}: [red]Failed to parse HDBITS API response. Error: {e!s}[/red]")
             else:
-                logger.error(f"[red]Failed to get info from HDBITS. Status code: {response.status_code}, Reason: {response.reason_phrase}[/red]")
+                logger.error(f"{self.tracker}: [red]Failed to get info from HDBITS. Status code: {response.status_code}, Reason: {response.reason_phrase}[/red]")
 
         except httpx.RequestError as e:
-            logger.info(f"[red]Request error: {e!s}[/red]")
+            logger.info(f"{self.tracker}: [red]Request error: {e!s}[/red]")
 
-        logger.info("[yellow]Could not find a matching release on HDBITS[/yellow]")
+        logger.info(f"{self.tracker}: [yellow]Could not find a matching release on HDBITS[/yellow]")
         return hdb_imdb, hdb_tvdb, hdb_name, hdb_torrenthash, hdb_description, hdb_id

--- a/src/trackers/hdspace.py
+++ b/src/trackers/hdspace.py
@@ -72,7 +72,7 @@ class HDSpace:
                 signature=f"[center][url=https://github.com/wastaken7/Upload-Assistant][size=2]{meta.ua_signature}[/size][/url][/center]",
             )
         except Exception as e:
-            logger.info(f"Error generating description: {e}")
+            logger.info(f"{self.tracker}: Error generating description: {e}")
             description = ""
 
         return description
@@ -93,7 +93,7 @@ class HDSpace:
 
         imdb_id = str(meta.imdb)
         if imdb_id == "0":
-            logger.info(f"IMDb ID not found, cannot search for duplicates on {self.tracker}.")
+            logger.info(f"{self.tracker}: IMDb ID not found, cannot search for duplicates on {self.tracker}.")
             return dupes
 
         search_url = f"{self.base_url}/index.php"
@@ -116,7 +116,7 @@ class HDSpace:
             response.raise_for_status()
             parts = response.text.split("Show/Hide Categories", 1)
             if len(parts) < 2:
-                logger.info(f"[bold yellow]{self.tracker}: Unexpected page structure on page {current_page}, stopping search[/bold yellow]")
+                logger.info(f"{self.tracker}: [bold yellow]Unexpected page structure on page {current_page}, stopping search[/bold yellow]")
                 break
             relevant_html = parts[1]
             soup = BeautifulSoup(relevant_html, "html.parser")
@@ -161,7 +161,7 @@ class HDSpace:
             else:
                 break
 
-        logger.info(f"[bold green]Found {len(dupes)} duplicates on {self.tracker}[/bold green]")
+        logger.info(f"{self.tracker}: [bold green]Found {len(dupes)} duplicates on {self.tracker}[/bold green]")
         return dupes
 
     async def get_category_id(self, meta: Meta) -> int:
@@ -246,7 +246,7 @@ class HDSpace:
             return results
 
         except Exception as e:
-            logger.info(f"An error occurred while fetching requests: {e}", extra={"markup": False})
+            logger.info(f"{self.tracker}: An error occurred while fetching requests: {e}", extra={"markup": False})
             return []
 
     async def get_data(self, meta: Meta) -> dict[str, Any]:

--- a/src/trackers/hdtorrents.py
+++ b/src/trackers/hdtorrents.py
@@ -171,7 +171,7 @@ class HDTorrents:
         if not hasattr(self, "auth_token") or not self.auth_token:
             credentials_valid = await self.validate_credentials(meta)
             if not credentials_valid:
-                logger.info(f"[bold red]{self.tracker}: Failed to validate credentials for search.")
+                logger.info(f"{self.tracker}: [bold red]Failed to validate credentials for search.")
                 return []
 
         search_url = f"{self.base_url}/torrents.php?"

--- a/src/trackers/iptorrents.py
+++ b/src/trackers/iptorrents.py
@@ -379,7 +379,7 @@ class IPTorrents:
             size_gb = total_size / (1024**3)
             return size_gb >= 8
         except Exception as e:
-            logger.info(f"[bold red]Error reading torrent file for size check on {self.tracker}: {e}[/bold red]")
+            logger.info(f"{self.tracker}: [bold red]Error reading torrent file for size check on {self.tracker}: {e}[/bold red]")
             return False
 
     async def get_data(self, meta: Meta):

--- a/src/trackers/makingoff.py
+++ b/src/trackers/makingoff.py
@@ -327,7 +327,7 @@ class MakingOff:
                                 )
                                 if stderr:
                                     logger.debug(f"{self.tracker}: [cyan][/cyan] ffmpeg stderr: {stderr.decode('utf-8', errors='ignore')}")
-                        except Exception as e:
+                        except (OSError, ValueError) as e:
                             logger.error(f"{self.tracker}: [cyan][/cyan] [red]Error running ffmpeg to extract subtitle: {e}[/red]")
 
         return sorted(set(pt_subs))
@@ -711,7 +711,7 @@ class MakingOff:
             if response is not None:
                 logger.debug(f"{self.tracker}: [cyan][/cyan] Response: {cast(httpx.Response, response).text}")
             return False
-        except Exception as e:
+        except ValueError as e:
             logger.error(f"{self.tracker}: [cyan][/cyan] [bold red]Failed to process upload response:[/bold red] {e}")
             return False
 
@@ -771,7 +771,7 @@ class MakingOff:
         except httpx.HTTPError as e:
             logger.error(f"{self.tracker}: [cyan][/cyan] [bold red]Error on the search POST:[/bold red] {e}")
             return None
-        except Exception as e:
+        except ValueError as e:
             logger.error(f"{self.tracker}: [cyan][/cyan] [bold red]Unwanted response while searching POST:[/bold red] {e}")
             return None
 
@@ -889,7 +889,7 @@ class MakingOff:
             if response is not None:
                 logger.debug(f"{self.tracker}: [cyan][/cyan] Response: {cast(httpx.Response, response).text}")
             return ""
-        except Exception as e:
+        except ValueError as e:
             logger.error(f"{self.tracker}: [cyan][/cyan] Failed to parse response: {e}")
             return ""
 
@@ -1598,7 +1598,7 @@ class MakingOff:
                         zipf.write(sub_file, arcname=Path(sub_file).name)
                 logger.info(f"{self.tracker}: [cyan][/cyan] [green]Zipped {len(sub_files)} subtitles to {Path(zip_path).name}[/green]")
                 sub_files = [zip_path]
-            except Exception as e:
+            except (OSError, zipfile.BadZipFile) as e:
                 logger.error(f"{self.tracker}: [cyan][/cyan] [red]Failed to create zip file for subtitles: {e}[/red]")
                 sub_files = []
 

--- a/src/trackers/makingoff.py
+++ b/src/trackers/makingoff.py
@@ -236,7 +236,7 @@ class MakingOff:
                 if content:
                     break
             except Exception as e:
-                logger.debug(f"Failed to read file {file_path} with encoding {enc}: {e}")
+                logger.debug(f"{self.tracker}: Failed to read file {file_path} with encoding {enc}: {e}")
                 continue
 
         if not content:
@@ -267,10 +267,10 @@ class MakingOff:
             name_lower = Path(sub_file).name.lower()
             if any(term in name_lower for term in (".pt", ".pt-br", ".por", "portuguese", "ptbr", "pt_br")):
                 pt_subs.append(sub_file)
-                logger.info(f"[cyan]{self.tracker}:[/cyan] [green]Found external Portuguese subtitle:[/green] {Path(sub_file).name}")
+                logger.info(f"{self.tracker}: [cyan][/cyan] [green]Found external Portuguese subtitle:[/green] {Path(sub_file).name}")
             elif self._is_subtitle_in_portuguese(sub_file):
                 pt_subs.append(sub_file)
-                logger.info(f"[cyan]{self.tracker}:[/cyan] [green]Found external Portuguese subtitle (content-matched):[/green] {Path(sub_file).name}")
+                logger.info(f"{self.tracker}: [cyan][/cyan] [green]Found external Portuguese subtitle (content-matched):[/green] {Path(sub_file).name}")
 
         # 2. Check embedded subtitle tracks (if it is a file upload, not a BD/DVD folder/disc structure)
         if not meta.is_disc and meta.filelist and len(meta.filelist) > 0:
@@ -314,19 +314,21 @@ class MakingOff:
                         ffmpeg_path = self._get_ffmpeg_path(meta)
                         cmd: list[str] = [ffmpeg_path, "-y", "-i", video_file, "-map", f"0:s:{idx}", output_path]
 
-                        logger.info(f"[cyan]{self.tracker}:[/cyan] Extracting embedded Portuguese subtitle (stream {idx}) to {output_name}...")
+                        logger.info(f"{self.tracker}: [cyan][/cyan] Extracting embedded Portuguese subtitle (stream {idx}) to {output_name}...")
                         try:
                             process = await asyncio.create_subprocess_exec(*cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
                             _, stderr = await process.communicate()
                             if process.returncode == 0 and Path(output_path).exists() and Path(output_path).stat().st_size > 0:
                                 pt_subs.append(output_path)
-                                logger.info(f"[cyan]{self.tracker}:[/cyan] [green]Successfully extracted embedded Portuguese subtitle.[/green]")
+                                logger.info(f"{self.tracker}: [cyan][/cyan] [green]Successfully extracted embedded Portuguese subtitle.[/green]")
                             else:
-                                logger.warning(f"[cyan]{self.tracker}:[/cyan] [yellow]Failed to extract subtitle stream {idx}. ffmpeg exit code: {process.returncode}[/yellow]")
+                                logger.warning(
+                                    f"{self.tracker}: [cyan][/cyan] [yellow]Failed to extract subtitle stream {idx}. ffmpeg exit code: {process.returncode}[/yellow]"
+                                )
                                 if stderr:
-                                    logger.debug(f"[cyan]{self.tracker}:[/cyan] ffmpeg stderr: {stderr.decode('utf-8', errors='ignore')}")
+                                    logger.debug(f"{self.tracker}: [cyan][/cyan] ffmpeg stderr: {stderr.decode('utf-8', errors='ignore')}")
                         except Exception as e:
-                            logger.error(f"[cyan]{self.tracker}:[/cyan] [red]Error running ffmpeg to extract subtitle: {e}[/red]")
+                            logger.error(f"{self.tracker}: [cyan][/cyan] [red]Error running ffmpeg to extract subtitle: {e}[/red]")
 
         return sorted(set(pt_subs))
 
@@ -556,7 +558,7 @@ class MakingOff:
             if response is not None:
                 html = cast(httpx.Response, response).text
             else:
-                logger.error(f"[cyan]{self.tracker}:[/cyan] Error validating session: {e}")
+                logger.error(f"{self.tracker}: [cyan][/cyan] Error validating session: {e}")
                 return False
 
         soup = BeautifulSoup(html, "html.parser")
@@ -564,7 +566,7 @@ class MakingOff:
         logged_in = html_tag.get("data-logged-in") == "true" if html_tag else False
 
         if not logged_in:
-            logger.warning(f"[cyan]{self.tracker}:[/cyan] The session is unauthenticated. Check the cookie file.")
+            logger.warning(f"{self.tracker}: [cyan][/cyan] The session is unauthenticated. Check the cookie file.")
             return False
 
         self._csrf_token = self._get_csrf_token(html)
@@ -586,7 +588,7 @@ class MakingOff:
             resp = await self.session.get(url)
             resp.raise_for_status()
         except httpx.HTTPError as e:
-            logger.error(f"[cyan]{self.tracker}:[/cyan] Failed loading topic new page: {e}")
+            logger.error(f"{self.tracker}: [cyan][/cyan] Failed loading topic new page: {e}")
             return "", "", ""
 
         soup = BeautifulSoup(resp.text, "html.parser")
@@ -594,7 +596,7 @@ class MakingOff:
         html_tag = soup.find("html")
         logged_in = html_tag.get("data-logged-in") == "true" if html_tag else False
         if not logged_in:
-            logger.warning(f"[cyan]{self.tracker}:[/cyan] Unauthenticated session detected on this page.")
+            logger.warning(f"{self.tracker}: [cyan][/cyan] Unauthenticated session detected on this page.")
             return "", "", ""
 
         csrf_token = self._get_csrf_token(resp.text)
@@ -610,7 +612,7 @@ class MakingOff:
             attachment_hash_combined = str(combined_tag.get("value", "")).strip()
 
         if not csrf_token:
-            logger.warning(f"[cyan]{self.tracker}:[/cyan] It wasn't possible to extract xfToken. Check if the session is valid.")
+            logger.warning(f"{self.tracker}: [cyan][/cyan] It wasn't possible to extract xfToken. Check if the session is valid.")
 
         return csrf_token, attachment_hash, attachment_hash_combined
 
@@ -672,7 +674,7 @@ class MakingOff:
                 attachment_type = combined_data.get("type", "post")
                 context = combined_data.get("context", {})
             except Exception as e:
-                logger.debug(f"Failed to parse attachment_hash_combined: {e}")
+                logger.debug(f"{self.tracker}: Failed to parse attachment_hash_combined: {e}")
 
         payload: dict[str, str] = {
             "_xfToken": csrf_token,
@@ -701,25 +703,25 @@ class MakingOff:
             resp.raise_for_status()
             res_data = resp.json()
         except FileNotFoundError:
-            logger.error(f"[cyan]{self.tracker}:[/cyan] [bold red]File not found[/bold red]: {file_path}")
+            logger.error(f"{self.tracker}: [cyan][/cyan] [bold red]File not found[/bold red]: {file_path}")
             return False
         except httpx.HTTPError as e:
-            logger.error(f"[cyan]{self.tracker}:[/cyan] [bold red]Failed uploading attachment:[/bold red] {e}")
+            logger.error(f"{self.tracker}: [cyan][/cyan] [bold red]Failed uploading attachment:[/bold red] {e}")
             response = getattr(e, "response", None)
             if response is not None:
-                logger.debug(f"[cyan]{self.tracker}:[/cyan] Response: {cast(httpx.Response, response).text}")
+                logger.debug(f"{self.tracker}: [cyan][/cyan] Response: {cast(httpx.Response, response).text}")
             return False
         except Exception as e:
-            logger.error(f"[cyan]{self.tracker}:[/cyan] [bold red]Failed to process upload response:[/bold red] {e}")
+            logger.error(f"{self.tracker}: [cyan][/cyan] [bold red]Failed to process upload response:[/bold red] {e}")
             return False
 
         if res_data.get("status") == "ok" or "attachment" in res_data:
-            logger.info(f"[cyan]{self.tracker}:[/cyan] [green]Attachment sent successfully: {filename}[/green]")
+            logger.info(f"{self.tracker}: [cyan][/cyan] [green]Attachment sent successfully: {filename}[/green]")
             return True
 
         errors = res_data.get("errors", {})
         error_msg = res_data.get("errorHtml", {}).get("content", "") or str(errors)
-        logger.error(f"[cyan]{self.tracker}:[/cyan] [bold red]Unwanted response while uploading attachment {filename}:[/bold red]\n{error_msg}")
+        logger.error(f"{self.tracker}: [cyan][/cyan] [bold red]Unwanted response while uploading attachment {filename}:[/bold red]\n{error_msg}")
         return False
 
     async def search_candidate(
@@ -743,7 +745,7 @@ class MakingOff:
         if not self._csrf_token:
             await self.refresh_session()
             if not self._csrf_token:
-                logger.error(f"[cyan]{self.tracker}:[/cyan] Cannot search, no CSRF token available.")
+                logger.error(f"{self.tracker}: [cyan][/cyan] Cannot search, no CSRF token available.")
                 return None
 
         search_url = f"{self.base_url}/search/search"
@@ -767,17 +769,17 @@ class MakingOff:
             resp.raise_for_status()
             res_data = resp.json()
         except httpx.HTTPError as e:
-            logger.error(f"[cyan]{self.tracker}:[/cyan] [bold red]Error on the search POST:[/bold red] {e}")
+            logger.error(f"{self.tracker}: [cyan][/cyan] [bold red]Error on the search POST:[/bold red] {e}")
             return None
         except Exception as e:
-            logger.error(f"[cyan]{self.tracker}:[/cyan] [bold red]Unwanted response while searching POST:[/bold red] {e}")
+            logger.error(f"{self.tracker}: [cyan][/cyan] [bold red]Unwanted response while searching POST:[/bold red] {e}")
             return None
 
         redirect_url = res_data.get("redirect")
         if not redirect_url:
             errors = res_data.get("errors", {})
             if errors:
-                logger.debug(f"[cyan]{self.tracker}:[/cyan] Search errors: {errors}")
+                logger.debug(f"{self.tracker}: [cyan][/cyan] Search errors: {errors}")
             return None
 
         if redirect_url.startswith("/"):
@@ -787,7 +789,7 @@ class MakingOff:
             resp = await self.session.get(redirect_url)
             resp.raise_for_status()
         except httpx.HTTPError as e:
-            logger.error(f"[cyan]{self.tracker}:[/cyan] [bold red]Error fetching search results page:[/bold red] {e}")
+            logger.error(f"{self.tracker}: [cyan][/cyan] [bold red]Error fetching search results page:[/bold red] {e}")
             return None
 
         soup = BeautifulSoup(resp.text, "html.parser")
@@ -882,13 +884,13 @@ class MakingOff:
             resp.raise_for_status()
             res_data = resp.json()
         except httpx.HTTPError as e:
-            logger.error(f"[cyan]{self.tracker}:[/cyan] Failed creating topic: {e}")
+            logger.error(f"{self.tracker}: [cyan][/cyan] Failed creating topic: {e}")
             response = getattr(e, "response", None)
             if response is not None:
-                logger.debug(f"[cyan]{self.tracker}:[/cyan] Response: {cast(httpx.Response, response).text}")
+                logger.debug(f"{self.tracker}: [cyan][/cyan] Response: {cast(httpx.Response, response).text}")
             return ""
         except Exception as e:
-            logger.error(f"[cyan]{self.tracker}:[/cyan] Failed to parse response: {e}")
+            logger.error(f"{self.tracker}: [cyan][/cyan] Failed to parse response: {e}")
             return ""
 
         if res_data.get("status") == "ok" and "redirect" in res_data:
@@ -899,7 +901,7 @@ class MakingOff:
 
         errors = res_data.get("errors", {})
         error_msg = res_data.get("errorHtml", {}).get("content", "") or str(errors)
-        logger.error(f"[cyan]{self.tracker}:[/cyan] [bold red]Failed creating topic:[/bold red]\n{error_msg}")
+        logger.error(f"{self.tracker}: [cyan][/cyan] [bold red]Failed creating topic:[/bold red]\n{error_msg}")
         return ""
 
     async def validate_credentials(self, meta: Meta) -> bool:
@@ -921,7 +923,7 @@ class MakingOff:
         self.session.cookies = cast(Any, cookie_jar)
 
         if not await self.refresh_session():
-            logger.error(f"[cyan]{self.tracker}:[/cyan] [bold red]Session couldn't be validated.[/bold red] Cookies may be expired.")
+            logger.error(f"{self.tracker}: [cyan][/cyan] [bold red]Session couldn't be validated.[/bold red] Cookies may be expired.")
             return False
 
         return True
@@ -963,7 +965,7 @@ class MakingOff:
 
         # 1. Search by IMDB ID (without title_only, as it is in the post description)
         if meta.imdb_tt:
-            logger.info(f"[cyan]{self.tracker}:[/cyan] [yellow]Searching by IMDB ID:[/yellow] {meta.imdb_tt}")
+            logger.info(f"{self.tracker}: [cyan][/cyan] [yellow]Searching by IMDB ID:[/yellow] {meta.imdb_tt}")
             found = await self.search_candidate(meta.imdb_tt, forum_id=forum_id, title_only=False)
             if found:
                 results.update(found)
@@ -971,7 +973,7 @@ class MakingOff:
         # 2. Search by title candidates (with title_only=True)
         for candidate in candidates:
             phrase = candidate.strip()
-            logger.info(f"[cyan]{self.tracker}:[/cyan] [yellow]Searching for title:[/yellow] {phrase}")
+            logger.info(f"{self.tracker}: [cyan][/cyan] [yellow]Searching for title:[/yellow] {phrase}")
             found = await self.search_candidate(phrase, forum_id=forum_id, title_only=True)
             if found:
                 results.update(found)
@@ -985,12 +987,12 @@ class MakingOff:
             if upload_year:
                 year_int = int(upload_year)
                 if not any(f"({y})" in title for y in (year_int - 1, year_int, year_int + 1)):
-                    logger.info(f"[cyan]{self.tracker}:[/cyan] [yellow]Skipping: different year in existing release:[/yellow] {title}")
+                    logger.info(f"{self.tracker}: [cyan][/cyan] [yellow]Skipping: different year in existing release:[/yellow] {title}")
                     continue
 
             # Uploading SD while a Hidef exists → block immediately.
             if not uploading_hidef and existing_hidef:
-                logger.warning(f"[cyan]{self.tracker}:[/cyan] [bold red]Aborting: A Hidef release exists:[/bold red] {title}")
+                logger.warning(f"{self.tracker}: [cyan][/cyan] [bold red]Aborting: A Hidef release exists:[/bold red] {title}")
                 meta.skipping = self.tracker
                 duplicates.append({"name": title, "size": "", "link": url})
                 continue
@@ -1008,7 +1010,7 @@ class MakingOff:
                 upload_height = 0
 
             if resolution >= upload_height:
-                logger.warning(f"[cyan]{self.tracker}:[/cyan] [bold red]Aborting: A better or equivalent Hidef release exists:[/bold red] {title}")
+                logger.warning(f"{self.tracker}: [cyan][/cyan] [bold red]Aborting: A better or equivalent Hidef release exists:[/bold red] {title}")
                 meta.skipping = self.tracker
                 duplicates.append({"name": title, "size": str(resolution), "link": url})
                 continue
@@ -1215,7 +1217,7 @@ class MakingOff:
                 return forum_id_by_country[code]
 
         logger.info(
-            f"[cyan]{self.tracker}:[/cyan] [bold yellow]Unmapped origin country [/bold yellow]({origin_countries}). [bold yellow]Select the subforum manually:[/bold yellow]"
+            f"{self.tracker}: [cyan][/cyan] [bold yellow]Unmapped origin country [/bold yellow]({origin_countries}). [bold yellow]Select the subforum manually:[/bold yellow]"
         )
         forum_options = {
             "1": (461, "África"),
@@ -1230,13 +1232,13 @@ class MakingOff:
             "10": (30, "Oriente Médio"),
         }
         for k, (fid, name) in forum_options.items():
-            logger.info(f"  {k}) {name} (ID: {fid})")
+            logger.info(f"{self.tracker}:   {k}) {name} (ID: {fid})")
 
         choice = (await asyncio.to_thread(input, "Escolha: ")).strip()
         if choice in forum_options:
             return forum_options[choice][0]
 
-        logger.warning(f"[cyan]{self.tracker}:[/cyan] [yellow]Invalid option, using North-American (26) as default.[/yellow]")
+        logger.warning(f"{self.tracker}: [cyan][/cyan] [yellow]Invalid option, using North-American (26) as default.[/yellow]")
         return 26
 
     # -- title resolution
@@ -1416,9 +1418,9 @@ class MakingOff:
             "4": "Fixas",
             "5": "Sem Legenda",
         }
-        logger.info(f"[cyan]{self.tracker}:[/cyan] [yellow]Any subtitles?[/yellow]")
+        logger.info(f"{self.tracker}: [cyan][/cyan] [yellow]Any subtitles?[/yellow]")
         for k, v in options.items():
-            logger.info(f"  {k}) {v}")
+            logger.info(f"{self.tracker}:   {k}) {v}")
         selection = (await asyncio.to_thread(input, "Choose: ")).strip()
         return options.get(selection, "Sem Legenda")
 
@@ -1541,16 +1543,16 @@ class MakingOff:
             bool: True if the release meets all requirements.
         """
         if meta.resolution == "2160p":
-            logger.warning(f"[cyan]{self.tracker}:[/cyan] [bold red]4K Resolution (2160p) isn't allowed on this forum.[/bold red]")
+            logger.warning(f"{self.tracker}: [cyan][/cyan] [bold red]4K Resolution (2160p) isn't allowed on this forum.[/bold red]")
             return False
 
         video = meta.video_codec.upper()
         if not any(c in video for c in ("H264", "H.264", "AVC")):
-            logger.warning(f"[cyan]{self.tracker}:[/cyan] [bold red]Only H.264 codec is allowed on this forum.[/bold red]")
+            logger.warning(f"{self.tracker}: [cyan][/cyan] [bold red]Only H.264 codec is allowed on this forum.[/bold red]")
             return False
 
         if not meta.is_disc and meta.container.upper() not in ("MKV", "AVI"):
-            logger.warning(f"[cyan]{self.tracker}:[/cyan] [bold red]Only MKV/AVI containers are allowed on this forum.[/bold red]")
+            logger.warning(f"{self.tracker}: [cyan][/cyan] [bold red]Only MKV/AVI containers are allowed on this forum.[/bold red]")
             return False
 
         return True
@@ -1566,7 +1568,7 @@ class MakingOff:
             bool: True if the upload succeeded.
         """
         forum_id = await self.get_forum_id(meta)
-        logger.info(f"[cyan]{self.tracker}:[/cyan] [green]Selected subforum:[/green] {forum_id} ")
+        logger.info(f"{self.tracker}: [cyan][/cyan] [green]Selected subforum:[/green] {forum_id} ")
         await self.common.create_torrent_for_upload(
             meta=meta,
             tracker=self.tracker,
@@ -1594,10 +1596,10 @@ class MakingOff:
                 with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zipf:
                     for sub_file in sub_files:
                         zipf.write(sub_file, arcname=Path(sub_file).name)
-                logger.info(f"[cyan]{self.tracker}:[/cyan] [green]Zipped {len(sub_files)} subtitles to {Path(zip_path).name}[/green]")
+                logger.info(f"{self.tracker}: [cyan][/cyan] [green]Zipped {len(sub_files)} subtitles to {Path(zip_path).name}[/green]")
                 sub_files = [zip_path]
             except Exception as e:
-                logger.error(f"[cyan]{self.tracker}:[/cyan] [red]Failed to create zip file for subtitles: {e}[/red]")
+                logger.error(f"{self.tracker}: [cyan][/cyan] [red]Failed to create zip file for subtitles: {e}[/red]")
                 sub_files = []
 
         if meta.debug:
@@ -1613,17 +1615,17 @@ class MakingOff:
                 post_body=post_body,
             )
 
-            logger.info(f"[cyan]{self.tracker} Request Data:[/cyan]")
+            logger.info(f"{self.tracker}: [cyan]Request Data:[/cyan]")
             logger.info(Redaction.redact_private_info(fields))
 
             if sub_files:
-                logger.info(f"[cyan]{self.tracker} Debug Subtitles to upload:[/cyan] {sub_files}")
+                logger.info(f"{self.tracker}: [cyan]Debug Subtitles to upload:[/cyan] {sub_files}")
 
             txt_path = f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/[{self.tracker}]DESCRIPTION.txt"
             async with aiofiles.open(txt_path, "w", encoding="utf-8") as f:
                 await f.write(f"TITULO: {topic_title}\n\n")
                 await f.write(post_body)
-            logger.info(f"[cyan]{self.tracker}:[/cyan] [yellow]BBCode saved.[/yellow] {txt_path}")
+            logger.info(f"{self.tracker}: [cyan][/cyan] [yellow]BBCode saved.[/yellow] {txt_path}")
             meta["tracker_status"][self.tracker]["status_message"] = "Debug mode enabled, not uploading (simulated successfully)"
             return True
 
@@ -1644,7 +1646,7 @@ class MakingOff:
 
         # Upload Portuguese subtitles if any
         for sub_file in sub_files:
-            logger.info(f"[cyan]{self.tracker}:[/cyan] [yellow]Uploading Portuguese subtitle as attachment:[/yellow] {Path(sub_file).name}")
+            logger.info(f"{self.tracker}: [cyan][/cyan] [yellow]Uploading Portuguese subtitle as attachment:[/yellow] {Path(sub_file).name}")
             await self.upload_attachment(sub_file, csrf_token, attachment_hash, attachment_hash_combined, forum_id)
 
         topic_title = await self.get_topic_title(meta)

--- a/src/trackers/morethantv.py
+++ b/src/trackers/morethantv.py
@@ -133,7 +133,7 @@ class MoreThanTV:
         if base_piece_mb > 8 and not meta.nohash:
             tracker_config = self.config["TRACKERS"].get(self.tracker, {})
             if str(tracker_config.get("skip_if_rehash", "false")).lower() == "false":
-                logger.info("[red]Piece size is OVER 8M and does not work on MORETHANTV. Generating a new .torrent")
+                logger.info(f"{self.tracker}: [red]Piece size is OVER 8M and does not work on MORETHANTV. Generating a new .torrent")
                 piece_size = 8
                 tracker_url = str(tracker_config.get("announce_url", "https://fake.tracker")).strip()
                 torrent_create = f"[{self.tracker}]"
@@ -148,7 +148,7 @@ class MoreThanTV:
                 await common.create_torrent_for_upload(meta, self.tracker, self.source_flag, torrent_filename=torrent_create)
 
             else:
-                logger.info("[red]Piece size is OVER 8M and skip_if_rehash enabled. Skipping upload.")
+                logger.info(f"{self.tracker}: [red]Piece size is OVER 8M and skip_if_rehash enabled. Skipping upload.")
                 return None
         else:
             await common.create_torrent_for_upload(meta, self.tracker, self.source_flag)
@@ -232,8 +232,8 @@ class MoreThanTV:
                         if "authkey.php" in str(response.url):
                             meta.tracker_status[self.tracker]["status_message"] = "data error - No DL link in response, It may have uploaded, check manually."
                         else:
-                            logger.info(f"response URL: {response.url}")
-                            logger.info(f"response status: {response.status_code}")
+                            logger.info(f"{self.tracker}: response URL: {response.url}")
+                            logger.info(f"{self.tracker}: response status: {response.status_code}")
                         return False
                     except Exception:
                         meta.tracker_status[self.tracker]["status_message"] = "data error -It may have uploaded, check manually."
@@ -243,7 +243,7 @@ class MoreThanTV:
                 meta.tracker_status[self.tracker]["status_message"] = f"data error: {e}"
                 return False
         else:
-            logger.info("[cyan]MORETHANTV Request Data:")
+            logger.info(f"{self.tracker}: [cyan]Request Data:")
             debug_data = data.copy()
             if "auth" in debug_data:
                 auth_value = str(debug_data.get("auth", ""))
@@ -504,7 +504,7 @@ class MoreThanTV:
             await self.login(cookiefile)
         vcookie = await self.validate_cookies(meta, cookiefile)
         if vcookie is not True:
-            logger.error("[red]Failed to validate cookies. Please confirm that the site is up and your username and password is valid.")
+            logger.error(f"{self.tracker}: [red]Failed to validate cookies. Please confirm that the site is up and your username and password is valid.")
             if "mtv_timeout" in meta and meta.mtv_timeout:
                 meta.skipping = "MORETHANTV"
                 return False
@@ -529,29 +529,29 @@ class MoreThanTV:
                 async with httpx.AsyncClient(cookies=cookies_dict, timeout=10) as client:
                     try:
                         resp = await client.get(url=url)
-                        logger.debug("[cyan]Validating MORETHANTV Cookies:")
+                        logger.debug(f"{self.tracker}: [cyan]Validating MORETHANTV Cookies:")
 
                         if "Logout" in resp.text:
                             return True
-                        logger.info("[yellow]Valid session not found in cookies")
+                        logger.info(f"{self.tracker}: [yellow]Valid session not found in cookies")
                         return False
 
                     except httpx.TimeoutException:
-                        logger.info(f"[red]Connection to {url} timed out. The site may be down or unreachable.")
+                        logger.info(f"{self.tracker}: [red]Connection to {url} timed out. The site may be down or unreachable.")
                         meta.mtv_timeout = True
                         return False
                     except httpx.ConnectError:
-                        logger.error(f"[red]Failed to connect to {url}. The site may be down or your connection is blocked.")
+                        logger.error(f"{self.tracker}: [red]Failed to connect to {url}. The site may be down or your connection is blocked.")
                         meta.mtv_timeout = True
                         return False
                     except Exception as e:
-                        logger.error(f"[red]Error connecting to MORETHANTV: {e!s}")
+                        logger.error(f"{self.tracker}: [red]Error connecting to MORETHANTV: {e!s}")
                         return False
             except Exception as e:
-                logger.error(f"[red]Error loading cookies: {e!s}")
+                logger.error(f"{self.tracker}: [red]Error loading cookies: {e!s}")
                 return False
         else:
-            logger.info("[yellow]Cookie file not found")
+            logger.info(f"{self.tracker}: [yellow]Cookie file not found")
             return False
 
     async def get_auth(self, cookiefile: str) -> str:
@@ -567,16 +567,16 @@ class MoreThanTV:
                         resp = await client.get(url=url)
                         if "authkey=" in resp.text:
                             return resp.text.rsplit("authkey=", 1)[1][:32]
-                        logger.info("[yellow]Auth key not found in response")
+                        logger.info(f"{self.tracker}: [yellow]Auth key not found in response")
                         return ""
                     except httpx.RequestError as e:
-                        logger.error(f"[red]Error getting auth key: {e!s}")
+                        logger.error(f"{self.tracker}: [red]Error getting auth key: {e!s}")
                         return ""
             else:
-                logger.info("[yellow]Cookie file not found for auth key retrieval")
+                logger.info(f"{self.tracker}: [yellow]Cookie file not found for auth key retrieval")
                 return ""
         except Exception as e:
-            logger.error(f"[red]Unexpected error retrieving auth key: {e!s}")
+            logger.error(f"{self.tracker}: [red]Unexpected error retrieving auth key: {e!s}")
             return ""
 
     async def login(self, cookiefile: str) -> bool:
@@ -596,7 +596,7 @@ class MoreThanTV:
                     res = await client.get(url=f"{self.base_url}/login")
 
                     if 'name="token" value="' not in res.text:
-                        logger.info("[red]Unable to find token in login page")
+                        logger.info(f"{self.tracker}: [red]Unable to find token in login page")
                         return False
 
                     token = res.text.rsplit('name="token" value="', 1)[1][:48]
@@ -621,36 +621,36 @@ class MoreThanTV:
 
                     await asyncio.sleep(1)
                     if "authkey=" in resp.text:
-                        logger.info("[green]Successfully logged in to MORETHANTV")
+                        logger.info(f"{self.tracker}: [green]Successfully logged in to MORETHANTV")
                         cookies_dict = dict(client.cookies)
                         cookies_data = await self.async_json_dumps(cookies_dict)
                         async with aiofiles.open(cookiefile, "w", encoding="utf-8") as cf:
                             await cf.write(cookies_data)
-                        logger.info(f"[green]Cookies saved to {cookiefile}")
+                        logger.info(f"{self.tracker}: [green]Cookies saved to {cookiefile}")
                         return True
-                    logger.info("[bold red]Something went wrong while trying to log into MORETHANTV")
-                    logger.info(f"[red]Final URL: {resp.url}")
+                    logger.info(f"{self.tracker}: [bold red]Something went wrong while trying to log into MORETHANTV")
+                    logger.info(f"{self.tracker}: [red]Final URL: {resp.url}")
                     return False
 
                 except httpx.TimeoutException:
-                    logger.info("[red]Connection to MORETHANTV timed out. The site may be down or unreachable.")
+                    logger.info(f"{self.tracker}: [red]Connection to MORETHANTV timed out. The site may be down or unreachable.")
                     return False
                 except httpx.ConnectError:
-                    logger.error("[red]Failed to connect to MORETHANTV. The site may be down or your connection is blocked.")
+                    logger.error(f"{self.tracker}: [red]Failed to connect to MORETHANTV. The site may be down or your connection is blocked.")
                     return False
                 except Exception as e:
-                    logger.error(f"[red]Error during MORETHANTV login: {e!s}")
-                    logger.info(f"[dim red]{traceback.format_exc()}[/dim red]")
+                    logger.error(f"{self.tracker}: [red]Error during MORETHANTV login: {e!s}")
+                    logger.info(f"{self.tracker}: [dim red]{traceback.format_exc()}[/dim red]")
                     return False
         except Exception as e:
-            logger.error(f"[red]Unexpected error during login: {e!s}")
-            logger.info(f"[dim red]{traceback.format_exc()}[/dim red]")
+            logger.error(f"{self.tracker}: [red]Unexpected error during login: {e!s}")
+            logger.info(f"{self.tracker}: [dim red]{traceback.format_exc()}[/dim red]")
         return False
 
     async def get_additional_checks(self, meta: Meta) -> bool:
         if meta.type not in ["WEBDL"] and meta.tag and any(x in meta.tag for x in ["EVO"]):
             if not meta.unattended or (meta.unattended and meta.unattended_confirm):
-                logger.info(f"[bold red]Group {meta.tag} is only allowed for raw type content at {self.tracker}[/bold red]")
+                logger.info(f"{self.tracker}: [bold red]Group {meta.tag} is only allowed for raw type content at {self.tracker}[/bold red]")
                 if cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
                     pass
                 else:
@@ -698,13 +698,13 @@ class MoreThanTV:
         if meta.resolution not in ["2160p"] and meta.video_codec in ["HEVC"]:
             if meta.anime and meta.tag and not any(x in meta.tag for x in allowed_anime):
                 if not meta.unattended or (meta.unattended and meta.unattended_confirm):
-                    logger.info(f"[bold red]Only 4K HEVC anime releases from {meta.tag} are allowed at {self.tracker}[/bold red]")
+                    logger.info(f"{self.tracker}: [bold red]Only 4K HEVC anime releases from {meta.tag} are allowed at {self.tracker}[/bold red]")
                     if cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
                         pass
                     else:
                         return False
             else:
-                logger.info(f"[bold red]Only 4K HEVC releases are allowed at {self.tracker}[/bold red]")
+                logger.info(f"{self.tracker}: [bold red]Only 4K HEVC releases are allowed at {self.tracker}[/bold red]")
                 if not meta.unattended or (meta.unattended and meta.unattended_confirm):
                     if cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
                         pass
@@ -726,7 +726,7 @@ class MoreThanTV:
         genres_lower = {g.lower() for g in genres_list if g}
         if any(keyword in keywords_lower for keyword in disallowed_keywords) or any(genre in genres_lower for genre in disallowed_genres):
             if not meta.unattended or (meta.unattended and meta.unattended_confirm):
-                logger.info(f"[bold red]Porn/xxx is not allowed at {self.tracker}.[/bold red]")
+                logger.info(f"{self.tracker}: [bold red]Porn/xxx is not allowed at {self.tracker}.[/bold red]")
                 if cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
                     pass
                 else:

--- a/src/trackers/morethantv.py
+++ b/src/trackers/morethantv.py
@@ -12,6 +12,7 @@ import cli_ui
 import httpx
 import pyotp
 from defusedxml import ElementTree
+from rich.markup import escape
 
 from cogs.redaction import Redaction
 from src.console import console, logger
@@ -133,7 +134,7 @@ class MoreThanTV:
         if base_piece_mb > 8 and not meta.nohash:
             tracker_config = self.config["TRACKERS"].get(self.tracker, {})
             if str(tracker_config.get("skip_if_rehash", "false")).lower() == "false":
-                logger.info(f"{self.tracker}: [red]Piece size is OVER 8M and does not work on MORETHANTV. Generating a new .torrent")
+                logger.info(f"{self.tracker}: [red]Piece size is OVER 8M and does not work on {self.tracker}. Generating a new .torrent")
                 piece_size = 8
                 tracker_url = str(tracker_config.get("announce_url", "https://fake.tracker")).strip()
                 torrent_create = f"[{self.tracker}]"
@@ -529,7 +530,7 @@ class MoreThanTV:
                 async with httpx.AsyncClient(cookies=cookies_dict, timeout=10) as client:
                     try:
                         resp = await client.get(url=url)
-                        logger.debug(f"{self.tracker}: [cyan]Validating MORETHANTV Cookies:")
+                        logger.debug(f"{self.tracker}: [cyan]Validating {self.tracker} Cookies:")
 
                         if "Logout" in resp.text:
                             return True
@@ -544,11 +545,11 @@ class MoreThanTV:
                         logger.error(f"{self.tracker}: [red]Failed to connect to {url}. The site may be down or your connection is blocked.")
                         meta.mtv_timeout = True
                         return False
-                    except Exception as e:
-                        logger.error(f"{self.tracker}: [red]Error connecting to MORETHANTV: {e!s}")
+                    except httpx.HTTPError as e:
+                        logger.error(f"{self.tracker}: [red]HTTP error connecting to {self.tracker}: {escape(str(e))}")
                         return False
-            except Exception as e:
-                logger.error(f"{self.tracker}: [red]Error loading cookies: {e!s}")
+            except (OSError, ValueError) as e:
+                logger.error(f"{self.tracker}: [red]Error loading cookies: {escape(str(e))}")
                 return False
         else:
             logger.info(f"{self.tracker}: [yellow]Cookie file not found")
@@ -570,13 +571,13 @@ class MoreThanTV:
                         logger.info(f"{self.tracker}: [yellow]Auth key not found in response")
                         return ""
                     except httpx.RequestError as e:
-                        logger.error(f"{self.tracker}: [red]Error getting auth key: {e!s}")
+                        logger.error(f"{self.tracker}: [red]Error getting auth key: {escape(str(e))}")
                         return ""
             else:
                 logger.info(f"{self.tracker}: [yellow]Cookie file not found for auth key retrieval")
                 return ""
-        except Exception as e:
-            logger.error(f"{self.tracker}: [red]Unexpected error retrieving auth key: {e!s}")
+        except (OSError, ValueError) as e:
+            logger.error(f"{self.tracker}: [red]Error loading cookies or parsing JSON: {escape(str(e))}")
             return ""
 
     async def login(self, cookiefile: str) -> bool:
@@ -611,9 +612,9 @@ class MoreThanTV:
                                 otp = pyotp.parse_uri(otp_uri)
                                 mfa_code = pyotp.TOTP(otp.secret).now()
                             except ValueError, TypeError:
-                                mfa_code = console.input("[yellow]MORETHANTV 2FA Code: ")
+                                mfa_code = console.input(f"[yellow]{self.tracker} 2FA Code: ")
                         else:
-                            mfa_code = console.input("[yellow]MORETHANTV 2FA Code: ")
+                            mfa_code = console.input(f"[yellow]{self.tracker} 2FA Code: ")
 
                         two_factor_token = resp.text.rsplit('name="token" value="', 1)[1][:48]
                         two_factor_payload = {"token": two_factor_token, "code": mfa_code, "submit": "login"}
@@ -621,30 +622,31 @@ class MoreThanTV:
 
                     await asyncio.sleep(1)
                     if "authkey=" in resp.text:
-                        logger.info(f"{self.tracker}: [green]Successfully logged in to MORETHANTV")
+                        logger.info(f"{self.tracker}: [green]Successfully logged in to {self.tracker}")
                         cookies_dict = dict(client.cookies)
                         cookies_data = await self.async_json_dumps(cookies_dict)
                         async with aiofiles.open(cookiefile, "w", encoding="utf-8") as cf:
                             await cf.write(cookies_data)
                         logger.info(f"{self.tracker}: [green]Cookies saved to {cookiefile}")
                         return True
-                    logger.info(f"{self.tracker}: [bold red]Something went wrong while trying to log into MORETHANTV")
+                    logger.info(f"{self.tracker}: [bold red]Something went wrong while trying to log into {self.tracker}")
                     logger.info(f"{self.tracker}: [red]Final URL: {resp.url}")
                     return False
 
                 except httpx.TimeoutException:
-                    logger.info(f"{self.tracker}: [red]Connection to MORETHANTV timed out. The site may be down or unreachable.")
+                    logger.info(f"{self.tracker}: [red]Connection to {self.tracker} timed out. The site may be down or unreachable.")
                     return False
                 except httpx.ConnectError:
-                    logger.error(f"{self.tracker}: [red]Failed to connect to MORETHANTV. The site may be down or your connection is blocked.")
+                    logger.error(f"{self.tracker}: [red]Failed to connect to {self.tracker}. The site may be down or your connection is blocked.")
                     return False
-                except Exception as e:
-                    logger.error(f"{self.tracker}: [red]Error during MORETHANTV login: {e!s}")
-                    logger.info(f"{self.tracker}: [dim red]{traceback.format_exc()}[/dim red]")
+                except (httpx.HTTPError, KeyError, IndexError, ValueError) as e:
+                    logger.error(f"{self.tracker}: [red]Error during {self.tracker} login: {escape(str(e))}")
+                    logger.info(f"{self.tracker}: [dim red]{escape(traceback.format_exc())}[/dim red]")
                     return False
         except Exception as e:
-            logger.error(f"{self.tracker}: [red]Unexpected error during login: {e!s}")
-            logger.info(f"{self.tracker}: [dim red]{traceback.format_exc()}[/dim red]")
+            logger.error(f"{self.tracker}: [red]Unexpected error during login: {escape(str(e))}")
+            logger.info(f"{self.tracker}: [dim red]{escape(traceback.format_exc())}[/dim red]")
+            raise
         return False
 
     async def get_additional_checks(self, meta: Meta) -> bool:

--- a/src/trackers/morethantv.py
+++ b/src/trackers/morethantv.py
@@ -244,7 +244,7 @@ class MoreThanTV:
                 meta.tracker_status[self.tracker]["status_message"] = f"data error: {e}"
                 return False
         else:
-            logger.info(f"{self.tracker}: [cyan]Request Data:")
+            logger.info(f"{self.tracker}: Request Data:")
             debug_data = data.copy()
             if "auth" in debug_data:
                 auth_value = str(debug_data.get("auth", ""))

--- a/src/trackers/mteam.py
+++ b/src/trackers/mteam.py
@@ -161,7 +161,7 @@ class MTeam:
             return response.json()
 
         except Exception as e:
-            logger.info(f"Error fetching Douban info: {e}")
+            logger.info(f"{self.tracker}: Error fetching Douban info: {e}")
             return info
 
     async def mteam_standard_desc(self, meta: Meta):
@@ -601,7 +601,7 @@ class MTeam:
                 return False
 
         else:
-            logger.info("[cyan]M-Team Request Data:")
+            logger.info(f"{self.tracker}: [cyan]M-Team Request Data:")
             logger.info(Redaction.redact_private_info(data))
             meta.tracker_status[self.tracker]["status_message"] = "Debug mode enabled, not uploading"
             await self.common.create_torrent_for_upload(meta, f"{self.tracker}" + "_DEBUG", f"{self.tracker}" + "_DEBUG", announce_url="https://fake.tracker")

--- a/src/trackers/mteam.py
+++ b/src/trackers/mteam.py
@@ -601,7 +601,7 @@ class MTeam:
                 return False
 
         else:
-            logger.info(f"{self.tracker}: [cyan]M-Team Request Data:")
+            logger.info(f"{self.tracker}: [cyan]{self.tracker} Request Data:")
             logger.info(Redaction.redact_private_info(data))
             meta.tracker_status[self.tracker]["status_message"] = "Debug mode enabled, not uploading"
             await self.common.create_torrent_for_upload(meta, f"{self.tracker}" + "_DEBUG", f"{self.tracker}" + "_DEBUG", announce_url="https://fake.tracker")

--- a/src/trackers/nebulance.py
+++ b/src/trackers/nebulance.py
@@ -157,7 +157,7 @@ class Nebulance:
                         meta.tracker_status[self.tracker]["status_message"] = response_data
                     return False
             else:
-                logger.info("[cyan]NEBULANCE Request Data:")
+                logger.info(f"{self.tracker}: [cyan]Request Data:")
                 logger.info(Redaction.redact_private_info(data))
                 meta.tracker_status[self.tracker]["status_message"] = "Debug mode enabled, not uploading."
                 await self.common.create_torrent_for_upload(meta, f"{self.tracker}" + "_DEBUG", f"{self.tracker}" + "_DEBUG", announce_url="https://fake.tracker")
@@ -170,7 +170,7 @@ class Nebulance:
         if meta.category != "TV":
             if meta.tvmaze_id != 0:
                 if not meta.unattended or (meta.unattended and meta.unattended_confirm):
-                    logger.info("[red]Only TV or TV Movies are allowed at NEBULANCE, this has a tvmaze ID[/red]")
+                    logger.info(f"{self.tracker}: [red]Only TV or TV Movies are allowed at NEBULANCE, this has a tvmaze ID[/red]")
                     if cli_ui.ask_yes_no("Do you want to upload it?", default=False):
                         pass
                     else:
@@ -179,7 +179,7 @@ class Nebulance:
                     return False
             else:
                 if not meta.unattended:
-                    logger.info("[red]Only TV Is allowed at NEBULANCE")
+                    logger.info(f"{self.tracker}: [red]Only TV Is allowed at NEBULANCE")
                 return False
 
         if meta.is_disc != "BDMV" and not await self.common.check_language_requirements(
@@ -188,12 +188,12 @@ class Nebulance:
             return False
 
         if meta.valid_mi is False:
-            logger.info(f"[bold red]No unique ID in mediainfo, skipping {self.tracker} upload.")
+            logger.info(f"{self.tracker}: [bold red]No unique ID in mediainfo, skipping {self.tracker} upload.")
             return False
 
         if meta.is_disc:
             if not meta.unattended:
-                logger.info("[bold red]NEBULANCE does not allow raw discs")
+                logger.info(f"{self.tracker}: [bold red]does not allow raw discs")
             return False
 
         return True

--- a/src/trackers/nebulance.py
+++ b/src/trackers/nebulance.py
@@ -157,7 +157,7 @@ class Nebulance:
                         meta.tracker_status[self.tracker]["status_message"] = response_data
                     return False
             else:
-                logger.info(f"{self.tracker}: [cyan]Request Data:")
+                logger.info(f"{self.tracker}: Request Data:")
                 logger.info(Redaction.redact_private_info(data))
                 meta.tracker_status[self.tracker]["status_message"] = "Debug mode enabled, not uploading."
                 await self.common.create_torrent_for_upload(meta, f"{self.tracker}" + "_DEBUG", f"{self.tracker}" + "_DEBUG", announce_url="https://fake.tracker")

--- a/src/trackers/nebulance.py
+++ b/src/trackers/nebulance.py
@@ -150,7 +150,7 @@ class Nebulance:
                                 meta.tracker_status[self.tracker]["torrent_id"] = torrent_id
                             return True
                         except json.JSONDecodeError:
-                            meta.tracker_status[self.tracker]["status_message"] = "data error: NEBULANCE json decode error, the API is probably down"
+                            meta.tracker_status[self.tracker]["status_message"] = f"data error: {self.tracker} json decode error, the API is probably down"
                             return False
                     else:
                         response_data = {"error": f"Unexpected status code: {response.status_code}", "response_content": response.text}
@@ -170,7 +170,7 @@ class Nebulance:
         if meta.category != "TV":
             if meta.tvmaze_id != 0:
                 if not meta.unattended or (meta.unattended and meta.unattended_confirm):
-                    logger.info(f"{self.tracker}: [red]Only TV or TV Movies are allowed at NEBULANCE, this has a tvmaze ID[/red]")
+                    logger.info(f"{self.tracker}: [red]Only TV or TV Movies are allowed at {self.tracker}, this has a tvmaze ID[/red]")
                     if cli_ui.ask_yes_no("Do you want to upload it?", default=False):
                         pass
                     else:
@@ -179,7 +179,7 @@ class Nebulance:
                     return False
             else:
                 if not meta.unattended:
-                    logger.info(f"{self.tracker}: [red]Only TV Is allowed at NEBULANCE")
+                    logger.info(f"{self.tracker}: [red]Only TV Is allowed at {self.tracker}[/red]")
                 return False
 
         if meta.is_disc != "BDMV" and not await self.common.check_language_requirements(
@@ -193,7 +193,7 @@ class Nebulance:
 
         if meta.is_disc:
             if not meta.unattended:
-                logger.info(f"{self.tracker}: [bold red]does not allow raw discs")
+                logger.info(f"{self.tracker}: [bold red]does not allow raw discs[/bold red]")
             return False
 
         return True

--- a/src/trackers/orpheus.py
+++ b/src/trackers/orpheus.py
@@ -8,6 +8,7 @@ from typing import Any, ClassVar, cast
 from urllib.parse import urlparse
 
 import httpx
+from rich.markup import escape
 
 from src.console import logger
 from src.meta import Meta
@@ -157,22 +158,36 @@ class Orpheus:
             async with httpx.AsyncClient(timeout=httpx.Timeout(8.0), headers=self._headers(meta)) as client:
                 response = await client.get(f"{self.base_url}/ajax.php", params=params)
                 response.raise_for_status()
-                payload = cast(dict[str, Any], response.json())
+                raw_json = response.json()
         except (httpx.HTTPError, ValueError) as error:
             logger.warning(f"{self.tracker}: [yellow]read-only duplicate search failed: {error}[/yellow]")
             return []
+        if not isinstance(raw_json, dict):
+            return []
+        payload = cast(dict[str, Any], raw_json)
         if payload.get("status") != "success":
             return []
-        response_data = cast(dict[str, Any], payload.get("response") or {})
-        results = cast(list[Any], response_data.get("results") or [])
+        response_data = payload.get("response")
+        if not isinstance(response_data, dict):
+            return []
+        response_data_dict = cast(dict[str, Any], response_data)
+        results = response_data_dict.get("results")
+        if not isinstance(results, list):
+            return []
+        results_list = cast(list[Any], results)
         dupes: list[dict[str, Any]] = []
-        for group_item in results:
+        for group_item in results_list:
+            if not isinstance(group_item, dict):
+                continue
             group = cast(dict[str, Any], group_item)
             group_id = group.get("groupId")
-            editions = cast(list[Any], group.get("torrents") or [])
+            editions = group.get("torrents")
+            if not isinstance(editions, list):
+                continue
+            editions_list = cast(list[Any], editions)
             encodings = [
                 f"{cast(dict[str, Any], torrent).get('media', '')} {cast(dict[str, Any], torrent).get('format', '')} {cast(dict[str, Any], torrent).get('encoding', '')}".strip()
-                for torrent in editions
+                for torrent in editions_list
                 if isinstance(torrent, dict)
             ]
             dupes.append(
@@ -201,14 +216,16 @@ class Orpheus:
             async with httpx.AsyncClient(timeout=httpx.Timeout(15.0), headers=self._headers(meta)) as client:
                 response = await client.get(f"{self.base_url}/ajax.php", params={"action": "torrent", "id": identifier})
                 response.raise_for_status()
-                payload = cast(dict[str, Any], response.json())
+                raw_json = response.json()
         except (httpx.HTTPError, ValueError) as error:
             logger.warning(f"{self.tracker}: [yellow]read-only torrent lookup failed for {identifier}: {error}[/yellow]")
             return None
+        if not isinstance(raw_json, dict):
+            return None
+        payload = cast(dict[str, Any], raw_json)
         response_data = payload.get("response")
         if payload.get("status") == "success" and isinstance(response_data, dict):
-            ret_val: dict[str, Any] = cast(dict[str, Any], response_data)
-            return ret_val
+            return cast(dict[str, Any], response_data)
         return None
 
     async def get_requests(self, meta: Meta) -> list[dict[str, Any]]:
@@ -236,17 +253,28 @@ class Orpheus:
             async with httpx.AsyncClient(timeout=httpx.Timeout(10.0), headers=self._headers(meta)) as client:
                 response = await client.get(f"{self.base_url}/ajax.php", params=params)
                 response.raise_for_status()
-                payload = cast(dict[str, Any], response.json())
+                raw_json = response.json()
         except (httpx.HTTPError, ValueError) as error:
             logger.warning(f"{self.tracker}: [yellow]read-only request search failed: {error}[/yellow]")
             return []
-        response_data = cast(dict[str, Any], payload.get("response") or {})
-        records = cast(list[Any], response_data.get("results") or [])
+        if not isinstance(raw_json, dict):
+            return []
+        payload = cast(dict[str, Any], raw_json)
         if payload.get("status") != "success":
             return []
+        response_data = payload.get("response")
+        if not isinstance(response_data, dict):
+            return []
+        response_data_dict = cast(dict[str, Any], response_data)
+        records = response_data_dict.get("results")
+        if not isinstance(records, list):
+            return []
+        records_list = cast(list[Any], records)
 
         matches: list[dict[str, Any]] = []
-        for record_item in records:
+        for record_item in records_list:
+            if not isinstance(record_item, dict):
+                continue
             record = cast(dict[str, Any], record_item)
             if record.get("isFilled"):
                 continue
@@ -280,7 +308,9 @@ class Orpheus:
         if matches:
             logger.info(f"{self.tracker}: [bold yellow]matching open music request(s) found; review requirements before filling:[/bold yellow]")
             for match in matches:
-                logger.info(f"[bold green]{match['match_type'].title()} match:[/bold green] {match['name']} — bounty: {match['bounty']}")
+                logger.info(
+                    f"{self.tracker}: [bold green]{match['match_type'].title()} match:[/bold green] {escape(str(match['name']))} — bounty: {escape(str(match['bounty']))}"
+                )
                 logger.info(f"{self.tracker}: [cyan]{match['url']}[/cyan]")
                 logger.info(f"{self.tracker}: [yellow]Requested technical fields: {match['requirements']}[/yellow]")
         meta.tracker_status.setdefault(self.tracker, {})["request_matches"] = matches

--- a/src/trackers/orpheus.py
+++ b/src/trackers/orpheus.py
@@ -1,15 +1,10 @@
-"""Orpheus (Gazelle) music tracker adapter.
-
-Read-only API calls are intentionally separate from ``upload``.  The latter is
-only reached by Upload Assistant's normal confirmed upload workflow.
-"""
-
 from __future__ import annotations
 
 import json
+import platform
 import re
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
 from urllib.parse import urlparse
 
 import httpx
@@ -22,6 +17,8 @@ from src.trackers.common import Common
 
 
 class Orpheus:
+    """Orpheus is a Private Torrent Tracker for MUSIC"""
+
     tracker = "ORPHEUS"
     display_name = "Orpheus"
     auth_type = "other_api"
@@ -83,8 +80,8 @@ class Orpheus:
         self.torrent_url = f"{self.base_url}/torrents.php?torrentid="
         self.common = Common(config)
 
-    def _headers(self) -> dict[str, str]:
-        return {"Authorization": f"token {self.api_key}", "User-Agent": "Upload-Assistant/2.x"}
+    def _headers(self, meta: Meta) -> dict[str, str]:
+        return {"Authorization": f"token {self.api_key}", "User-Agent": f"{meta.ua_name} {meta.current_version} ({platform.system()} {platform.release()})"}
 
     @staticmethod
     def _release(meta: Meta) -> MusicRelease:
@@ -145,7 +142,7 @@ class Orpheus:
         status = meta.tracker_status.setdefault(self.tracker, {})
         status["status_message"] = message
         status["blocked_reasons"] = reasons
-        logger.error(f"[red]ORPHEUS: {message}[/red]")
+        logger.error(f"{self.tracker}: [red]{message}[/red]")
         return False
 
     async def search_existing(self, meta: Meta) -> list[dict[str, Any]]:
@@ -155,24 +152,29 @@ class Orpheus:
         if not artist or not album or not self.api_key:
             return []
         params = {"action": "browse", "artistname": artist, "groupname": album}
+        payload: dict[str, Any] = {}
         try:
-            async with httpx.AsyncClient(timeout=httpx.Timeout(8.0), headers=self._headers()) as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(8.0), headers=self._headers(meta)) as client:
                 response = await client.get(f"{self.base_url}/ajax.php", params=params)
                 response.raise_for_status()
-                payload = response.json()
+                payload = cast(dict[str, Any], response.json())
         except (httpx.HTTPError, ValueError) as error:
-            logger.warning(f"[yellow]ORPHEUS: read-only duplicate search failed: {error}[/yellow]")
+            logger.warning(f"{self.tracker}: [yellow]read-only duplicate search failed: {error}[/yellow]")
             return []
         if payload.get("status") != "success":
             return []
-        results = payload.get("response", {}).get("results", [])
+        response_data = cast(dict[str, Any], payload.get("response") or {})
+        results = cast(list[Any], response_data.get("results") or [])
         dupes: list[dict[str, Any]] = []
-        for group in results:
-            if not isinstance(group, dict):
-                continue
+        for group_item in results:
+            group = cast(dict[str, Any], group_item)
             group_id = group.get("groupId")
-            editions = group.get("torrents", [])
-            encodings = [f"{torrent.get('media', '')} {torrent.get('format', '')} {torrent.get('encoding', '')}".strip() for torrent in editions if isinstance(torrent, dict)]
+            editions = cast(list[Any], group.get("torrents") or [])
+            encodings = [
+                f"{cast(dict[str, Any], torrent).get('media', '')} {cast(dict[str, Any], torrent).get('format', '')} {cast(dict[str, Any], torrent).get('encoding', '')}".strip()
+                for torrent in editions
+                if isinstance(torrent, dict)
+            ]
             dupes.append(
                 {
                     "name": f"{group.get('artist', '')} - {group.get('groupName', '')}".strip(" -"),
@@ -185,7 +187,7 @@ class Orpheus:
             )
         return dupes
 
-    async def get_torrent(self, torrent_id: int | str) -> dict[str, Any] | None:
+    async def get_torrent(self, torrent_id: int | str, meta: Meta) -> dict[str, Any] | None:
         """Return one Orpheus torrent's Gazelle metadata using a read-only API call.
 
         This is deliberately separate from upload and is useful for local
@@ -194,16 +196,20 @@ class Orpheus:
         identifier = str(torrent_id).strip()
         if not identifier.isdigit() or not self.api_key:
             return None
+        payload: dict[str, Any] = {}
         try:
-            async with httpx.AsyncClient(timeout=httpx.Timeout(15.0), headers=self._headers()) as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(15.0), headers=self._headers(meta)) as client:
                 response = await client.get(f"{self.base_url}/ajax.php", params={"action": "torrent", "id": identifier})
                 response.raise_for_status()
-                payload = response.json()
+                payload = cast(dict[str, Any], response.json())
         except (httpx.HTTPError, ValueError) as error:
-            logger.warning(f"[yellow]ORPHEUS: read-only torrent lookup failed for {identifier}: {error}[/yellow]")
+            logger.warning(f"{self.tracker}: [yellow]read-only torrent lookup failed for {identifier}: {error}[/yellow]")
             return None
         response_data = payload.get("response")
-        return response_data if payload.get("status") == "success" and isinstance(response_data, dict) else None
+        if payload.get("status") == "success" and isinstance(response_data, dict):
+            ret_val: dict[str, Any] = cast(dict[str, Any], response_data)
+            return ret_val
+        return None
 
     async def get_requests(self, meta: Meta) -> list[dict[str, Any]]:
         """Search open MUSIC requests with one bounded, read-only API call.
@@ -219,28 +225,30 @@ class Orpheus:
         album = str(release.get("album", "")).strip()
         if not album:
             return []
-        params: list[tuple[str, str]] = [
-            ("action", "requests"),
-            ("search", album),
-            ("show_filled", "false"),
-            ("filter_cat[]", "1"),
-        ]
+        params = {
+            "action": "requests",
+            "search": album,
+            "show_filled": "false",
+            "filter_cat[]": "1",
+        }
+        payload: dict[str, Any] = {}
         try:
-            async with httpx.AsyncClient(timeout=httpx.Timeout(10.0), headers=self._headers()) as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(10.0), headers=self._headers(meta)) as client:
                 response = await client.get(f"{self.base_url}/ajax.php", params=params)
                 response.raise_for_status()
-                payload = response.json()
+                payload = cast(dict[str, Any], response.json())
         except (httpx.HTTPError, ValueError) as error:
-            logger.warning(f"[yellow]ORPHEUS: read-only request search failed: {error}[/yellow]")
+            logger.warning(f"{self.tracker}: [yellow]read-only request search failed: {error}[/yellow]")
             return []
-        response_data = payload.get("response", {})
-        records = response_data.get("results", []) if isinstance(response_data, dict) else []
-        if payload.get("status") != "success" or not isinstance(records, list):
+        response_data = cast(dict[str, Any], payload.get("response") or {})
+        records = cast(list[Any], response_data.get("results") or [])
+        if payload.get("status") != "success":
             return []
 
         matches: list[dict[str, Any]] = []
-        for record in records:
-            if not isinstance(record, dict) or record.get("isFilled"):
+        for record_item in records:
+            record = cast(dict[str, Any], record_item)
+            if record.get("isFilled"):
                 continue
             match_type = self._request_match_type(release, record)
             if match_type is None:
@@ -270,11 +278,11 @@ class Orpheus:
             )
 
         if matches:
-            logger.info("[bold yellow]ORPHEUS: matching open music request(s) found; review requirements before filling:[/bold yellow]")
+            logger.info(f"{self.tracker}: [bold yellow]matching open music request(s) found; review requirements before filling:[/bold yellow]")
             for match in matches:
                 logger.info(f"[bold green]{match['match_type'].title()} match:[/bold green] {match['name']} — bounty: {match['bounty']}")
-                logger.info(f"[cyan]{match['url']}[/cyan]")
-                logger.info(f"[yellow]Requested technical fields: {match['requirements']}[/yellow]")
+                logger.info(f"{self.tracker}: [cyan]{match['url']}[/cyan]")
+                logger.info(f"{self.tracker}: [yellow]Requested technical fields: {match['requirements']}[/yellow]")
         meta.tracker_status.setdefault(self.tracker, {})["request_matches"] = matches
         return matches
 
@@ -285,11 +293,14 @@ class Orpheus:
     @classmethod
     def _request_artists(cls, record: dict[str, Any]) -> list[str]:
         artists: list[str] = []
-        for role in record.get("artists", []):
+        role_list = cast(list[Any], record.get("artists") or [])
+        for role in role_list:
             if not isinstance(role, list):
                 continue
-            for artist in role:
-                if isinstance(artist, dict):
+            role_items = cast(list[Any], role)
+            for artist_item in role_items:
+                if isinstance(artist_item, dict):
+                    artist = cast(dict[str, Any], artist_item)
                     name = str(artist.get("name", "")).strip()
                     if name and name not in artists:
                         artists.append(name)
@@ -336,7 +347,7 @@ class Orpheus:
             status["status_message"] = "Debug mode: upload skipped; payload prepared locally. Artwork is optional on Orpheus."
             status["debug_payload_fields"] = sorted(data)
             status["debug_payload"] = debug_payload
-            logger.info("[yellow]ORPHEUS: debug mode enabled; POST upload skipped. Prepared payload:[/yellow]")
+            logger.info(f"{self.tracker}: [yellow]debug mode enabled; POST upload skipped. Prepared payload:[/yellow]")
             logger.info(json.dumps(debug_payload, ensure_ascii=False, indent=2), extra={"markup": False})
             return True
         if not self.api_key or not self.announce_url:
@@ -349,7 +360,7 @@ class Orpheus:
             return False
         data = self.build_upload_payload(meta, release)
         try:
-            async with httpx.AsyncClient(timeout=httpx.Timeout(60.0), headers=self._headers()) as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(60.0), headers=self._headers(meta)) as client:
                 with torrent_path.open("rb") as torrent_file:
                     files: list[tuple[str, tuple[str, Any, str]]] = [("file_input", (torrent_path.name, torrent_file, "application/x-bittorrent"))]
                     for log in release.auxiliary.logs:
@@ -388,30 +399,36 @@ class Orpheus:
         if not isinstance(payload, dict):
             status["status_message"] = "Orpheus returned a malformed upload response."
             return False
-        if payload.get("status") != "success":
-            error = str(payload.get("error", "")).strip()
+        response_payload: dict[str, Any] = cast(dict[str, Any], payload)
+        if response_payload.get("status") != "success":
+            error = str(response_payload.get("error", "")).strip()
             status["status_message"] = f"Orpheus rejected the upload request: {error}" if error else "Orpheus rejected the upload request."
             return False
 
-        result = payload.get("response")
+        result = response_payload.get("response")
         if not isinstance(result, dict):
             status["status_message"] = "Orpheus accepted the request but returned no upload result. Verify it on the tracker."
             return True
+        result_dict: dict[str, Any] = cast(dict[str, Any], result)
 
-        torrent_id = result.get("torrentId")
-        group_id = result.get("groupId")
+        torrent_id = result_dict.get("torrentId")
+        group_id = result_dict.get("groupId")
         if torrent_id is not None:
             status["torrent_id"] = torrent_id
         if group_id is not None:
             status["group_id"] = group_id
-        if "newgroup" in result:
-            status["new_group"] = bool(result["newgroup"])
-        response_warnings = result.get("warnings", [])
-        warnings = [str(warning).strip() for warning in response_warnings if warning is not None and str(warning).strip()] if isinstance(response_warnings, list) else []
+        if "newgroup" in result_dict:
+            status["new_group"] = bool(result_dict["newgroup"])
+        response_warnings = result_dict.get("warnings")
+        warnings: list[str] = (
+            [str(warning).strip() for warning in cast(list[Any], response_warnings) if warning is not None and str(warning).strip()]
+            if isinstance(response_warnings, list)
+            else []
+        )
         if warnings:
             status["warnings"] = warnings
             status["status_message"] = f"Upload accepted by Orpheus. Warnings: {' | '.join(warnings)}"
-            logger.warning(f"[yellow]ORPHEUS upload accepted with warning(s): {' | '.join(warnings)}[/yellow]")
+            logger.warning(f"{self.tracker}: [yellow]upload accepted with warning(s): {' | '.join(warnings)}[/yellow]")
         else:
             status["status_message"] = "Upload accepted by Orpheus."
         return True
@@ -476,9 +493,9 @@ class Orpheus:
 
     @staticmethod
     def _artists(release: MusicRelease) -> list[str]:
-        values = release.get("artists", [])
+        values = release.get("artists")
         if isinstance(values, list):
-            artists = [str(value).strip() for value in values if str(value).strip()]
+            artists = [str(value).strip() for value in cast(list[Any], values) if value is not None and str(value).strip()]
             if artists:
                 return artists
         artist = str(release.get("artist", "")).strip()

--- a/src/trackers/passthepopcorn.py
+++ b/src/trackers/passthepopcorn.py
@@ -131,11 +131,11 @@ class PassThePopcorn:
         self.api_key = config["TRACKERS"]["PassThePopcorn"].get("api_key", "").strip()
         announce_url = config["TRACKERS"]["PassThePopcorn"].get("announce_url", "").strip()
         if announce_url and announce_url.startswith("http://"):
-            logger.info("[red]PassThePopcorn announce URL is using plaintext HTTP.\n")
+            logger.info(f"{self.tracker}: [red]announce URL is using plaintext HTTP.\n")
             logger.info(
-                "[red]PassThePopcorn is turning off their plaintext HTTP tracker soon. You must update your announce URLS. See PassThePopcorn/forums.php?page=1&action=viewthread&threadid=46663"
+                f"{self.tracker}: [red]is turning off their plaintext HTTP tracker soon. You must update your announce URLS. See PassThePopcorn/forums.php?page=1&action=viewthread&threadid=46663"
             )
-            logger.info("[yellow]Modifying the url to use HTTPS. Update your config file to avoid this message in the future.")
+            logger.info(f"{self.tracker}: [yellow]Modifying the url to use HTTPS. Update your config file to avoid this message in the future.")
             self.announce_url = announce_url.replace("http://", "https://").replace(":2710", "")
         else:
             self.announce_url = announce_url
@@ -154,20 +154,20 @@ class PassThePopcorn:
             tag_clean = meta.tag.strip().lower()
             banned_groups_lower = {g.lower() for g in self.banned_groups}
             if tag_clean in banned_groups_lower:
-                logger.info(f"[red]{self.tracker}: Release group {meta.tag} is banned. Skipping upload.[/red]")
+                logger.info(f"{self.tracker}: [red]Release group {meta.tag} is banned. Skipping upload.[/red]")
                 return False
 
         if not self.api_user:
-            logger.info(f"[red]{self.tracker}: API User is missing in config. Skipping upload.[/red]")
+            logger.info(f"{self.tracker}: [red]API User is missing in config. Skipping upload.[/red]")
             return False
 
         if not self.username or not self.password:
-            logger.info(f"[red]{self.tracker}: Username or Password is missing in config. Skipping upload.[/red]")
+            logger.info(f"{self.tracker}: [red]Username or Password is missing in config. Skipping upload.[/red]")
             return False
 
         passkey_match = re.match(r"https?://please\.passthepopcorn\.me:?\d*/(.+)/announce", self.announce_url)
         if not passkey_match:
-            logger.info(f"[red]{self.tracker}: Failed to extract passkey from PassThePopcorn announce URL. Skipping upload.[/red]")
+            logger.info(f"{self.tracker}: [red]Failed to extract passkey from PassThePopcorn announce URL. Skipping upload.[/red]")
             return False
 
         return True
@@ -219,18 +219,18 @@ class PassThePopcorn:
                     if imdb_value:
                         return int(imdb_value or 0), ptp_torrent_id, ptp_torrent_hash
 
-                logger.info(f"[yellow]Could not find any release matching [bold yellow]{search_value}[/bold yellow] on PassThePopcorn")
+                logger.info(f"{self.tracker}: [yellow]Could not find any release matching [bold yellow]{search_value}[/bold yellow] on PassThePopcorn")
                 return None, None, None
 
             if response.status_code in [400, 401, 403]:
-                logger.info("[bold red]PassThePopcorn Error: 400/401/403 - Invalid request or authentication failed[/bold red]")
+                logger.info(f"{self.tracker}: [bold red]Error: 400/401/403 - Invalid request or authentication failed[/bold red]")
                 return None, None, None
             if response.status_code == 503:
-                logger.info("[bold yellow]PassThePopcorn Unavailable (503)")
+                logger.info(f"{self.tracker}: [bold yellow]Unavailable (503)")
                 return None, None, None
             return None, None, None
         except Exception as e:
-            logger.info(f"[red]An error occurred: {e!s}[/red]")
+            logger.info(f"{self.tracker}: [red]An error occurred: {e!s}[/red]")
             return None, None, None
 
     async def get_imdb_from_torrent_id(self, ptp_torrent_id: int | str) -> tuple[int | None, str | None]:
@@ -253,7 +253,7 @@ class PassThePopcorn:
                 logger.info(response.text)
                 return None, None
             if response.status_code == 503:
-                logger.info("[bold yellow]PassThePopcorn Unavailable (503)")
+                logger.info(f"{self.tracker}: [bold yellow]Unavailable (503)")
                 return None, None
             return None, None
         except Exception:
@@ -263,7 +263,7 @@ class PassThePopcorn:
         params = {"id": ptp_torrent_id, "action": "get_description"}
         headers = {"ApiUser": self.api_user, "api_key": self.api_key, "User-Agent": self.user_agent}
         url = f"{self.base_url}/torrents.php"
-        logger.info(f"[yellow]Requesting description from {url} with ID {ptp_torrent_id}")
+        logger.info(f"{self.tracker}: [yellow]Requesting description from {url} with ID {ptp_torrent_id}")
         async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
             response = await client.get(url, params=params, headers=headers)
         await asyncio.sleep(1)
@@ -276,12 +276,12 @@ class PassThePopcorn:
         desc, imagelist = bbcode.clean_ptp_description(ptp_desc, is_disc)
 
         if not meta.skip_tracker_descriptions:
-            logger.info("[bold green]Successfully grabbed description from PassThePopcorn")
-            logger.info(f"Description after cleaning:\n{desc[:1000]}...", extra={"markup": False})  # Show first 1000 characters for brevity
+            logger.info(f"{self.tracker}: [bold green]Successfully grabbed description from PassThePopcorn")
+            logger.info(f"{self.tracker}: Description after cleaning:\n{desc[:1000]}...", extra={"markup": False})  # Show first 1000 characters for brevity
 
             if not meta.skipit and not meta.unattended:
                 # Allow user to edit or discard the description
-                logger.info("[cyan]Do you want to edit, discard or keep the description?[/cyan]")
+                logger.info(f"{self.tracker}: [cyan]Do you want to edit, discard or keep the description?[/cyan]")
                 edit_choice = cli_ui.ask_string("Enter 'e' to edit, 'd' to discard, or press Enter to keep it as is: ")
 
                 if (edit_choice or "").lower() == "e":
@@ -290,12 +290,12 @@ class PassThePopcorn:
                         desc = edited_description.strip()
                         meta.description = desc
                         meta.saved_description = True
-                    logger.info(f"[green]Final description after editing:[/green] {desc}")
+                    logger.info(f"{self.tracker}: [green]Final description after editing:[/green] {desc}")
                 elif (edit_choice or "").lower() == "d":
                     desc = None
-                    logger.info("[yellow]Description discarded.[/yellow]")
+                    logger.info(f"{self.tracker}: [yellow]Description discarded.[/yellow]")
                 else:
-                    logger.info("[green]Keeping the original description.[/green]")
+                    logger.info(f"{self.tracker}: [green]Keeping the original description.[/green]")
                     meta.description = desc
                     meta.saved_description = True
             else:
@@ -314,24 +314,24 @@ class PassThePopcorn:
         await asyncio.sleep(1)
         try:
             if response.status_code != 200:
-                logger.info(f"[red]PassThePopcorn group lookup failed with HTTP {response.status_code}[/red]")
+                logger.info(f"{self.tracker}: [red]group lookup failed with HTTP {response.status_code}[/red]")
                 if response.text:
-                    logger.info(f"[red]Response body (truncated): {response.text[:200]}[/red]")
+                    logger.info(f"{self.tracker}: [red]Response body (truncated): {response.text[:200]}[/red]")
                 return None
 
             try:
                 response_data = response.json()
             except json.JSONDecodeError:
                 content_type = response.headers.get("content-type", "unknown")
-                logger.info(f"[red]PassThePopcorn group lookup returned non-JSON content (content-type: {content_type})[/red]")
+                logger.info(f"{self.tracker}: [red]group lookup returned non-JSON content (content-type: {content_type})[/red]")
                 if response.text:
-                    logger.info(f"[red]Response body (truncated): {response.text[:200]}[/red]")
+                    logger.info(f"{self.tracker}: [red]Response body (truncated): {response.text[:200]}[/red]")
                 return None
 
             if response_data.get("TotalResults"):  # Search results page
                 total_results = int(response_data.get("TotalResults", 0))
                 if total_results == 0:
-                    logger.info(f"[yellow]No results found for IMDb: tt{imdb}[/yellow]")
+                    logger.info(f"{self.tracker}: [yellow]No results found for IMDb: tt{imdb}[/yellow]")
                     return None
                 if total_results == 1:
                     # Single result - use it
@@ -339,11 +339,11 @@ class PassThePopcorn:
                     group_id: str | None = str(movie.get("GroupId")) if movie.get("GroupId") is not None else None
                     title = movie.get("Title", "Unknown")
                     year = movie.get("Year", "Unknown")
-                    logger.info(f"[green]Found single match for IMDb: [yellow]tt{imdb}[/yellow] -> Group ID: [yellow]{group_id}[/yellow][/green]")
-                    logger.info(f"[green]Title: [yellow]{title}[/yellow] ([yellow]{year}[/yellow])")
+                    logger.info(f"{self.tracker}: [green]Found single match for IMDb: [yellow]tt{imdb}[/yellow] -> Group ID: [yellow]{group_id}[/yellow][/green]")
+                    logger.info(f"{self.tracker}: [green]Title: [yellow]{title}[/yellow] ([yellow]{year}[/yellow])")
                     return group_id
                 # Multiple results - let user choose
-                logger.info(f"[yellow]Found {total_results} matches for IMDb: tt{imdb}[/yellow]")
+                logger.info(f"{self.tracker}: [yellow]Found {total_results} matches for IMDb: tt{imdb}[/yellow]")
                 movies = cast(list[dict[str, Any]], response_data.get("Movies", []))
                 choices: list[str] = []
                 for _i, movie in enumerate(movies):
@@ -358,7 +358,7 @@ class PassThePopcorn:
                 try:
                     selected = cli_ui.ask_choice("Select the correct movie:", choices=choices)
                     if selected == "Skip - Don't use any of these matches":
-                        logger.info("[yellow]User chose to skip all matches[/yellow]")
+                        logger.info(f"{self.tracker}: [yellow]User chose to skip all matches[/yellow]")
                         return None
 
                     # Match selection directly to movie data to avoid index issues from cli_ui sorting
@@ -371,22 +371,22 @@ class PassThePopcorn:
                             group_id = str(group_id)
                             break
 
-                    logger.info(f"[green]User selected: Group ID [yellow]{group_id}[/yellow][/green]")
+                    logger.info(f"{self.tracker}: [green]User selected: Group ID [yellow]{group_id}[/yellow][/green]")
                     return group_id
 
                 except KeyboardInterrupt:
-                    logger.info("[yellow]Selection cancelled by user[/yellow]")
+                    logger.info(f"{self.tracker}: [yellow]Selection cancelled by user[/yellow]")
                     return None
             elif response_data.get("Page") == "Browse":  # No Releases on Site with ID
                 return None
             elif response_data.get("Page") == "Details":  # Group Found
                 group_id = response_data.get("GroupId")
-                logger.info(f"[green]Matched IMDb: [yellow]tt{imdb}[/yellow] to Group ID: [yellow]{group_id}[/yellow][/green]")
-                logger.info(f"[green]Title: [yellow]{response_data.get('Name')}[/yellow] ([yellow]{response_data.get('Year')}[/yellow])")
+                logger.info(f"{self.tracker}: [green]Matched IMDb: [yellow]tt{imdb}[/yellow] to Group ID: [yellow]{group_id}[/yellow][/green]")
+                logger.info(f"{self.tracker}: [green]Title: [yellow]{response_data.get('Name')}[/yellow] ([yellow]{response_data.get('Year')}[/yellow])")
                 return str(group_id) if group_id is not None else None
         except Exception:
-            logger.info("[red]An error has occurred trying to find a group ID")
-            logger.info("[red]Please check that the site is online and your ApiUser/api_key values are correct")
+            logger.info(f"{self.tracker}: [red]An error has occurred trying to find a group ID")
+            logger.info(f"{self.tracker}: [red]Please check that the site is online and your ApiUser/api_key values are correct")
             return None
 
         return None
@@ -569,7 +569,7 @@ class PassThePopcorn:
                 if isinstance(uploaded_url, str) and uploaded_url:
                     return uploaded_url
         except Exception as e:
-            logger.info(f"[red]PassThePopcorn poster rehost to {selected_host} failed: {e}")
+            logger.info(f"{self.tracker}: [red]poster rehost to {selected_host} failed: {e}")
 
         return image_url
 
@@ -848,7 +848,7 @@ class PassThePopcorn:
         multi_screens = int(self.config["DEFAULT"].get("multiScreens", 2))
         if multi_screens < 2:
             multi_screens = 2
-            logger.info("[yellow]PassThePopcorn requires at least 2 screenshots for multi disc/file content, overriding config")
+            logger.info(f"{self.tracker}: [yellow]requires at least 2 screenshots for multi disc/file content, overriding config")
 
         image_list_value: Any = (meta.PTP_images_key if "PTP_images_key" in meta else meta.image_list) if not meta.skip_imghost_upload else []
         image_list = cast(list[dict[str, Any]], image_list_value) if isinstance(image_list_value, list) else []
@@ -881,10 +881,10 @@ class PassThePopcorn:
                                 if host_key in self.approved_image_hosts:
                                     images_to_keep.append(img)
                                 elif meta.debug:
-                                    logger.info(f"[yellow]Filtering out image from non-approved host: {hostname}[/yellow]")
+                                    logger.info(f"{self.tracker}: [yellow]Filtering out image from non-approved host: {hostname}[/yellow]")
                             except Exception:
                                 # If URL parsing fails, skip this image
-                                logger.debug(f"[yellow]Could not parse URL: {raw_url}[/yellow]")
+                                logger.debug(f"{self.tracker}: [yellow]Could not parse URL: {raw_url}[/yellow]")
                                 continue
 
                         if images_to_keep:
@@ -898,7 +898,7 @@ class PassThePopcorn:
                     # Remove keys with no approved images
                     for key_name in keys_to_remove:
                         del pack_images_data["keys"][key_name]
-                        logger.debug(f"[yellow]Removed key '{key_name}' - no approved image hosts[/yellow]")
+                        logger.debug(f"{self.tracker}: [yellow]Removed key '{key_name}' - no approved image hosts[/yellow]")
 
                     # Recalculate total count
                     keys = cast(dict[str, Any], pack_images_data.get("keys", {}))
@@ -906,12 +906,14 @@ class PassThePopcorn:
 
                     if pack_images_data.get("total_count", 0) < 3:
                         pack_images_data = {}  # Invalidate if less than 3 images total
-                        logger.debug("[yellow]Invalidating pack images - less than 3 approved images total[/yellow]")
+                        logger.debug(f"{self.tracker}: [yellow]Invalidating pack images - less than 3 approved images total[/yellow]")
                     else:
-                        logger.debug(f"[green]Loaded previously uploaded images from {pack_images_file}")
-                        logger.debug(f"[blue]Found {pack_images_data.get('total_count', 0)} approved images across {len(pack_images_data.get('keys', {}))} keys[/blue]")
+                        logger.debug(f"{self.tracker}: [green]Loaded previously uploaded images from {pack_images_file}")
+                        logger.debug(
+                            f"{self.tracker}: [blue]Found {pack_images_data.get('total_count', 0)} approved images across {len(pack_images_data.get('keys', {}))} keys[/blue]"
+                        )
             except Exception as e:
-                logger.warning(f"[yellow]Warning: Could not load pack image data: {e!s}[/yellow]")
+                logger.warning(f"{self.tracker}: [yellow]Warning: Could not load pack image data: {e!s}[/yellow]")
 
         desc = io.StringIO()
         discs = cast(list[dict[str, Any]], meta.discs)
@@ -940,7 +942,7 @@ class PassThePopcorn:
                         desc.write(tonemapped_header)
                         desc.write("\n\n")
                 except Exception as e:
-                    logger.warning(f"[yellow]Warning: Error setting tonemapped header: {e!s}[/yellow]")
+                    logger.warning(f"{self.tracker}: [yellow]Warning: Error setting tonemapped header: {e!s}[/yellow]")
                 for img_index in range(len(images[: meta.screens])):
                     raw_url = str(image_list[img_index].get("raw_url", ""))
                     desc.write(f"[img]{raw_url}[/img]\n")
@@ -973,7 +975,7 @@ class PassThePopcorn:
                     if pack_images_data and "keys" in pack_images_data and new_images_key in pack_images_data["keys"]:
                         saved_images = cast(list[dict[str, Any]], pack_images_data["keys"][new_images_key]["images"])
                         if saved_images:
-                            logger.debug(f"[yellow]Using saved images from pack_image_links.json for {new_images_key}")
+                            logger.debug(f"{self.tracker}: [yellow]Using saved images from pack_image_links.json for {new_images_key}")
 
                             meta[new_images_key] = []
                             for img in saved_images:
@@ -985,7 +987,7 @@ class PassThePopcorn:
                         desc.write(f"\n[b]{edition}[/b]\n\n")
                         # Use the summary corresponding to the current bdinfo
                         desc.write(f"[mediainfo]{summary}[/mediainfo]\n\n")
-                        logger.debug("[yellow]Using original uploaded images for first disc")
+                        logger.debug(f"{self.tracker}: [yellow]Using original uploaded images for first disc")
                         for img in meta[new_images_key]:
                             raw_url = str(img.get("raw_url", ""))
                             desc.write(f"[img]{raw_url}[/img]\n")
@@ -1003,7 +1005,7 @@ class PassThePopcorn:
                                     meta, f"PLAYLIST_{i}", bdinfo, meta.uuid, meta.base_dir, use_vs, [], meta.ffdebug, multi_screens, True
                                 )
                             except Exception as e:
-                                logger.info(f"Error during BDMV screenshot capture: {e}", extra={"markup": False})
+                                logger.info(f"{self.tracker}: Error during BDMV screenshot capture: {e}", extra={"markup": False})
                             new_screens = [f.name for f in (Path(meta.base_dir) / "tmp" / meta.uuid).glob(f"PLAYLIST_{i}-*.png")]
                         uploaded_images: list[dict[str, Any]] = []
                         if new_screens and not meta.skip_imghost_upload:
@@ -1045,7 +1047,7 @@ class PassThePopcorn:
                                 desc.write(tonemapped_header)
                                 desc.write("\n\n")
                         except Exception as e:
-                            logger.warning(f"[yellow]Warning: Error setting tonemapped header: {e!s}[/yellow]")
+                            logger.warning(f"{self.tracker}: [yellow]Warning: Error setting tonemapped header: {e!s}[/yellow]")
                         for img_index in range(min(multi_screens, len(image_list))):
                             raw_url = str(image_list[img_index].get("raw_url", ""))
                             desc.write(f"[img]{raw_url}[/img]\n")
@@ -1060,7 +1062,7 @@ class PassThePopcorn:
                         if pack_images_data and "keys" in pack_images_data and new_images_key in pack_images_data["keys"]:
                             saved_images = cast(list[dict[str, Any]], pack_images_data["keys"][new_images_key]["images"])
                             if saved_images:
-                                logger.debug(f"[yellow]Using saved images from pack_image_links.json for {new_images_key}")
+                                logger.debug(f"{self.tracker}: [yellow]Using saved images from pack_image_links.json for {new_images_key}")
 
                                 meta[new_images_key] = []
                                 for img in saved_images:
@@ -1082,7 +1084,7 @@ class PassThePopcorn:
                                         meta, f"FILE_{i}", each["bdinfo"], meta.uuid, meta.base_dir, meta.vapoursynth, [], meta.ffdebug, multi_screens, True
                                     )
                                 except Exception as e:
-                                    logger.info(f"Error during BDMV screenshot capture: {e}", extra={"markup": False})
+                                    logger.info(f"{self.tracker}: Error during BDMV screenshot capture: {e}", extra={"markup": False})
                             new_screens = [f.name for f in (Path(meta.base_dir) / "tmp" / meta.uuid).glob(f"FILE_{i}-*.png")]
                             uploaded_images: list[dict[str, Any]] = []
                             if new_screens and not meta.skip_imghost_upload:
@@ -1128,7 +1130,7 @@ class PassThePopcorn:
                         if pack_images_data and "keys" in pack_images_data and new_images_key in pack_images_data["keys"]:
                             saved_images = pack_images_data["keys"][new_images_key]["images"]
                             if saved_images:
-                                logger.debug(f"[yellow]Using saved images from pack_image_links.json for {new_images_key}")
+                                logger.debug(f"{self.tracker}: [yellow]Using saved images from pack_image_links.json for {new_images_key}")
 
                                 meta[new_images_key] = []
                                 for img in saved_images:
@@ -1146,7 +1148,7 @@ class PassThePopcorn:
                                 try:
                                     await self.takescreens_manager.dvd_screenshots(meta, i, multi_screens, True)
                                 except Exception as e:
-                                    logger.info(f"Error during DVD screenshot capture: {e}", extra={"markup": False})
+                                    logger.info(f"{self.tracker}: Error during DVD screenshot capture: {e}", extra={"markup": False})
                             new_screens = [f.name for f in (Path(meta.base_dir) / "tmp" / meta.uuid).glob(f"{glob.escape(meta.discs[i]['name'])}-*.png")]
                             uploaded_images: list[dict[str, Any]] = []
                             if new_screens and not meta.skip_imghost_upload:
@@ -1206,7 +1208,7 @@ class PassThePopcorn:
                     desc.write(tonemapped_header)
                     desc.write("\n\n")
             except Exception as e:
-                logger.warning(f"[yellow]Warning: Error setting tonemapped header: {e!s}[/yellow]")
+                logger.warning(f"{self.tracker}: [yellow]Warning: Error setting tonemapped header: {e!s}[/yellow]")
 
             for img_index in range(len(images[: meta.screens])):
                 raw_url = image_list[img_index]["raw_url"]
@@ -1233,7 +1235,7 @@ class PassThePopcorn:
                             desc.write(tonemapped_header)
                             desc.write("\n\n")
                     except Exception as e:
-                        logger.warning(f"[yellow]Warning: Error setting tonemapped header: {e!s}[/yellow]")
+                        logger.warning(f"{self.tracker}: [yellow]Warning: Error setting tonemapped header: {e!s}[/yellow]")
                     for img_index in range(min(multi_screens, len(image_list))):
                         raw_url = image_list[img_index]["raw_url"]
                         desc.write(f"[img]{raw_url}[/img]\n")
@@ -1251,7 +1253,7 @@ class PassThePopcorn:
                     if pack_images_data and "keys" in pack_images_data and new_images_key in pack_images_data["keys"]:
                         saved_images = pack_images_data["keys"][new_images_key]["images"]
                         if saved_images:
-                            logger.debug(f"[yellow]Using saved images from pack_image_links.json for {new_images_key}")
+                            logger.debug(f"{self.tracker}: [yellow]Using saved images from pack_image_links.json for {new_images_key}")
 
                             meta[new_images_key] = []
                             for img in saved_images:
@@ -1269,7 +1271,7 @@ class PassThePopcorn:
                             try:
                                 await self.takescreens_manager.screenshots(file, f"FILE_{i}", meta.uuid, meta.base_dir, meta, multi_screens, True, "")
                             except Exception as e:
-                                logger.info(f"Error during generic screenshot capture: {e}", extra={"markup": False})
+                                logger.info(f"{self.tracker}: Error during generic screenshot capture: {e}", extra={"markup": False})
                         new_screens = [f.name for f in (Path(meta.base_dir) / "tmp" / meta.uuid).glob(f"FILE_{i}-*.png")]
                         if new_screens and not meta.skip_imghost_upload:
                             uploaded_images, _ = await self.uploadscreens_manager.upload_screens(
@@ -1301,7 +1303,7 @@ class PassThePopcorn:
         image_list: list[dict[str, Any]] | None = None,
     ) -> str | None:
         if image_list is None:
-            logger.info("[yellow]No image links to save.[/yellow]")
+            logger.info(f"{self.tracker}: [yellow]No image links to save.[/yellow]")
             return None
 
         output_dir = Path(meta.base_dir) / "tmp" / meta.uuid
@@ -1316,7 +1318,7 @@ class PassThePopcorn:
                     content = await f.read()
                     existing_data = cast(dict[str, Any], json.loads(content)) if content.strip() else {}
             except Exception as e:
-                logger.warning(f"[yellow]Warning: Could not load existing image data: {e!s}[/yellow]")
+                logger.warning(f"{self.tracker}: [yellow]Warning: Could not load existing image data: {e!s}[/yellow]")
 
         # Create data structure if it doesn't exist yet
         if not existing_data:
@@ -1347,12 +1349,12 @@ class PassThePopcorn:
             async with aiofiles.open(output_file, "w", encoding="utf-8") as f:
                 await f.write(json.dumps(existing_data, indent=2))
 
-            logger.debug(f"[green]Saved {len(image_list)} new images for key '{image_key}' (total: {existing_data['total_count']}):[/green]")
-            logger.debug(f"[blue]  - JSON: {output_file}[/blue]")
+            logger.debug(f"{self.tracker}: [green]Saved {len(image_list)} new images for key '{image_key}' (total: {existing_data['total_count']}):[/green]")
+            logger.debug(f"{self.tracker}: [blue]  - JSON: {output_file}[/blue]")
 
             return output_file
         except Exception as e:
-            logger.info(f"[bold red]Error saving image links: {e}[/bold red]")
+            logger.info(f"{self.tracker}: [bold red]Error saving image links: {e}[/bold red]")
             return None
 
     async def get_anti_csrf_token(self, meta: Meta) -> str:
@@ -1375,12 +1377,12 @@ class PassThePopcorn:
                     if token_match:
                         return token_match.group(1)
             # Cookies are expired/invalid — discard them so the login POST is clean
-            logger.info("[yellow]PassThePopcorn session expired. Clearing cookies and re-authenticating.")
+            logger.info(f"{self.tracker}: [yellow]session expired. Clearing cookies and re-authenticating.")
             cookies = {}
             with contextlib.suppress(OSError):
                 Path(cookiefile).unlink()
         else:
-            logger.info("[yellow]PassThePopcorn Cookies not found. Creating new session.")
+            logger.info(f"{self.tracker}: [yellow]Cookies not found. Creating new session.")
 
         passkey_match = re.match(r"https?://please\.passthepopcorn\.me:?\d*/(.+)/announce", self.announce_url)
         if not passkey_match:
@@ -1430,7 +1432,7 @@ class PassThePopcorn:
     async def validate_login(self, response: httpx.Response) -> bool:
         logged_in = False
         if response.text.find("""<a href="login.php?act=recover">""") != -1:
-            logger.info("Looks like you are not logged in to PassThePopcorn. Probably due to the bad user name, password, or expired session.")
+            logger.info(f"{self.tracker}: Looks like you are not logged in to PassThePopcorn. Probably due to the bad user name, password, or expired session.")
         elif "Your popcorn quota has been reached, come back later!" in response.text:
             raise LoginError("Your PassThePopcorn request/popcorn quota has been reached, try again later")  # noqa F405
         else:
@@ -1447,7 +1449,7 @@ class PassThePopcorn:
             async with aiofiles.open(file_path, encoding="utf-8") as f:
                 desc = await f.read()
         except OSError as e:
-            logger.info(f"File error: {e}", extra={"markup": False})
+            logger.info(f"{self.tracker}: File error: {e}", extra={"markup": False})
         ptp_subtitles = self.get_subtitles(meta)
         no_audio_found = False
         english_audio = False
@@ -1465,14 +1467,14 @@ class PassThePopcorn:
         else:
             mediainfo = meta.mediainfo
             audio_tracks = [track for track in mediainfo.get("media", {}).get("track", []) if track.get("@type") == "Audio"]
-            logger.debug(f"[Debug] Found {len(audio_tracks)} audio tracks")
+            logger.debug(f"{self.tracker}: [Debug] Found {len(audio_tracks)} audio tracks")
 
             if not audio_tracks:
                 no_audio_found = True
-                logger.info("[yellow]No audio tracks found in mediainfo")
+                logger.info(f"{self.tracker}: [yellow]No audio tracks found in mediainfo")
             else:
                 first_language = str(audio_tracks[0].get("Language", "")).lower()
-                logger.debug(f"[Debug] First audio track language: {first_language}")
+                logger.debug(f"{self.tracker}: [Debug] First audio track language: {first_language}")
 
                 if not first_language:
                     no_audio_found = True
@@ -1506,8 +1508,8 @@ class PassThePopcorn:
             if cli_ui.ask_yes_no("Mark trumpable?", default=True):
                 ptp_trumpable, ptp_subtitles = self.get_trumpable(ptp_subtitles)
 
-        logger.debug(f"ptp_trumpable: {ptp_trumpable}")
-        logger.debug(f"ptp_subtitles: {ptp_subtitles}")
+        logger.debug(f"{self.tracker}: ptp_trumpable: {ptp_trumpable}")
+        logger.debug(f"{self.tracker}: ptp_subtitles: {ptp_subtitles}")
         data: dict[str, Any] = {
             "submit": "true",
             "remaster_year": "",
@@ -1568,7 +1570,7 @@ class PassThePopcorn:
                 if not cover_input:
                     continue
                 if not cover_input.lower().endswith((".jpg", ".jpeg", ".png", ".webp")):
-                    logger.info("[red]Cover URL must end with .jpg, .jpeg, .png, or .webp")
+                    logger.info(f"{self.tracker}: [red]Cover URL must end with .jpg, .jpeg, .png, or .webp")
                     continue
                 cover = await self.rehost_poster_to_selected_host(meta, cover_input)
             new_data = {
@@ -1584,8 +1586,8 @@ class PassThePopcorn:
             if not new_data["tags"]:
                 if (meta.mode if meta.mode is not None else "non_cli") == "cli":
                     while not new_data["tags"]:
-                        logger.info("[yellow]Unable to match any tags")
-                        logger.info("Valid tags can be found on the PassThePopcorn upload form")
+                        logger.info(f"{self.tracker}: [yellow]Unable to match any tags")
+                        logger.info(f"{self.tracker}: Valid tags can be found on the PassThePopcorn upload form")
                         new_data["tags"] = console.input("Please enter at least one tag. Comma separated (action, animation, short):")
                 else:
                     raise UploadError("PassThePopcorn requires at least one valid tag.")
@@ -1612,7 +1614,7 @@ class PassThePopcorn:
 
         # Check if the piece size exceeds 16 MiB and regenerate the torrent if needed
         if base_piece_mb > 16 and not meta.nohash:
-            logger.info("[red]Piece size is OVER 16M and does not work on PassThePopcorn. Generating a new .torrent")
+            logger.info(f"{self.tracker}: [red]Piece size is OVER 16M and does not work on PassThePopcorn. Generating a new .torrent")
             tracker_url = self.announce_url.strip() if self.announce_url else "https://fake.tracker"
             piece_size = 16
             torrent_create = f"[{self.tracker}]"
@@ -1655,7 +1657,7 @@ class PassThePopcorn:
         cookies = {name: str(data.get("value", "")) for name, data in raw_cookies.items()}
         async with httpx.AsyncClient(cookies=cookies, timeout=60.0, follow_redirects=True) as client:
             response = await client.post(url=url, data=data, headers=headers, files=files)
-        logger.info(f"[cyan]{response.url}")
+        logger.info(f"{self.tracker}: [cyan]{response.url}")
         responsetext = response.text
         # If the response contains our announce URL, then we are on the upload page and the upload wasn't successful.
         if responsetext.find(self.announce_url) != -1:

--- a/src/trackers/passthepopcorn.py
+++ b/src/trackers/passthepopcorn.py
@@ -15,6 +15,7 @@ import cli_ui
 import click
 import httpx
 from pymediainfo import MediaInfo
+from rich.markup import escape
 
 from cogs.redaction import PathAwareEncoder, Redaction
 from src.bbcode import BBCODE
@@ -290,7 +291,7 @@ class PassThePopcorn:
                         desc = edited_description.strip()
                         meta.description = desc
                         meta.saved_description = True
-                    logger.info(f"{self.tracker}: [green]Final description after editing:[/green] {desc}")
+                    logger.info(f"{self.tracker}: [green]Final description after editing:[/green] {escape(str(desc))}")
                 elif (edit_choice or "").lower() == "d":
                     desc = None
                     logger.info(f"{self.tracker}: [yellow]Description discarded.[/yellow]")
@@ -1301,7 +1302,7 @@ class PassThePopcorn:
         meta: Meta,
         image_key: str,
         image_list: list[dict[str, Any]] | None = None,
-    ) -> str | None:
+    ) -> Path | None:
         if image_list is None:
             logger.info(f"{self.tracker}: [yellow]No image links to save.[/yellow]")
             return None

--- a/src/trackers/pterclub.py
+++ b/src/trackers/pterclub.py
@@ -56,7 +56,7 @@ class PTerClub:
     async def validate_credentials(self, meta: Meta) -> bool:
         vcookie = await self.validate_cookies(meta)
         if vcookie is not True:
-            logger.error("[red]Failed to validate cookies. Please confirm that the site is up and your passkey is valid.")
+            logger.error(f"{self.tracker}: [red]Failed to validate cookies. Please confirm that the site is up and your passkey is valid.")
             return False
         return True
 
@@ -73,7 +73,7 @@ class PTerClub:
 
                 return resp.text.find("""<a href="#" data-url="logout.php" id="logout-confirm">""") != -1
         else:
-            logger.info("[bold red]Missing Cookie File. (data/cookies/PTERCLUB.txt)")
+            logger.info(f"{self.tracker}: [bold red]Missing Cookie File. (data/cookies/PTERCLUB.txt)")
             return False
 
     async def search_existing(self, meta: Meta) -> list[str] | bool:
@@ -83,7 +83,7 @@ class PTerClub:
 
         cookiefile = find_cookie_file(meta.base_dir, self.tracker, self.config)
         if not Path(cookiefile).exists():
-            logger.info("[bold red]Missing Cookie File. (data/cookies/PTERCLUB.txt)")
+            logger.info(f"{self.tracker}: [bold red]Missing Cookie File. (data/cookies/PTERCLUB.txt)")
             return False
         cookies = await common.parse_cookie_file(cookiefile)
         imdb_id = meta.imdb_id or 0
@@ -226,7 +226,7 @@ class PTerClub:
         parts.append(desc)
 
         if self.rehost_images is True:
-            logger.info("[green]Rehosting Images...")
+            logger.info(f"{self.tracker}: [green]Rehosting Images...")
             images = await self.pterimg_upload(meta)
             if len(images) > 0:
                 parts.append("[center]")
@@ -270,7 +270,7 @@ class PTerClub:
                 if logged_in is True:
                     return self._extract_auth_token(response.text, r'auth_token.*?"(\w+)"')
         else:
-            logger.info("[yellow]Pterimg Cookies not found. Creating new session.")
+            logger.info(f"{self.tracker}: [yellow]Pterimg Cookies not found. Creating new session.")
 
         data = {"login-subject": self.username, "password": self.password, "keep-login": 1}
         async with httpx.AsyncClient(cookies=cookies, timeout=30.0, follow_redirects=True) as client:
@@ -449,7 +449,7 @@ class PTerClub:
                 up = await client.post(url=url, data=data, files=files)
 
                 if str(up.url).startswith(f"{self.base_url}/details.php?id="):
-                    logger.info(f"[green]Uploaded to: [yellow]{str(up.url).replace('&uploaded=1', '')}[/yellow][/green]")
+                    logger.info(f"{self.tracker}: [green]Uploaded to: [yellow]{str(up.url).replace('&uploaded=1', '')}[/yellow][/green]")
                     id_match = re.search(r"(id=)(\d+)", urlparse(str(up.url)).query)
                     if id_match is None:
                         raise UploadError("Upload succeeded but torrent id was not present in the redirect URL.", "red")  # noqa: F405
@@ -459,7 +459,7 @@ class PTerClub:
                     meta.tracker_status[self.tracker]["torrent_id"] = torrent_id
                     return True
                 logger.info(data)
-                logger.info("\n\n")
+                logger.info(f"{self.tracker}: \n\n")
                 raise UploadError(f"Upload to Pter Failed: result URL {up.url} ({up.status_code}) was not expected", "red")  # noqa #F405
         return False
 
@@ -471,5 +471,5 @@ class PTerClub:
             async with aiofiles.open(torrent_path, "wb") as tor:
                 await tor.write(r.content)
         else:
-            logger.info("[red]There was an issue downloading the new .torrent from pter")
+            logger.info(f"{self.tracker}: [red]There was an issue downloading the new .torrent from pter")
             logger.info(r.text)

--- a/src/trackers/ptskit.py
+++ b/src/trackers/ptskit.py
@@ -83,7 +83,7 @@ class Ptskit:
         if not mandarin:
             user_input = await asyncio.to_thread(input, "Warning: Mandarin subtitle or audio not found. Do you want to continue with the upload anyway? (y/n): ")
             if user_input.lower() not in ["y", "yes"]:
-                logger.info("Upload cancelled by user.", extra={"markup": False})
+                logger.info(f"{self.tracker}: Upload cancelled by user.", extra={"markup": False})
                 return False
         return True
 

--- a/src/trackers/retroflix.py
+++ b/src/trackers/retroflix.py
@@ -157,7 +157,7 @@ class RetroFlix:
                         except Exception:
                             error_msg = f"HTTP {response.status_code}: {response.text[:200]}"
 
-                        logger.info(f"[bold red]Unexpected response: {error_msg}")
+                        logger.info(f"{self.tracker}: [bold red]Unexpected response: {error_msg}")
                         meta.tracker_status[self.tracker]["status_message"] = f"Unexpected response: {error_msg}"
                         return False
 
@@ -172,7 +172,7 @@ class RetroFlix:
                 return False
 
         else:
-            logger.info("[cyan]RETROFLIX Request Data:")
+            logger.info(f"{self.tracker}: [cyan]Request Data:")
             debug_data = json_data.copy()
             if debug_data.get("file"):
                 debug_data["file"] = f"{str(debug_data['file'])[:10]}..."
@@ -241,7 +241,7 @@ class RetroFlix:
                 ten_years_ago = datetime.datetime.now(datetime.UTC).date() - datetime.timedelta(days=365 * 10 + 3)  # add leeway
                 if release_date > ten_years_ago:
                     if not meta.unattended:
-                        logger.info("[red]Content must be older than 10 Years to upload at RETROFLIX")
+                        logger.info(f"{self.tracker}: [red]Content must be older than 10 Years to upload at RETROFLIX")
                     return False
             except ValueError, AttributeError:
                 # If date parsing fails, fall back to year comparison
@@ -250,7 +250,7 @@ class RetroFlix:
                     year = int(release_year)
                     if datetime.datetime.now(datetime.UTC).date().year - year <= 9:
                         if not meta.unattended:
-                            logger.info("[red]Content must be older than 10 Years to upload at RETROFLIX")
+                            logger.info(f"{self.tracker}: [red]Content must be older than 10 Years to upload at RETROFLIX")
                         return False
 
         elif meta.category == "TV" and most_recent_aired_date:
@@ -258,13 +258,13 @@ class RetroFlix:
             ten_years_ago = datetime.datetime.now(datetime.UTC).date() - datetime.timedelta(days=365 * 10 + 3)  # add leeway
             if most_recent_aired_date > ten_years_ago:
                 if not meta.unattended:
-                    logger.info("[red]Content must be older than 10 Years to upload at RETROFLIX")
+                    logger.info(f"{self.tracker}: [red]Content must be older than 10 Years to upload at RETROFLIX")
                 return False
 
         else:
             if year is not None and datetime.datetime.now(datetime.UTC).date().year - year <= 9:
                 if not meta.unattended:
-                    logger.info("[red]Content must be older than 10 Years to upload at RETROFLIX")
+                    logger.info(f"{self.tracker}: [red]Content must be older than 10 Years to upload at RETROFLIX")
                 return False
         return True
 
@@ -346,16 +346,16 @@ class RetroFlix:
                 response = await client.get(f"{self.base_url}/api/test", headers=headers)
 
                 if response.status_code != 200:
-                    logger.info("[bold red]Your API key is incorrect SO generating a new one")
+                    logger.info(f"{self.tracker}: [bold red]Your API key is incorrect SO generating a new one")
                     await self.generate_new_api(meta)
                     return None
                 return True
         except httpx.RequestError as e:
-            logger.info(f"[bold red]Error testing API: {e!s}")
+            logger.info(f"{self.tracker}: [bold red]Error testing API: {e!s}")
             await self.generate_new_api(meta)
             return None
         except Exception as e:
-            logger.error(f"[bold red]Unexpected error testing API: {e!s}")
+            logger.error(f"{self.tracker}: [bold red]Unexpected error testing API: {e!s}")
             await self.generate_new_api(meta)
             return None
 
@@ -408,31 +408,31 @@ class RetroFlix:
                             flags=re.DOTALL,
                         )
                         if replacements == 0:
-                            logger.info("[bold red]Failed to update RETROFLIX api_key in config file.")
+                            logger.info(f"{self.tracker}: [bold red]Failed to update RETROFLIX api_key in config file.")
                             return None
 
                         # Write the updated config back to the file
                         async with aiofiles.open(config_path, "w", encoding="utf-8") as file:
                             await file.write(new_config_data)
 
-                        logger.info(f"[bold green]API Key successfully saved to {config_path}")
+                        logger.info(f"{self.tracker}: [bold green]API Key successfully saved to {config_path}")
                         return True
                     except Exception as e:
-                        logger.info(f"[bold red]Failed to update config file: {e!s}")
+                        logger.info(f"{self.tracker}: [bold red]Failed to update config file: {e!s}")
                         return None
                 else:
-                    logger.info("[bold red]API response does not contain a token.")
+                    logger.info(f"{self.tracker}: [bold red]API response does not contain a token.")
                     return None
             else:
-                logger.info(f"[bold red]Error getting new API key: {response.status_code}, please check username and password in the config.")
+                logger.info(f"{self.tracker}: [bold red]Error getting new API key: {response.status_code}, please check username and password in the config.")
                 return None
 
         except httpx.RequestError as e:
-            logger.info(f"[bold red]An error occurred while requesting the API: {e!s}")
+            logger.info(f"{self.tracker}: [bold red]An error occurred while requesting the API: {e!s}")
             return None
 
         except Exception as e:
-            logger.info(f"[bold red]An unexpected error occurred: {e!s}")
+            logger.info(f"{self.tracker}: [bold red]An unexpected error occurred: {e!s}")
             return None
 
     async def get_name(self, meta: Meta) -> str:

--- a/src/trackers/retroflix.py
+++ b/src/trackers/retroflix.py
@@ -172,7 +172,7 @@ class RetroFlix:
                 return False
 
         else:
-            logger.info(f"{self.tracker}: [cyan]Request Data:")
+            logger.info(f"{self.tracker}: Request Data:")
             debug_data = json_data.copy()
             if debug_data.get("file"):
                 debug_data["file"] = f"{str(debug_data['file'])[:10]}..."

--- a/src/trackers/speedapp.py
+++ b/src/trackers/speedapp.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 
 import aiofiles
 import httpx
+from rich.markup import escape
 
 from cogs.redaction import Redaction
 from src.console import console, logger
@@ -184,19 +185,17 @@ class SpeedApp:
                     channel_id = entry.get("id")
                     tag = entry.get("tag")
 
-                    if channel_id and tag:
-                        if tag != spd_channel:
-                            logger.info(f"{self.tracker}: [{self.tracker}]Unable to find a matching channel based on your input. Please check if you entered it correctly.")
-                            return None
+                    if channel_id and tag and tag == spd_channel:
                         return int(channel_id)
-                    logger.info(f"{self.tracker}: [{self.tracker}]Could not find the channel ID. Please check if you entered it correctly.")
-
-                else:
-                    logger.info(f"{self.tracker}: [bold red]HTTP request failed. Status: {response.status_code}")
+                logger.info(f"{self.tracker}: [{self.tracker}]Could not find the channel ID matching your input. Please check if you entered it correctly.")
+                return None
+            logger.info(f"{self.tracker}: [bold red]HTTP request failed. Status: {response.status_code}[/bold red]")
+            return None
 
         except Exception as e:
-            logger.error(f"{self.tracker}: [bold red]Unexpected error: {e}")
+            logger.error(f"{self.tracker}: [bold red]Unexpected error: {escape(str(e))}[/bold red]")
             console.print_exception()
+            return None
 
     async def edit_desc(self, meta: Meta) -> str:
         builder = DescriptionBuilder(self.tracker, self.config)

--- a/src/trackers/speedapp.py
+++ b/src/trackers/speedapp.py
@@ -186,16 +186,16 @@ class SpeedApp:
 
                     if channel_id and tag:
                         if tag != spd_channel:
-                            logger.info(f"[{self.tracker}]: Unable to find a matching channel based on your input. Please check if you entered it correctly.")
+                            logger.info(f"{self.tracker}: [{self.tracker}]Unable to find a matching channel based on your input. Please check if you entered it correctly.")
                             return None
                         return int(channel_id)
-                    logger.info(f"[{self.tracker}]: Could not find the channel ID. Please check if you entered it correctly.")
+                    logger.info(f"{self.tracker}: [{self.tracker}]Could not find the channel ID. Please check if you entered it correctly.")
 
                 else:
-                    logger.info(f"[bold red]HTTP request failed. Status: {response.status_code}")
+                    logger.info(f"{self.tracker}: [bold red]HTTP request failed. Status: {response.status_code}")
 
         except Exception as e:
-            logger.error(f"[bold red]Unexpected error: {e}")
+            logger.error(f"{self.tracker}: [bold red]Unexpected error: {e}")
             console.print_exception()
 
     async def edit_desc(self, meta: Meta) -> str:
@@ -361,7 +361,7 @@ class SpeedApp:
                 return False
 
         else:
-            logger.info("[cyan]SPEEDAPP Request Data:")
+            logger.info(f"{self.tracker}: [cyan]Request Data:")
             logger.info(Redaction.redact_private_info(data))
             tracker_status[self.tracker]["status_message"] = "Debug mode enabled, not uploading."
             await self.common.create_torrent_for_upload(meta, f"{self.tracker}" + "_DEBUG", f"{self.tracker}" + "_DEBUG", announce_url="https://fake.tracker")

--- a/src/trackers/speedapp.py
+++ b/src/trackers/speedapp.py
@@ -360,7 +360,7 @@ class SpeedApp:
                 return False
 
         else:
-            logger.info(f"{self.tracker}: [cyan]Request Data:")
+            logger.info(f"{self.tracker}: Request Data:")
             logger.info(Redaction.redact_private_info(data))
             tracker_status[self.tracker]["status_message"] = "Debug mode enabled, not uploading."
             await self.common.create_torrent_for_upload(meta, f"{self.tracker}" + "_DEBUG", f"{self.tracker}" + "_DEBUG", announce_url="https://fake.tracker")

--- a/src/trackers/swarmazon.py
+++ b/src/trackers/swarmazon.py
@@ -112,7 +112,7 @@ class Swarmazon:
                 async with httpx.AsyncClient(timeout=30.0) as client:
                     response = await client.post(self.upload_url, data=data, files=files)
             except httpx.RequestError as e:
-                logger.info(f"[red]Request failed with error: {e}")
+                logger.info(f"{self.tracker}: [red]Request failed with error: {e}")
                 return False
 
             try:
@@ -130,18 +130,18 @@ class Swarmazon:
                             str(response.json()["link"]),
                         )
                         return True
-                    logger.info("[red]No Link in Response")
+                    logger.info(f"{self.tracker}: [red]No Link in Response")
                     return False
-                logger.info("[red]Did not upload successfully")
+                logger.info(f"{self.tracker}: [red]Did not upload successfully")
                 logger.info(response.json())
                 return False
             except Exception:
-                logger.error("[red]Error! It may have uploaded, go check")
+                logger.error(f"{self.tracker}: [red]Error! It may have uploaded, go check")
                 logger.info(Redaction.redact_private_info(data))
                 console.print_exception()
                 return False
         else:
-            logger.info("[cyan]SWARMAZON Request Data:")
+            logger.info(f"{self.tracker}: [cyan]Request Data:")
             logger.info(Redaction.redact_private_info(data))
             tracker_status = meta.tracker_status
             tracker_status.setdefault(self.tracker, {})

--- a/src/trackers/swarmazon.py
+++ b/src/trackers/swarmazon.py
@@ -141,7 +141,7 @@ class Swarmazon:
                 console.print_exception()
                 return False
         else:
-            logger.info(f"{self.tracker}: [cyan]Request Data:")
+            logger.info(f"{self.tracker}: Request Data:")
             logger.info(Redaction.redact_private_info(data))
             tracker_status = meta.tracker_status
             tracker_status.setdefault(self.tracker, {})

--- a/src/trackers/torrenthr.py
+++ b/src/trackers/torrenthr.py
@@ -102,13 +102,13 @@ class TorrentHR:
                 cookies = await self.login(meta)
 
                 if cookies:
-                    logger.info("[green]Using authenticated session for upload")
+                    logger.info(f"{self.tracker}: [green]Using authenticated session for upload")
 
                     async with httpx.AsyncClient(cookies=cookies, follow_redirects=True) as session:
                         response = await session.post(url=url, files=files, data=payload, headers=headers)
 
-                        logger.debug(f"[dim]Response status: {response.status_code}")
-                        logger.debug(f"[dim]Response URL: {response.url}")
+                        logger.debug(f"{self.tracker}: [dim]Response status: {response.status_code}")
+                        logger.debug(f"{self.tracker}: [dim]Response URL: {response.url}")
                         logger.debug(response.text[:500] + "...")
 
                         if "uploaded=1" in str(response.url):
@@ -116,30 +116,30 @@ class TorrentHR:
                             tracker_status.setdefault(self.tracker, {})
                             tracker_status[self.tracker]["status_message"] = response.url
                             return True
-                        logger.info(f"[yellow]Upload response didn't contain 'uploaded=1'. URL: {response.url}")
+                        logger.info(f"{self.tracker}: [yellow]Upload response didn't contain 'uploaded=1'. URL: {response.url}")
                         soup = BeautifulSoup(response.text, "html.parser")
                         error_text = soup.find("h2", string=re.compile(r"Error"))  # type: ignore
 
                         if error_text:
                             error_message = cast(Any, error_text).find_next("p")
                             if error_message:
-                                logger.info(f"[red]Upload error: {error_message.text}")
+                                logger.info(f"{self.tracker}: [red]Upload error: {error_message.text}")
 
                         return False
                 else:
-                    logger.error("[red]Failed to log in to TORRENTHR for upload")
+                    logger.error(f"{self.tracker}: [red]Failed to log in to TORRENTHR for upload")
                     return False
 
             except Exception as e:
-                logger.error(f"[red]Error during upload: {e!s}")
+                logger.error(f"{self.tracker}: [red]Error during upload: {e!s}")
                 console.print_exception()
                 if meta.debug and response is not None:
                     with contextlib.suppress(Exception):
-                        logger.info(f"[red]Response: {response.text[:500]}...")
-                logger.info("[yellow]It may have uploaded, please check TORRENTHR manually")
+                        logger.info(f"{self.tracker}: [red]Response: {response.text[:500]}...")
+                logger.info(f"{self.tracker}: [yellow]It may have uploaded, please check TORRENTHR manually")
                 return False
         else:
-            logger.info("[cyan]TORRENTHR Request Data:")
+            logger.info(f"{self.tracker}: [cyan]Request Data:")
             logger.info(Redaction.redact_private_info(payload))
             tracker_status = meta.tracker_status
             tracker_status.setdefault(self.tracker, {})
@@ -273,7 +273,7 @@ class TorrentHR:
         image_list: list[str] = []
         image_api_key = str(self.config["TRACKERS"]["TORRENTHR"].get("img_api", "")).strip()
         if ordered_images and not image_api_key:
-            logger.info("[yellow]TORRENTHR image API key is not configured, skipping screenshot rehost")
+            logger.info(f"{self.tracker}: [yellow]image API key is not configured, skipping screenshot rehost")
 
         for image in ordered_images:
             if not image_api_key:
@@ -302,18 +302,18 @@ class TorrentHR:
                         raise KeyError("image.url")
                     image_list.append(img_url)
             except httpx.RequestError as exc:
-                logger.info(f"[yellow]Failed to upload image {Path(image).name}: {exc}")
+                logger.info(f"{self.tracker}: [yellow]Failed to upload image {Path(image).name}: {exc}")
             except httpx.HTTPStatusError:
-                logger.info(f"[yellow]Failed to upload image {Path(image).name}")
+                logger.info(f"{self.tracker}: [yellow]Failed to upload image {Path(image).name}")
                 if response is not None:
-                    logger.info(f"[yellow]TORRENTHR image host returned HTTP {response.status_code}")
+                    logger.info(f"{self.tracker}: [yellow]image host returned HTTP {response.status_code}")
                     logger.info(response.text)
             except json.decoder.JSONDecodeError:
-                logger.info(f"[yellow]Failed to parse TORRENTHR image host response for {Path(image).name}")
+                logger.info(f"{self.tracker}: [yellow]Failed to parse TORRENTHR image host response for {Path(image).name}")
                 if response is not None:
                     logger.info(response.text)
             except KeyError:
-                logger.info(f"[yellow]TORRENTHR image host response was missing an image URL for {Path(image).name}")
+                logger.info(f"{self.tracker}: [yellow]image host response was missing an image URL for {Path(image).name}")
                 logger.info(response_data)
             await asyncio.sleep(1)
 
@@ -339,8 +339,8 @@ class TorrentHR:
                     desc_parts.append(f"\n[img]{mi_img}[/img]\n")
                     pronfo = True
             except Exception:
-                logger.info("[bold red]Error parsing pronfo response, using TORRENTHR parser instead")
-                logger.debug(f"{response}")
+                logger.info(f"{self.tracker}: [bold red]Error parsing pronfo response, using TORRENTHR parser instead")
+                logger.debug(f"{self.tracker}: {response}")
                 logger.debug(response.text)
 
         screens = meta.screens or 0
@@ -365,7 +365,7 @@ class TorrentHR:
         dupes: list[str] = []
 
         if not imdb_id:
-            logger.info("[red]No IMDb ID available for search")
+            logger.info(f"{self.tracker}: [red]No IMDb ID available for search")
             return dupes
 
         cookies = await self.login(meta)
@@ -374,7 +374,7 @@ class TorrentHR:
         if cookies:
             client_args["cookies"] = cookies
         else:
-            logger.error("[red]Failed to log in to TORRENTHR for search")
+            logger.error(f"{self.tracker}: [red]Failed to log in to TORRENTHR for search")
             return dupes
 
         async with httpx.AsyncClient(**client_args) as client:
@@ -390,7 +390,7 @@ class TorrentHR:
                     page_url += f"&page={current_page}"
 
                 page_count += 1
-                logger.debug(f"[dim]Searching page {page_count}...")
+                logger.debug(f"{self.tracker}: [dim]Searching page {page_count}...")
                 response = await client.get(page_url)
                 response.raise_for_status()
 
@@ -402,7 +402,7 @@ class TorrentHR:
                         all_titles_seen.add(dupe)
 
                 if has_next_page:
-                    logger.debug(f"[dim]Next page available: page {next_page_number}")
+                    logger.debug(f"{self.tracker}: [dim]Next page available: page {next_page_number}")
 
                 if has_next_page:
                     current_page = next_page_number
@@ -424,18 +424,18 @@ class TorrentHR:
 
         if response.status_code == 200 or response.status_code == 302:
             html_length = len(response.text)
-            logger.debug(f"[dim]Response HTML length: {html_length} bytes")
+            logger.debug(f"{self.tracker}: [dim]Response HTML length: {html_length} bytes")
 
             if html_length < 1000:
-                logger.info(f"[yellow]Response seems too small ({html_length} bytes), might be an error page")
-                logger.debug(f"[yellow]Response content: {response.text[:500]}")
+                logger.info(f"{self.tracker}: [yellow]Response seems too small ({html_length} bytes), might be an error page")
+                logger.debug(f"{self.tracker}: [yellow]Response content: {response.text[:500]}")
                 return page_dupes, False, current_page
 
             soup = BeautifulSoup(response.text, "html.parser")
 
             result_table = soup.find("table", {"class": "torrentlist"}) or soup.find("table", {"align": "center"})
             if not result_table:
-                logger.info("[yellow]No results table found in HTML - either no results or page structure changed")
+                logger.info(f"{self.tracker}: [yellow]No results table found in HTML - either no results or page structure changed")
 
             link_count = 0
             onmousemove_count = 0
@@ -457,16 +457,16 @@ class TorrentHR:
                             dupe = dupe.replace("return overlibImage('", "")
                             page_dupes.append(dupe)
                         except Exception as parsing_error:
-                            logger.debug(f"[yellow]Error parsing link: {parsing_error}")
+                            logger.debug(f"{self.tracker}: [yellow]Error parsing link: {parsing_error}")
 
             page_number_display = current_page + 1
-            logger.debug(f"[dim]Page {page_number_display}: Found {link_count} detail links, {onmousemove_count} parsed successfully")
+            logger.debug(f"{self.tracker}: [dim]Page {page_number_display}: Found {link_count} detail links, {onmousemove_count} parsed successfully")
 
             pagination_text = None
             for p_tag in soup.find_all("p", align="center"):
                 if p_tag.text and ("Prev" in p_tag.text or "Next" in p_tag.text):
                     pagination_text = p_tag
-                    logger.debug(f"[dim]Found pagination: {pagination_text.text.strip()}")
+                    logger.debug(f"{self.tracker}: [dim]Found pagination: {pagination_text.text.strip()}")
                     break
 
             if pagination_text:
@@ -479,25 +479,25 @@ class TorrentHR:
                         if href_raw:
                             href = " ".join(href_raw) if isinstance(href_raw, AttributeValueList) else href_raw
 
-                        logger.debug(f"[dim]Next page URL: {href}")
+                        logger.debug(f"{self.tracker}: [dim]Next page URL: {href}")
 
                         page_match = re.search(r"page=(\d+)", href)
                         if page_match:
                             next_page_number = int(page_match.group(1))
-                            logger.debug(f"[dim]Found next page link: page={next_page_number} (will be displayed as page {next_page_number + 1})")
+                            logger.debug(f"{self.tracker}: [dim]Found next page link: page={next_page_number} (will be displayed as page {next_page_number + 1})")
                             break
         else:
-            logger.info(f"[bold red]HTTP request failed. Status: {response.status_code}")
-            logger.debug(f"[red]Response: {response.text[:500]}...")
+            logger.info(f"{self.tracker}: [bold red]HTTP request failed. Status: {response.status_code}")
+            logger.debug(f"{self.tracker}: [red]Response: {response.text[:500]}...")
 
         return page_dupes, has_next_page, next_page_number
 
     async def login(self, meta: Meta) -> dict[str, Any] | None:
-        logger.info("[yellow]Logging in to TORRENTHR...")
+        logger.info(f"{self.tracker}: [yellow]Logging in to TORRENTHR...")
         url = f"{self.base_url}/takelogin.php"
 
         if not self.username or not self.password:
-            logger.info("[red]Missing TORRENTHR credentials in config.py")
+            logger.info(f"{self.tracker}: [red]Missing TORRENTHR credentials in config.py")
             return None
 
         payload: dict[str, Any] = {"username": self.username, "password": self.password, "ssl": "yes"}
@@ -522,15 +522,15 @@ class TorrentHR:
                 resp = await session.post(url, headers=headers, data=payload)
 
                 if "index.php" in str(resp.url) or "logout.php" in resp.text:
-                    logger.info("[green]Successfully logged in to TORRENTHR")
+                    logger.info(f"{self.tracker}: [green]Successfully logged in to TORRENTHR")
                     return dict(session.cookies)
-                logger.error("[red]Failed to log in to TORRENTHR")
-                logger.info(f"[red]Login response URL: {resp.url}")
-                logger.info(f"[red]Login status code: {resp.status_code}")
+                logger.error(f"{self.tracker}: [red]Failed to log in to TORRENTHR")
+                logger.info(f"{self.tracker}: [red]Login response URL: {resp.url}")
+                logger.info(f"{self.tracker}: [red]Login status code: {resp.status_code}")
                 return None
 
             except Exception as e:
-                logger.error(f"[red]Error during TORRENTHR login: {e!s}")
+                logger.error(f"{self.tracker}: [red]Error during TORRENTHR login: {e!s}")
                 console.print_exception()
                 return None
 

--- a/src/trackers/torrenthr.py
+++ b/src/trackers/torrenthr.py
@@ -139,7 +139,7 @@ class TorrentHR:
                 logger.info(f"{self.tracker}: [yellow]It may have uploaded, please check TORRENTHR manually")
                 return False
         else:
-            logger.info(f"{self.tracker}: [cyan]Request Data:")
+            logger.info(f"{self.tracker}: Request Data:")
             logger.info(Redaction.redact_private_info(payload))
             tracker_status = meta.tracker_status
             tracker_status.setdefault(self.tracker, {})

--- a/src/trackers/torrentleech.py
+++ b/src/trackers/torrentleech.py
@@ -356,7 +356,7 @@ class TorrentLeech:
                 return True
 
         else:
-            logger.info(f"{self.tracker}: [cyan]Request Data:")
+            logger.info(f"{self.tracker}: Request Data:")
             logger.info(Redaction.redact_private_info(data))
             await self.common.create_torrent_for_upload(meta, f"{self.tracker}" + "_DEBUG", f"{self.tracker}" + "_DEBUG", announce_url="https://fake.tracker")
             return True  # Debug mode - simulated success

--- a/src/trackers/torrentleech.py
+++ b/src/trackers/torrentleech.py
@@ -66,13 +66,13 @@ class TorrentLeech:
                 logged_in = response.status_code == 200 and "torrents/upload" in str(response.url)
 
             if logged_in:
-                logger.debug(f"[bold green]Logged in to '{self.tracker}' with cookies.[/bold green]")
+                logger.debug(f"{self.tracker}: [bold green]Logged in to '{self.tracker}' with cookies.[/bold green]")
                 return True
 
-            logger.info(f"[bold red]Login to '{self.tracker}' with cookies failed. Please check your cookies.[/bold red]")
+            logger.info(f"{self.tracker}: [bold red]Login to '{self.tracker}' with cookies failed. Please check your cookies.[/bold red]")
             return False
         except httpx.RequestError as e:
-            logger.info(f"[bold red]Error while validating credentials for '{self.tracker}': {e}[/bold red]")
+            logger.info(f"{self.tracker}: [bold red]Error while validating credentials for '{self.tracker}': {e}[/bold red]")
             return False
 
     async def generate_description(self, meta: Meta) -> str:
@@ -227,7 +227,7 @@ class TorrentLeech:
         login = await self.login(meta, force=True)
         if not login:
             meta.skipping = "TORRENTLEECH"
-            logger.debug(f"[bold red]Skipping upload to '{self.tracker}' as login failed.[/bold red]")
+            logger.debug(f"{self.tracker}: [bold red]Skipping upload to '{self.tracker}' as login failed.[/bold red]")
             return []
         cat_id = self.get_category(meta)
 
@@ -356,7 +356,7 @@ class TorrentLeech:
                 return True
 
         else:
-            logger.info("[cyan]TORRENTLEECH Request Data:")
+            logger.info(f"{self.tracker}: [cyan]Request Data:")
             logger.info(Redaction.redact_private_info(data))
             await self.common.create_torrent_for_upload(meta, f"{self.tracker}" + "_DEBUG", f"{self.tracker}" + "_DEBUG", announce_url="https://fake.tracker")
             return True  # Debug mode - simulated success
@@ -403,7 +403,7 @@ class TorrentLeech:
         data = await self.get_cookie_upload_data(meta)
 
         if meta.debug:
-            logger.debug("[cyan]TORRENTLEECH Request Data:")
+            logger.debug(f"{self.tracker}: [cyan]Request Data:")
             logger.debug(Redaction.redact_private_info(data))
             await self.common.create_torrent_for_upload(meta, f"{self.tracker}" + "_DEBUG", f"{self.tracker}" + "_DEBUG", announce_url="https://fake.tracker")
             return True  # Debug mode - simulated success

--- a/src/trackers/totheglory.py
+++ b/src/trackers/totheglory.py
@@ -195,14 +195,14 @@ class ToTheGlory:
             await self.download_new_torrent(torrent_id, torrent_path)
             return True
         logger.info(data)
-        logger.info("\n\n")
+        logger.info(f"{self.tracker}: \n\n")
         raise UploadError(f"Upload to {self.tracker} Failed: result URL {up.url} ({up.status_code}) was not expected", "red")  # noqa #F405
 
     async def search_existing(self, meta: Meta) -> list[str]:
         dupes: list[str] = []
         cookiefile = str(Path(f"{meta.base_dir}/data/cookies/{self.tracker}.json").resolve())
         if not Path(cookiefile).exists():
-            logger.info(f"[bold red]Cookie file not found: {self.tracker}.json")
+            logger.info(f"{self.tracker}: [bold red]Cookie file not found: {self.tracker}.json")
             return []
         cookies = self.cookie_validator._load_cookies_dict_secure(cookiefile)  # type: ignore[reportPrivateUsage]
 
@@ -238,7 +238,7 @@ class ToTheGlory:
             await self.login(cookiefile)
         vcookie = await self.validate_cookies(meta, cookiefile)
         if vcookie is not True:
-            logger.error("[red]Failed to validate cookies. Please confirm that the site is up and your passkey is valid.")
+            logger.error(f"{self.tracker}: [red]Failed to validate cookies. Please confirm that the site is up and your passkey is valid.")
             recreate = cli_ui.ask_yes_no("Log in again and create new session?")
             if recreate is True:
                 if Path(cookiefile).exists():
@@ -255,7 +255,7 @@ class ToTheGlory:
             cookies = {name: str(data.get("value", "")) for name, data in raw_cookies.items()}
             async with httpx.AsyncClient(cookies=cookies, timeout=30.0, follow_redirects=True) as client:
                 resp = await client.get(url=url)
-                logger.debug("[cyan]Cookies:")
+                logger.debug(f"{self.tracker}: [cyan]Cookies:")
                 logger.debug(resp.url)
                 return resp.text.find("""<a href="/logout.php">Logout</a>""") != -1
         else:
@@ -278,10 +278,10 @@ class ToTheGlory:
                 response = await client.post(two_factor_url, data=two_factor_data)
                 await asyncio.sleep(0.5)
             if str(response.url).endswith("my.php"):
-                logger.info(f"[green]Successfully logged into {self.tracker}")
+                logger.info(f"{self.tracker}: [green]Successfully logged into {self.tracker}")
                 self.cookie_validator._save_cookies_secure(client.cookies.jar, cookiefile)  # type: ignore[reportPrivateUsage]
             else:
-                logger.info("[bold red]Something went wrong")
+                logger.info(f"{self.tracker}: [bold red]Something went wrong")
                 await asyncio.sleep(1)
                 logger.info(response.text)
                 logger.info(response.url)
@@ -369,5 +369,5 @@ class ToTheGlory:
             async with aiofiles.open(torrent_path, "wb") as tor:
                 await tor.write(r.content)
         else:
-            logger.info(f"[red]There was an issue downloading the new .torrent from {self.tracker}")
+            logger.info(f"{self.tracker}: [red]There was an issue downloading the new .torrent from {self.tracker}")
             logger.info(r.text)

--- a/src/trackers/tvchaosuk.py
+++ b/src/trackers/tvchaosuk.py
@@ -336,7 +336,7 @@ class TVChaosUK:
 
             await asyncio.to_thread(_write)
         except OSError as e:
-            logger.warning(f"[yellow]Warning: Failed to write description file: {e}[/yellow]")
+            logger.warning(f"{self.tracker}: [yellow]Warning: Failed to write description file: {e}[/yellow]")
 
     async def get_cat_id(self, genres: list[str]) -> str:
         """
@@ -468,7 +468,7 @@ class TVChaosUK:
             content = await self.read_file(f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/MediaInfo.json")
             mi = cast(dict[str, Any], json.loads(content))
         except (FileNotFoundError, json.JSONDecodeError) as e:
-            logger.warning(f"[yellow]Warning: Could not load MediaInfo.json: {e}")
+            logger.warning(f"{self.tracker}: [yellow]Warning: Could not load MediaInfo.json: {e}")
             mi = {}
 
         cat_id = await self.get_cat_id(meta.genres) if meta.category == "TV" else "44"
@@ -499,7 +499,7 @@ class TVChaosUK:
         desc = await self.edit_desc(meta, self.tracker, self.signature, image_list)
 
         if not desc:
-            logger.warning(f"[yellow]Warning: DESCRIPTION.txt file not found at {descfile_path}")
+            logger.warning(f"{self.tracker}: [yellow]Warning: DESCRIPTION.txt file not found at {descfile_path}")
             desc = ""
 
         # Naming logic
@@ -649,7 +649,7 @@ class TVChaosUK:
                 return False
 
         else:
-            logger.info("[cyan]TVCHAOSUK Request Data:")
+            logger.info(f"{self.tracker}: [cyan]Request Data:")
             logger.info(Redaction.redact_private_info(data))
             tracker_status = meta.tracker_status
             tracker_status.setdefault(self.tracker, {})
@@ -704,10 +704,10 @@ class TVChaosUK:
         if meta.category == "MOVIE":
             # Everything movie-specific is already handled
             if meta.debug and meta.tmdb is not None:
-                logger.info("[yellow]Fetching TMDb movie details[/yellow]")
+                logger.info(f"{self.tracker}: [yellow]Fetching TMDb movie details[/yellow]")
                 movie = tmdb.Movies(meta.tmdb)
                 response = cast(Any, movie).info()
-                logger.info(f"[cyan]DEBUG: Movie data: {response}[/cyan]")
+                logger.info(f"{self.tracker}: [cyan]DEBUG: Movie data: {response}[/cyan]")
             return {}
 
         if meta.category == "TV":
@@ -770,11 +770,11 @@ class TVChaosUK:
                         meta.episodes = episodes
 
             except (requests.exceptions.RequestException, KeyError, TypeError) as e:
-                logger.info(f"[yellow]Expected error while fetching TV episode/season info: {e}")
+                logger.info(f"{self.tracker}: [yellow]Expected error while fetching TV episode/season info: {e}")
                 logger.info(traceback.format_exc())
 
                 logger.info(
-                    f"Unable to get episode information, Make sure episode {meta.season}{meta.episode} exists in TMDB.\n"
+                    f"{self.tracker}: Unable to get episode information, Make sure episode {meta.season}{meta.episode} exists in TMDB.\n"
                     f"https://www.themoviedb.org/tv/{meta.tmdb}/season/{meta.season_int}"
                 )
                 year_str = str(meta.year) if meta.year is not None else ""
@@ -789,7 +789,7 @@ class TVChaosUK:
     async def get_additional_checks(self, meta: Meta) -> bool:
         # UHD, Discs, remux and non-1080p HEVC are not allowed on TVCHAOSUK.
         if meta.resolution == "2160p" or (meta.is_disc or "REMUX" in str(meta.type)) or (meta.video_codec == "HEVC" and meta.resolution != "1080p"):
-            logger.info("[bold red]No UHD, Discs, Remuxes or non-1080p HEVC allowed at TVCHAOSUK[/bold red]")
+            logger.info(f"{self.tracker}: [bold red]No UHD, Discs, Remuxes or non-1080p HEVC allowed at TVCHAOSUK[/bold red]")
             return False
         return True
 
@@ -797,8 +797,8 @@ class TVChaosUK:
         # Search on TVCUK has been DISABLED due to issues, but we can still skip uploads based on criteria
         dupes: list[dict[str, Any]] = []
 
-        logger.info("[red]Cannot search for dupes on TVCHAOSUK at this time.[/red]")
-        logger.info("[red]Please make sure you are not uploading duplicates.")
+        logger.info(f"{self.tracker}: [red]Cannot search for dupes on TVCHAOSUK at this time.[/red]")
+        logger.info(f"{self.tracker}: [red]Please make sure you are not uploading duplicates.")
         await asyncio.sleep(2)
 
         return dupes

--- a/src/trackers/tvchaosuk.py
+++ b/src/trackers/tvchaosuk.py
@@ -649,7 +649,7 @@ class TVChaosUK:
                 return False
 
         else:
-            logger.info(f"{self.tracker}: [cyan]Request Data:")
+            logger.info(f"{self.tracker}: Request Data:")
             logger.info(Redaction.redact_private_info(data))
             tracker_status = meta.tracker_status
             tracker_status.setdefault(self.tracker, {})

--- a/tests/test_peergarden.py
+++ b/tests/test_peergarden.py
@@ -29,7 +29,7 @@ def test_peergarden_get_imdb_non_video_category():
 
     meta = Meta()
     meta.category = "MUSIC"
-    meta.imdb = "1234567"
+    meta.imdb_id = 1234567
 
     imdb_data = asyncio.run(tracker.get_imdb(meta))
     assert imdb_data == {"imdb": "0"}
@@ -40,7 +40,7 @@ def test_peergarden_get_imdb_video_category_missing():
 
     meta = Meta()
     meta.category = "MOVIE"
-    meta.imdb = ""
+    meta.imdb_id = None
 
     imdb_data = asyncio.run(tracker.get_imdb(meta))
     assert imdb_data == {"imdb": "0"}
@@ -51,7 +51,7 @@ def test_peergarden_get_imdb_video_category_valid():
 
     meta = Meta()
     meta.category = "MOVIE"
-    meta.imdb = "1234567"
+    meta.imdb_id = 1234567
 
     imdb_data = asyncio.run(tracker.get_imdb(meta))
     assert imdb_data == {"imdb": "1234567"}


### PR DESCRIPTION
- Ensure tracker logs always begin with f'{self.tracker}: ' format (uncolored tracker name). 
- Strip hardcoded tracker names/prefixes and place Rich color tags after the tracker prefix. 
- Restrict UNIT3D.get_imdb to video categories and fix the corresponding PeerGarden regression test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Standardized tracker-specific status, warning, error, and debug messages across upload, search, authentication, validation, and media-processing workflows.
  * Improved console formatting and context, making failures, skipped uploads, request details, and upload outcomes easier to identify.
  * IMDb lookup handling is now limited to movie and TV categories.
  * API requests now use metadata-aware headers in supported workflows.

* **Tests**
  * Updated tracker regression tests to use the current IMDb metadata field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->