### PR TITLE
feat(audio): support music and audiobooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This branch introduces new media categories and automation features not present 
 
 ### 2. Audio Stream Spectrogram Generation
 
-- **Spectrogram Extraction & Plotting**: Use `-as` / `--audio-spectrogram` to automatically extract audio streams from MKVs or Blu-ray BDInfo using FFmpeg and plot frequency/time graphs (inferno theme) via `librosa` and `matplotlib`.
+- **Spectrogram Extraction & Plotting**: Use `-as` / `--audio-spectrogram` to automatically extract audio streams from MKVs, Blu-ray BDInfo, music tracks, or audiobook chapters using FFmpeg and plot frequency/time graphs (inferno theme) via `librosa` and `matplotlib`. Music and audiobook processing is capped by `audio_spectrogram_max_files`.
 - **Automated Upload**: Automatically uploads generated spectrograms along with your screenshots for release verification.
 - **Stream Selection**: Supports targeting specific tracks using `-ast` / `--audio-spectrogram-tracks` (e.g., track indexes or `all`).
 
@@ -87,7 +87,7 @@ This branch introduces new media categories and automation features not present 
 <details>
 <summary><strong>Click to view Supported Torrent Trackers</strong></summary>
 
-| Site                                                                                                                 | Usage                | Supported Categories         |
+| Site                                                                                                                 | Usage                  | Supported Categories         |
 | -------------------------------------------------------------------------------------------------------------------- | ---------------------- | ---------------------------- |
 | <img src="web_ui/static/img/trackers/aither.png" width="16" height="16" />‎ ‎ Aither                                 | AITHER                 | MOVIE, TV                    |
 | <img src="web_ui/static/img/trackers/alpharatio.png" width="16" height="16" />‎ ‎ Alpharatio                         | ALPHARATIO             | MOVIE, TV                    |
@@ -173,7 +173,7 @@ This branch introduces new media categories and automation features not present 
 <details>
 <summary><strong>Click to view Supported Usenet Indexers</strong></summary>
 
-| Site                                                                                           | Usage     | Supported Categories  |
+| Site                                                                                           | Usage       | Supported Categories  |
 | ---------------------------------------------------------------------------------------------- | ----------- | --------------------- |
 | <img src="web_ui/static/img/trackers/curupira.png" width="16" height="16" />‎ ‎ Curupira       | CURUPIRA    | MOVIE, TV, BOOK, GAME |
 | <img src="web_ui/static/img/trackers/drunkenslug.png" width="16" height="16" />‎ ‎ DrunkenSlug | DRUNKENSLUG | MOVIE, TV, BOOK, GAME |

--- a/data/example_config.py
+++ b/data/example_config.py
@@ -333,6 +333,12 @@ config: dict[str, Any] = {
         "add_audio_spectrogram": True,
         # Set true to generate spectrograms for all audio streams
         "process_all_audio_spectrogram": False,
+        # Seconds from the beginning of each selected stream to analyse.
+        "audio_spectrogram_duration": 600,
+        # Decode at this sample rate (48 kHz retains frequencies up to 24 kHz).
+        "audio_spectrogram_sample_rate": 48000,
+        # For MUSIC and audiobooks, limit the number of tracks/chapters processed.
+        "audio_spectrogram_max_files": 12,
 
         # CLIENT SETUP
 

--- a/docs/description-builder.md
+++ b/docs/description-builder.md
@@ -49,6 +49,9 @@ Below is the detailed list of configuration variables that affect description bu
 
 - `episode_overview` (Boolean): If `True` and category is `TV`, retrieves the specific episode's name and overview text from API databases.
 - `add_audio_spectrogram` (Boolean): If `True`, attaches audio spectrogram analysis images to the description.
+- `audio_spectrogram_duration` (Integer): Seconds to analyse from each selected stream (default: `600`).
+- `audio_spectrogram_sample_rate` (Integer): Decode rate for analysis (default: `48000`, preserving frequencies up to 24 kHz).
+- `audio_spectrogram_max_files` (Integer): Maximum music tracks or audiobook chapters to process (default: `12`).
 
 ---
 

--- a/src/args.py
+++ b/src/args.py
@@ -626,7 +626,7 @@ class Args:
             "--audio-spectrogram-tracks",
             nargs=1,
             required=False,
-            help="Select which audio tracks/streams to generate spectrograms for (comma-separated indexes or 'all')",
+            help="Select zero-based displayed audio stream positions for spectrograms (comma-separated, e.g. '0,1', or 'all')",
             type=str,
             dest="audio_spectrogram_tracks",
             default=None,

--- a/src/audio_spectrogram.py
+++ b/src/audio_spectrogram.py
@@ -1,191 +1,361 @@
 # Upload Assistant © 2025 Audionut & wastaken7 — Licensed under UAPL v1.0
+import asyncio
+import hashlib
 import io
 import json
 import subprocess
 from pathlib import Path
 from typing import Any, cast
 
-import aiofiles
 import librosa
 import librosa.display
+import matplotlib
+
+matplotlib.use("Agg")
+
 import matplotlib.pyplot as plt
 import numpy as np
 from rich.prompt import Prompt
 
 from src.console import logger
 from src.meta import Meta
+from src.webui_progress import complete_progress, publish_progress
 
 DURATION_LIMIT = 600
+SAMPLE_RATE = 48000
 WIDTH_INCH = 16
 HEIGHT_INCH = 9
 DPI_VALUE = 240
+CACHE_VERSION = 2
+AUDIOBOOK_EXTENSIONS = {".aac", ".aax", ".flac", ".m4a", ".m4b", ".mp3", ".ogg", ".opus", ".wav", ".wma"}
+SPECTROGRAM_N_FFT = 2048
+MAX_TIME_BINS = 1024
 
 
-def get_audio_streams(file_path):
-    """
-    Uses ffprobe to list all audio streams in the MKV file.
-    """
-    command: list[str] = ["ffprobe", "-v", "error", "-show_entries", "stream=index:stream_tags=language,title", "-select_streams", "a", "-of", "json", file_path]
-    result = subprocess.run(command, capture_output=True, text=True)  # noqa: S603
-    return json.loads(result.stdout).get("streams", [])
+def get_audio_streams(file_path: str | Path) -> list[dict[str, Any]]:
+    """Return the audio streams reported by ffprobe, or raise a useful error."""
+    command = ["ffprobe", "-v", "error", "-show_entries", "stream=index:stream_tags=language,title", "-select_streams", "a", "-of", "json", str(file_path)]
+    try:
+        result = subprocess.run(command, capture_output=True, text=True, check=False, timeout=60)  # noqa: S603
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise RuntimeError(f"Could not run ffprobe: {error}") from error
+
+    if result.returncode:
+        detail = result.stderr.strip() or "unknown ffprobe error"
+        raise RuntimeError(f"ffprobe could not inspect '{file_path}': {detail}")
+    try:
+        streams = json.loads(result.stdout).get("streams", [])
+    except json.JSONDecodeError as error:
+        raise RuntimeError(f"ffprobe returned invalid JSON for '{file_path}'") from error
+    return [stream for stream in streams if isinstance(stream, dict)]
 
 
-def generate_spectrogram(stream_index, stream_label, stream_lang, file_path, output_dir):
-    """
-    Extracts specific stream and generates the spectrogram plot.
-    """
+def select_audio_streams(streams: list[dict[str, Any]], choice: str) -> list[dict[str, Any]]:
+    """Select streams by their displayed, zero-based position; ``all`` selects all."""
+    normalized = [item.strip().lower() for item in choice.split(",") if item.strip()]
+    if "all" in normalized:
+        return streams
+
+    selected: list[dict[str, Any]] = []
+    seen: set[int] = set()
+    for item in normalized:
+        if not item.isdigit():
+            logger.info(f"Invalid audio stream selection: {item}. Use zero-based positions or 'all'.")
+            continue
+        position = int(item)
+        if not 0 <= position < len(streams):
+            logger.info(f"Invalid audio stream position: {position}. Available positions: 0-{len(streams) - 1}.")
+            continue
+        if position not in seen:
+            selected.append(streams[position])
+            seen.add(position)
+    return selected
+
+
+def _positive_config_int(config: dict[str, Any], key: str, default: int) -> int:
+    value = config.get("DEFAULT", {}).get(key, default)
+    try:
+        value_as_int = int(value)
+    except TypeError, ValueError:
+        logger.warning(f"[yellow]Invalid {key!r} value {value!r}; using {default}.[/yellow]")
+        return default
+    if value_as_int <= 0:
+        logger.warning(f"[yellow]{key!r} must be positive; using {default}.[/yellow]")
+        return default
+    return value_as_int
+
+
+def get_spectrogram_sources(category: str, filelist: list[Any], disc_final_path: Path | None, max_source_files: int) -> list[Path]:
+    """Return source files for a release, preserving all music/audiobook chapters."""
+    if disc_final_path:
+        return [disc_final_path]
+    sources = [Path(file_path) for file_path in filelist if Path(file_path).is_file()]
+    if category == "BOOK":
+        sources = [source for source in sources if source.suffix.lower() in AUDIOBOOK_EXTENSIONS]
+    elif category not in ("BOOK", "MUSIC"):
+        sources = sources[:1]
+    return sources[:max_source_files]
+
+
+def get_stft_parameters(sample_count: int) -> tuple[int, int]:
+    """Bound the matrix plotted by Matplotlib while retaining useful frequency detail."""
+    n_fft = min(SPECTROGRAM_N_FFT, max(32, 2 ** int(np.floor(np.log2(max(sample_count, 1))))))
+    hop_length = max(n_fft // 4, int(np.ceil(sample_count / MAX_TIME_BINS)))
+    return n_fft, hop_length
+
+
+def _cache_fingerprint(audio_sources: list[Path], duration: int, sample_rate: int, stream_indexes: list[tuple[Path, int]]) -> str:
+    data = {
+        "cache_version": CACHE_VERSION,
+        "sources": [{"path": str(source.resolve()), "size": source.stat().st_size, "mtime_ns": source.stat().st_mtime_ns} for source in audio_sources],
+        "duration": duration,
+        "sample_rate": sample_rate,
+        "stream_indexes": [{"path": str(source.resolve()), "index": index} for source, index in stream_indexes],
+    }
+    return hashlib.sha256(json.dumps(data, sort_keys=True).encode()).hexdigest()
+
+
+def _load_cached_images(cache_path: Path, fingerprint: str) -> list[Any]:
+    if not cache_path.exists():
+        return []
+    try:
+        content = cache_path.read_text(encoding="utf-8")
+        cache = cast(dict[str, Any], json.loads(content)) if content.strip() else {}
+        images = cache.get("spectrograms_images")
+        if cache.get("fingerprint") == fingerprint and isinstance(images, list):
+            return images
+    except (OSError, json.JSONDecodeError) as error:
+        logger.info(f"[yellow]Could not load spectrogram image cache: {error!s}[/yellow]")
+    return []
+
+
+def generate_spectrogram(
+    stream_index: int,
+    stream_label: str,
+    stream_lang: str,
+    file_path: str | Path,
+    output_dir: Path,
+    duration: int,
+    sample_rate: int,
+    source_position: int,
+    source_name: str,
+) -> Path:
+    """Decode one stream and generate a frequency/time image suitable for review."""
     logger.info(f"--- Processing Stream {stream_index} ({stream_label}) [{stream_lang}] ---")
+    command = [
+        "ffmpeg",
+        "-v",
+        "error",
+        "-nostdin",
+        "-i",
+        str(file_path),
+        "-map",
+        f"0:{stream_index}",
+        "-t",
+        str(duration),
+        "-ac",
+        "1",
+        "-ar",
+        str(sample_rate),
+        "-f",
+        "wav",
+        "pipe:1",
+    ]
+    try:
+        result = subprocess.run(command, capture_output=True, check=False, timeout=duration + 120)  # noqa: S603
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise RuntimeError(f"Could not decode audio stream {stream_index}: {error}") from error
+    if result.returncode or not result.stdout:
+        detail = result.stderr.decode(errors="replace").strip() or "no audio was produced"
+        raise RuntimeError(f"FFmpeg could not decode audio stream {stream_index}: {detail}")
 
-    # FFmpeg command to extract specific audio stream to pipe
-    command = ["ffmpeg", "-y", "-i", file_path, "-map", f"0:{stream_index}", "-t", str(DURATION_LIMIT), "-f", "wav", "-ac", "1", "-ar", "22050", "pipe:1"]
+    try:
+        samples, actual_sample_rate = librosa.load(io.BytesIO(result.stdout), sr=None, mono=True)
+    except Exception as error:
+        raise RuntimeError(f"Could not read decoded audio for stream {stream_index}: {error}") from error
+    if samples.size == 0:
+        raise RuntimeError(f"Audio stream {stream_index} contains no decodable samples.")
 
-    process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)  # noqa: S603  # noqa: S603
-    stdout, _ = process.communicate()
-
-    # Load into librosa
-    y, sr = librosa.load(io.BytesIO(stdout), sr=22050)
-    stft = np.abs(librosa.stft(y))
+    n_fft, hop_length = get_stft_parameters(samples.size)
+    stft = np.abs(librosa.stft(samples, n_fft=n_fft, hop_length=hop_length))
     db_spectrogram = librosa.amplitude_to_db(stft, ref=np.max)
 
-    # Plotting
-    plt.figure(figsize=(WIDTH_INCH, HEIGHT_INCH), dpi=DPI_VALUE)
-    img = librosa.display.specshow(db_spectrogram, sr=sr, x_axis="time", y_axis="hz", cmap="inferno")
+    figure, axis = plt.subplots(figsize=(WIDTH_INCH, HEIGHT_INCH), dpi=DPI_VALUE)
+    image = librosa.display.specshow(
+        db_spectrogram,
+        sr=actual_sample_rate,
+        hop_length=hop_length,
+        x_axis="time",
+        y_axis="hz",
+        cmap="inferno",
+        ax=axis,
+        rasterized=True,
+    )
+    figure.colorbar(image, ax=axis, format="%+2.0f dB")
+    display_label = stream_label if stream_label and stream_label != f"Stream_{stream_index}" else source_name
+    axis.set_title(display_label, fontsize=18, fontweight="bold", pad=22)
+    axis.text(
+        0.5,
+        1.01,
+        f"File: {source_name}  •  Stream {stream_index}  •  {stream_lang}  •  First {duration}s  •  mono mix @ {actual_sample_rate / 1000:g} kHz",
+        transform=axis.transAxes,
+        ha="center",
+        va="bottom",
+        fontsize=10,
+    )
+    axis.set_xlabel("Time (s)")
+    axis.set_ylabel("Frequency (Hz)")
 
-    plt.colorbar(img, format="%+2.0f dB")
-    plt.title(f"Spectrogram - Index: {stream_index} | Lang: {stream_lang} | Label: {stream_label} | First {DURATION_LIMIT}s", fontsize=22, pad=20)
-    plt.xlabel("Time (s)", fontsize=14)
-    plt.ylabel("Frequency (Hz)", fontsize=14)
-
-    output_name = Path(output_dir) / f"spectrogram_stream_{stream_index}.png"
-    plt.tight_layout()
-    plt.savefig(output_name, dpi=DPI_VALUE, bbox_inches="tight")
-    plt.close()  # Free memory
+    output_name = output_dir / f"spectrogram_source_{source_position:02d}_stream_{stream_index}.png"
+    figure.tight_layout()
+    figure.savefig(output_name, dpi=DPI_VALUE, bbox_inches="tight")
+    plt.close(figure)
     logger.info(f"Saved: {output_name}")
     return output_name
 
 
 async def process_audio_spectrograms(meta: Meta, config: dict[str, Any], uploadscreens_manager: Any = None) -> list[str]:
-    audio_spectrograms_images = f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/audio_spectrograms_images.json"
-    if Path(audio_spectrograms_images).exists():
-        try:
-            async with aiofiles.open(audio_spectrograms_images, encoding="utf-8") as spec_file:
-                content = await spec_file.read()
-                spectrograms_image_file = cast(dict[str, Any], json.loads(content)) if content.strip() else {}
-
-                if "spectrograms_images" in spectrograms_image_file and not meta.spectrograms_images:
-                    meta.spectrograms_images = spectrograms_image_file["spectrograms_images"]
-                    logger.debug(f"[cyan]Loaded {len(spectrograms_image_file['spectrograms_images'])} previously saved spectrograms")
-
-        except Exception as e:
-            logger.info(f"[yellow]Could not load spectrograms image data: {e!s}")
-
     if meta.spectrograms_images:
         return []
 
     logger.info("[yellow]Generating Audio Spectrograms...[/yellow]")
-
     output_dir = Path(meta.base_dir) / "tmp" / meta.uuid / "spectrograms"
-    Path(output_dir).mkdir(parents=True, exist_ok=True)
+    cache_path = Path(meta.base_dir) / "tmp" / meta.uuid / "audio_spectrograms_images.json"
+    output_dir.mkdir(parents=True, exist_ok=True)
 
-    disc_final_path = ""
     bdinfo = meta.bdinfo
+    disc_final_path: Path | None = None
     if bdinfo:
         disc_path = bdinfo.get("path", "")
         files_list = bdinfo.get("files", [])
         disc_file = files_list[0].get("file", "") if files_list else ""
-        disc_final_path = Path(disc_path) / "STREAM" / disc_file if disc_path and disc_file else ""
-        logger.debug(f"disc_final_path: {disc_final_path}")
+        if disc_path and disc_file:
+            disc_final_path = Path(disc_path) / "STREAM" / disc_file
+            logger.debug(f"disc_final_path: {disc_final_path}")
 
-    mkv_path = ""
-    filelist = meta.filelist
-    if filelist:
-        mkv_path = filelist[0]
+    max_source_files = _positive_config_int(config, "audio_spectrogram_max_files", 12)
+    all_audio_sources = get_spectrogram_sources(meta.category, meta.filelist, disc_final_path, max(len(meta.filelist), 1))
+    audio_sources = all_audio_sources[:max_source_files]
+    if len(all_audio_sources) > max_source_files:
+        logger.info(f"[yellow]Limiting audio spectrogram generation to the first {max_source_files} of {len(all_audio_sources)} {meta.category.lower()} audio files.[/yellow]")
 
-    audio_path = disc_final_path if disc_final_path else mkv_path
-
-    generated_files = []
-
-    if not audio_path or not Path(audio_path).exists():
+    if not audio_sources:
         logger.info("[red]Could not find a valid audio or video file to process spectrograms from.[/red]")
-        return generated_files
+        return []
 
-    streams = get_audio_streams(audio_path)
+    source_streams: list[tuple[int, Path, list[dict[str, Any]]]] = []
+    for source_position, audio_path in enumerate(audio_sources, start=1):
+        try:
+            streams = await asyncio.to_thread(get_audio_streams, audio_path)
+        except RuntimeError as error:
+            logger.error(f"[red]{error}[/red]")
+            continue
 
-    if bdinfo and audio_path == disc_final_path:
-        bdinfo_audios = bdinfo.get("audio", [])
-        valid_streams = []
-        for i, s in enumerate(streams):
-            if i < len(bdinfo_audios):
-                if "tags" not in s:
-                    s["tags"] = {}
-                if not s["tags"].get("language") or s["tags"].get("language") == "und":
-                    s["tags"]["language"] = bdinfo_audios[i].get("language", "und")
-                s["tags"]["title"] = bdinfo_audios[i].get("codec", "No Title")
-                valid_streams.append(s)
-        streams = valid_streams
+        if bdinfo and audio_path == disc_final_path:
+            bdinfo_audios = bdinfo.get("audio", [])
+            for position, stream in enumerate(streams):
+                tags = stream.setdefault("tags", {})
+                if position < len(bdinfo_audios):
+                    if not tags.get("language") or tags.get("language") == "und":
+                        tags["language"] = bdinfo_audios[position].get("language", "und")
+                    tags.setdefault("title", bdinfo_audios[position].get("codec", "No Title"))
+        if streams:
+            source_streams.append((source_position, audio_path, streams))
 
-    if not streams:
+    if not source_streams:
         logger.info("No audio streams found.")
+        return []
+
+    _, first_audio_path, first_streams = source_streams[0]
+    logger.info(f"\nAvailable Audio Streams for {first_audio_path.name} (use these zero-based positions):")
+    for position, stream in enumerate(first_streams):
+        tags = stream.get("tags", {})
+        logger.info(f"[{position}] FFmpeg stream {stream.get('index')} | Lang: {tags.get('language', 'und')} | Title: {tags.get('title', 'No Title')}")
+
+    if meta.audio_spectrogram_tracks is not None:
+        choice = str(meta.audio_spectrogram_tracks)
+        logger.info(f"[yellow]Using audio spectrogram tracks from argument: {choice}[/yellow]")
+    elif meta.unattended or len(source_streams) > 1:
+        choice = "all" if config["DEFAULT"].get("process_all_audio_spectrogram", False) else "0"
+        logger.info(f"[yellow]Automatically selected stream position: {choice}[/yellow]")
     else:
-        logger.info("\nAvailable Audio Streams:")
-        for i, s in enumerate(streams):
-            lang = s.get("tags", {}).get("language", "und")
-            title = s.get("tags", {}).get("title", "No Title")
-            logger.info(f"[{i}] Lang: {lang} | Title: {title}")
+        choice = Prompt.ask("\nSelect audio stream positions (e.g. [bold yellow]0,1[/bold yellow] or [bold yellow]all[/bold yellow])", default="all")
 
-        unattended = meta.unattended
-        audio_spectrogram_tracks = meta.audio_spectrogram_tracks
+    selected_jobs: list[tuple[int, Path, dict[str, Any]]] = []
+    for source_position, audio_path, streams in source_streams:
+        selected_streams = select_audio_streams(streams, choice)
+        if not selected_streams:
+            logger.info(f"[yellow]No valid streams selected for {audio_path.name}; skipping it.[/yellow]")
+            continue
+        selected_jobs.extend((source_position, audio_path, stream) for stream in selected_streams)
 
-        if audio_spectrogram_tracks is not None:
-            choice = str(audio_spectrogram_tracks)
-            logger.info(f"[yellow]Using audio spectrogram tracks from argument: {choice}[/yellow]")
-        elif unattended:
-            choice = "all" if config["DEFAULT"].get("process_all_audio_spectrogram", False) else "0"
-            logger.info(f"[yellow]Unattended mode. Automatically selected option: {choice}[/yellow]")
-        else:
-            choice = Prompt.ask(
-                "\nSelect the stream index to scan (comma-separated list e.g. [bold yellow]0,1,2[/bold yellow] or [bold yellow]all[/bold yellow])", default="all"
+    if not selected_jobs:
+        logger.info("[yellow]No valid audio streams were selected.[/yellow]")
+        return []
+
+    duration = _positive_config_int(config, "audio_spectrogram_duration", DURATION_LIMIT)
+    sample_rate = _positive_config_int(config, "audio_spectrogram_sample_rate", SAMPLE_RATE)
+    fingerprint = _cache_fingerprint(audio_sources, duration, sample_rate, [(audio_path, int(stream["index"])) for _, audio_path, stream in selected_jobs])
+    cached_images = await asyncio.to_thread(_load_cached_images, cache_path, fingerprint)
+    if cached_images:
+        meta.spectrograms_images = cached_images
+        logger.debug(f"[cyan]Loaded {len(cached_images)} matching cached spectrograms.[/cyan]")
+        return []
+
+    generated_files: list[str] = []
+    progress_id = f"audio-spectrogram-{meta.uuid}"
+    publish_progress(progress_id, "Generating audio spectrograms", current=0, total=len(selected_jobs), detail="Preparing audio streams", group="spectrogram", unit="streams")
+    for job_position, (source_position, audio_path, stream) in enumerate(selected_jobs, start=1):
+        tags = stream.get("tags", {})
+        label = tags.get("title", f"Stream_{stream['index']}")
+        language = tags.get("language", "und")
+        try:
+            file_path = await asyncio.to_thread(
+                generate_spectrogram, int(stream["index"]), label, language, audio_path, output_dir, duration, sample_rate, source_position, audio_path.stem
             )
+        except RuntimeError as error:
+            logger.error(f"[red]{error}[/red]")
+            publish_progress(
+                progress_id,
+                "Generating audio spectrograms",
+                current=job_position,
+                total=len(selected_jobs),
+                detail=f"{audio_path.name}: stream {stream['index']} failed",
+                status="failed",
+                group="spectrogram",
+                unit="streams",
+            )
+            continue
+        generated_files.append(str(file_path))
+        publish_progress(
+            progress_id,
+            "Generating audio spectrograms",
+            current=job_position,
+            total=len(selected_jobs),
+            detail=f"Processed {audio_path.name}: stream {stream['index']}",
+            group="spectrogram",
+            unit="streams",
+        )
 
-        choices = [c.strip().lower() for c in choice.split(",")]
+    if generated_files and uploadscreens_manager:
+        logger.info("[yellow]Uploading Audio Spectrograms...[/yellow]")
+        try:
+            spec_images, _ = await uploadscreens_manager.upload_screens(meta, len(generated_files), 1, 0, len(generated_files), generated_files, {})
+            if spec_images:
+                meta.spectrograms_images = spec_images
+                cache = {"cache_version": CACHE_VERSION, "fingerprint": fingerprint, "spectrograms_images": spec_images}
+                await asyncio.to_thread(cache_path.write_text, json.dumps(cache, indent=4), encoding="utf-8")
+                logger.debug(f"[cyan]Saved {len(spec_images)} spectrograms to audio_spectrograms_images.json[/cyan]")
+        except Exception as error:
+            logger.error(f"[red]Error uploading audio spectrograms: {error}[/red]")
 
-        if "all" in choices or str(len(streams)) in choices:
-            # Scan all
-            for s in streams:
-                label = s.get("tags", {}).get("title", f"Stream_{s['index']}")
-                lang = s.get("tags", {}).get("language", "und")
-                filepath = generate_spectrogram(s["index"], label, lang, audio_path, output_dir)
-                generated_files.append(filepath)
-        else:
-            # Scan selected
-            for c in choices:
-                if c.isdigit():
-                    idx = int(c)
-                    if 0 <= idx < len(streams):
-                        target = streams[idx]
-                        label = target.get("tags", {}).get("title", f"Stream_{target['index']}")
-                        lang = target.get("tags", {}).get("language", "und")
-                        filepath = generate_spectrogram(target["index"], label, lang, audio_path, output_dir)
-                        generated_files.append(filepath)
-                    else:
-                        logger.info(f"Invalid index: {idx}")
-                else:
-                    logger.info(f"Invalid input: {c}")
-
-        if generated_files and uploadscreens_manager:
-            logger.info("[yellow]Uploading Audio Spectrograms...[/yellow]")
-            try:
-                spec_images, _ = await uploadscreens_manager.upload_screens(meta, len(generated_files), 1, 0, len(generated_files), generated_files, {})
-                if spec_images:
-                    meta.spectrograms_images = spec_images
-                    try:
-                        spectrograms_image_file_dict = {"spectrograms_images": spec_images}
-                        async with aiofiles.open(audio_spectrograms_images, "w", encoding="utf-8") as spec_file:
-                            await spec_file.write(json.dumps(spectrograms_image_file_dict, indent=4))
-                        logger.debug(f"[cyan]Saved {len(spec_images)} spectrograms to audio_spectrograms_images.json")
-                    except Exception as e:
-                        logger.info(f"[yellow]Failed to save spectrograms image data: {e!s}")
-            except Exception as e:
-                logger.error(f"[red]Error uploading audio spectrograms: {e}[/red]")
-
+    complete_progress(
+        progress_id,
+        "Audio spectrograms generated",
+        current=len(generated_files),
+        total=len(selected_jobs),
+        detail=f"Generated {len(generated_files)} of {len(selected_jobs)} stream(s)",
+        group="spectrogram",
+        unit="streams",
+    )
     return generated_files

--- a/tests/test_audio_spectrogram.py
+++ b/tests/test_audio_spectrogram.py
@@ -1,0 +1,40 @@
+from src.audio_spectrogram import MAX_TIME_BINS, get_spectrogram_sources, get_stft_parameters, select_audio_streams
+
+
+def test_select_audio_streams_accepts_positions_and_removes_duplicates():
+    streams = [{"index": 2}, {"index": 5}, {"index": 9}]
+
+    assert select_audio_streams(streams, "2,0,2") == [streams[2], streams[0]]  # noqa: S101
+
+
+def test_select_audio_streams_only_accepts_all_for_every_stream():
+    streams = [{"index": 2}, {"index": 5}, {"index": 9}]
+
+    assert select_audio_streams(streams, "3") == []  # noqa: S101
+    assert select_audio_streams(streams, "all") == streams  # noqa: S101
+
+
+def test_get_spectrogram_sources_uses_every_music_track_and_applies_limit(tmp_path):
+    tracks = [tmp_path / f"track-{number}.flac" for number in range(3)]
+    for track in tracks:
+        track.touch()
+
+    assert get_spectrogram_sources("MUSIC", [str(track) for track in tracks], None, 2) == tracks[:2]  # noqa: S101
+
+
+def test_get_spectrogram_sources_only_uses_audio_files_for_audiobooks(tmp_path):
+    chapter = tmp_path / "chapter-01.m4b"
+    cover = tmp_path / "cover.jpg"
+    chapter.touch()
+    cover.touch()
+
+    assert get_spectrogram_sources("BOOK", [str(cover), str(chapter)], None, 12) == [chapter]  # noqa: S101
+
+
+def test_stft_parameters_bound_the_number_of_time_bins_for_long_audio():
+    sample_count = 600 * 48000
+
+    n_fft, hop_length = get_stft_parameters(sample_count)
+
+    assert n_fft == 2048  # noqa: S101
+    assert sample_count / hop_length <= MAX_TIME_BINS  # noqa: S101

--- a/upload.py
+++ b/upload.py
@@ -1413,7 +1413,7 @@ async def process_meta(meta: Meta, base_dir: str) -> bool:
                 elif meta.path_to_menu_screenshots or config["DEFAULT"].get("auto_dvd_menus", False):
                     await process_disc_menus(meta, config)
 
-            if meta.category != "MUSIC" and (meta.audio_spectrogram or meta.audio_spectrogram_tracks or config["DEFAULT"].get("add_audio_spectrogram", False)):
+            if meta.audio_spectrogram or meta.audio_spectrogram_tracks or config["DEFAULT"].get("add_audio_spectrogram", False):
                 try:
                     await process_audio_spectrograms(meta, config, uploadscreens_manager)
                 except Exception as e:

--- a/web_ui/static/js/app.js
+++ b/web_ui/static/js/app.js
@@ -572,6 +572,36 @@ const argumentCategories = [
     ],
   },
   {
+    title: "Audio Spectrograms",
+    subtitle:
+      "The stream positions are zero-based. Choose a preset, then edit the command if you want a different list.",
+    args: [
+      {
+        label: "First audio stream",
+        insert: "--audio-spectrogram --audio-spectrogram-tracks 0",
+        description:
+          "Generate an upload-ready spectrogram for stream position 0.",
+      },
+      {
+        label: "All audio streams",
+        insert: "--audio-spectrogram --audio-spectrogram-tracks all",
+        description: "Generate one spectrogram per available stream.",
+      },
+      {
+        label: "--audio-spectrogram",
+        description:
+          "Generate spectrograms; without a stream selection, the workflow will ask which streams to use.",
+      },
+      {
+        label: "--audio-spectrogram-tracks",
+        placeholder: "0,1 or all",
+        insert: "--audio-spectrogram --audio-spectrogram-tracks all",
+        description:
+          "Preset inserts a valid selection. Replace 'all' with zero-based positions in the command field if needed.",
+      },
+    ],
+  },
+  {
     title: "Misc Options",
     args: [
       {
@@ -582,15 +612,6 @@ const argumentCategories = [
         label: "--channel",
         placeholder: "ID_OR_TAG",
         description: "SPD channel",
-      },
-      {
-        label: "--audio-spectrogram",
-        description: "Generate audio spectrograms",
-      },
-      {
-        label: "--audio-spectrogram-tracks",
-        placeholder: "1,2",
-        description: "Specific tracks for spectrograms",
       },
       { label: "--usenet", description: "Upload files to Usenet (NNTP)" },
       {
@@ -4125,7 +4146,9 @@ function AudionutsUAGUI() {
                                 >
                                   <div className="flex items-start justify-between gap-3">
                                     <button
-                                      onClick={() => addArgument(a.label)}
+                                      onClick={() =>
+                                        addArgument(a.insert || a.label)
+                                      }
                                       disabled={isExecuting}
                                       className={`px-3 py-1.5 text-sm font-mono rounded-md border ${isDarkMode ? "bg-gray-700 border-gray-600 text-white hover:bg-purple-600 hover:text-white" : "bg-white border-gray-200 text-gray-800 hover:bg-purple-600 hover:text-white"} transition-colors`}
                                     >
@@ -4970,7 +4993,9 @@ function AudionutsUAGUI() {
                             >
                               <div className="flex items-start justify-between gap-3">
                                 <button
-                                  onClick={() => addArgument(a.label)}
+                                  onClick={() =>
+                                    addArgument(a.insert || a.label)
+                                  }
                                   disabled={isExecuting}
                                   className={`px-3 py-1 text-sm font-mono rounded-md border ${isDarkMode ? "bg-gray-700 border-gray-600 text-white hover:bg-purple-600 hover:text-white" : "bg-white border-gray-200 text-gray-800 hover:bg-purple-600 hover:text-white"} transition-colors`}
                                 >


### PR DESCRIPTION
## Summary
- generate spectrograms for music tracks and audiobook chapters with a configurable file limit
- improve stream selection, cache invalidation, FFmpeg error handling, and WebUI presets/progress
- bound spectrogram rendering memory and use the non-GUI Matplotlib backend
- include source track names in generated image headers

## Validation
- python -m pytest -q (84 passed)
- ruff check src/audio_spectrogram.py upload.py src/args.py tests/test_audio_spectrogram.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added audio spectrogram support for music tracks and audiobook chapters.
  - Added configurable analysis duration, sample rate, and source-file limits.
  - Added caching, progress updates, improved stream selection, and clearer spectrogram output.
  - Added a dedicated Audio Spectrograms category with preset options in the web interface.

- **Documentation**
  - Updated configuration, CLI, and feature documentation with new options and supported sources.

- **Tests**
  - Added coverage for stream selection, source filtering, limits, and spectrogram sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->