### PR TITLE
fix(edition): avoid TV2 repack false positive

### DIFF
--- a/src/edition.py
+++ b/src/edition.py
@@ -28,6 +28,11 @@ def _has_release_token(value: str, token: str) -> bool:
     return re.search(rf"(?<![A-Z0-9]){re.escape(token)}(?![A-Z0-9])", value, flags=re.IGNORECASE) is not None
 
 
+def _strip_release_tokens(value: str) -> str:
+    """Remove standalone release markers while preserving adjacent text."""
+    return re.sub(r"(?<![A-Z0-9])(?:REPACK\d?|RERIP|PROPER\d?)(?![A-Z0-9])", "", value, flags=re.IGNORECASE).strip()
+
+
 async def get_edition(video: str, bdinfo: dict[str, Any] | None, filelist: list[str], manual_edition: str | list[str], meta: Meta) -> tuple[str, str, bool]:
     edition = ""
     imdb_info = cast(dict[str, Any], meta.imdb_info)
@@ -329,7 +334,7 @@ async def get_edition(video: str, bdinfo: dict[str, Any] | None, filelist: list[
         if len(filelist) == 1:
             video = Path(video).name
 
-        video = video.upper().replace(".", " ").replace(tag.upper(), "").replace("-", "")
+        video = video.upper().replace(".", " ").replace(tag.upper(), "").replace("-", " ")
 
         if "OPEN MATTE" in video.upper():
             edition = edition + " Open Matte"
@@ -365,7 +370,7 @@ async def get_edition(video: str, bdinfo: dict[str, Any] | None, filelist: list[
         isinstance(manual_edition, str)
         and all(tag.lower() not in ["repack", "repack2", "repack3", "proper", "proper2", "proper3", "rerip"] for tag in manual_edition.strip().lower().split())
     ):
-        edition = re.sub(r"(\bREPACK\d?\b|\bRERIP\b|\bPROPER\d?\b)", "", edition, flags=re.IGNORECASE).strip()
+        edition = _strip_release_tokens(edition)
 
     if not meta.webdv:
         hybrid = False

--- a/src/edition.py
+++ b/src/edition.py
@@ -18,6 +18,16 @@ def guessit_fn(value: str, options: dict[str, Any] | None = None) -> dict[str, A
     return cast(dict[str, Any], guessit_module.guessit(value, options))
 
 
+def _has_release_token(value: str, token: str) -> bool:
+    """Return whether a scene-release marker appears as its own token.
+
+    Release names commonly use dots, dashes, and spaces as separators.  A
+    substring check is too broad here: for example, ``TV2`` is a broadcaster,
+    not the ``V2`` marker for a repack.
+    """
+    return re.search(rf"(?<![A-Z0-9]){re.escape(token)}(?![A-Z0-9])", value, flags=re.IGNORECASE) is not None
+
+
 async def get_edition(video: str, bdinfo: dict[str, Any] | None, filelist: list[str], manual_edition: str | list[str], meta: Meta) -> tuple[str, str, bool]:
     edition = ""
     imdb_info = cast(dict[str, Any], meta.imdb_info)
@@ -334,19 +344,20 @@ async def get_edition(video: str, bdinfo: dict[str, Any] | None, filelist: list[
 
     # Handle repack info
     repack = ""
-    if "REPACK" in (video.upper() or edition.upper()) or "V2" in video:
+    release_text = f"{video} {edition}"
+    if _has_release_token(release_text, "REPACK") or _has_release_token(release_text, "V2"):
         repack = "REPACK"
-    if "REPACK2" in (video.upper() or edition.upper()) or "V3" in video:
+    if _has_release_token(release_text, "REPACK2") or _has_release_token(release_text, "V3"):
         repack = "REPACK2"
-    if "REPACK3" in (video.upper() or edition.upper()) or "V4" in video:
+    if _has_release_token(release_text, "REPACK3") or _has_release_token(release_text, "V4"):
         repack = "REPACK3"
-    if "PROPER" in (video.upper() or edition.upper()):
+    if _has_release_token(release_text, "PROPER"):
         repack = "PROPER"
-    if "PROPER2" in (video.upper() or edition.upper()):
+    if _has_release_token(release_text, "PROPER2"):
         repack = "PROPER2"
-    if "PROPER3" in (video.upper() or edition.upper()):
+    if _has_release_token(release_text, "PROPER3"):
         repack = "PROPER3"
-    if "RERIP" in (video.upper() or edition.upper()):
+    if _has_release_token(release_text, "RERIP"):
         repack = "RERIP"
 
     # Only remove REPACK, RERIP, or PROPER from edition if not in manual edition
@@ -354,7 +365,7 @@ async def get_edition(video: str, bdinfo: dict[str, Any] | None, filelist: list[
         isinstance(manual_edition, str)
         and all(tag.lower() not in ["repack", "repack2", "repack3", "proper", "proper2", "proper3", "rerip"] for tag in manual_edition.strip().lower().split())
     ):
-        edition = re.sub(r"(\bREPACK\d?\b|\bRERIP\b|\bPROPER\b)", "", edition, flags=re.IGNORECASE).strip()
+        edition = re.sub(r"(\bREPACK\d?\b|\bRERIP\b|\bPROPER\d?\b)", "", edition, flags=re.IGNORECASE).strip()
 
     if not meta.webdv:
         hybrid = False

--- a/tests/test_edition.py
+++ b/tests/test_edition.py
@@ -1,0 +1,18 @@
+"""Regression coverage for release-marker detection in edition handling."""
+
+import pytest
+
+from src.edition import _has_release_token
+
+
+@pytest.mark.parametrize("value", ["V2", "Show.S01E01.V2.1080p", "Movie-REPACK-1080p", "Movie PROPER2 1080p"])
+def test_release_marker_matches_standalone_tokens(value: str) -> None:
+    token = "V2" if "V2" in value else "REPACK" if "REPACK" in value else "PROPER2"
+    assert _has_release_token(value, token)
+
+
+@pytest.mark.parametrize("value", ["TV2", "TV2.WEB-DL", "SV2", "V2GROUP", "REPACKAGED", "PROPERLY"])
+def test_release_marker_does_not_match_inside_other_tokens(value: str) -> None:
+    assert not _has_release_token(value, "V2")
+    assert not _has_release_token(value, "REPACK")
+    assert not _has_release_token(value, "PROPER")

--- a/tests/test_edition.py
+++ b/tests/test_edition.py
@@ -1,18 +1,58 @@
 """Regression coverage for release-marker detection in edition handling."""
 
+import asyncio
+
 import pytest
 
-from src.edition import _has_release_token
+from src.edition import _has_release_token, _strip_release_tokens, get_edition
+from src.meta import Meta
 
 
-@pytest.mark.parametrize("value", ["V2", "Show.S01E01.V2.1080p", "Movie-REPACK-1080p", "Movie PROPER2 1080p"])
-def test_release_marker_matches_standalone_tokens(value: str) -> None:
-    token = "V2" if "V2" in value else "REPACK" if "REPACK" in value else "PROPER2"
+@pytest.mark.parametrize(
+    ("value", "token"),
+    [
+        ("Show.V2.1080p", "V2"),
+        ("Show-V3-1080p", "V3"),
+        ("Show V4 1080p", "V4"),
+        ("Show.REPACK.1080p", "REPACK"),
+        ("Show-REPACK2-1080p", "REPACK2"),
+        ("Show REPACK3 1080p", "REPACK3"),
+        ("Show.PROPER.1080p", "PROPER"),
+        ("Show-PROPER2-1080p", "PROPER2"),
+        ("Show PROPER3 1080p", "PROPER3"),
+        ("Show.RERIP.1080p", "RERIP"),
+    ],
+)
+def test_release_marker_matches_standalone_tokens(value: str, token: str) -> None:
     assert _has_release_token(value, token)
 
 
-@pytest.mark.parametrize("value", ["TV2", "TV2.WEB-DL", "SV2", "V2GROUP", "REPACKAGED", "PROPERLY"])
-def test_release_marker_does_not_match_inside_other_tokens(value: str) -> None:
-    assert not _has_release_token(value, "V2")
-    assert not _has_release_token(value, "REPACK")
-    assert not _has_release_token(value, "PROPER")
+@pytest.mark.parametrize(
+    ("value", "token"),
+    [
+        ("TV2", "V2"),
+        ("TV3", "V3"),
+        ("TV4", "V4"),
+        ("REPACKAGED", "REPACK"),
+        ("REPACK2X", "REPACK2"),
+        ("REPACK3X", "REPACK3"),
+        ("PROPERLY", "PROPER"),
+        ("PROPER2X", "PROPER2"),
+        ("PROPER3X", "PROPER3"),
+        ("RERIPPED", "RERIP"),
+    ],
+)
+def test_release_marker_does_not_match_inside_other_tokens(value: str, token: str) -> None:
+    assert not _has_release_token(value, token)
+
+
+def test_strip_release_tokens_uses_non_alphanumeric_boundaries() -> None:
+    assert _strip_release_tokens("Director_PROPER2") == "Director_"
+
+
+def test_get_edition_detects_repack_between_hyphens() -> None:
+    edition, repack, hybrid = asyncio.run(get_edition("Movie-REPACK-1080p", None, [], "", Meta(category="TV")))
+
+    assert edition == ""
+    assert repack == "REPACK"
+    assert not hybrid


### PR DESCRIPTION
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release-marker detection to recognize standalone tags such as REPACK, V2, and PROPER2.
  * Prevented incorrect matches within unrelated words, such as TV2, REPACKAGED, or PROPERLY.
  * Improved cleanup of release markers with numeric suffixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->