### PR TITLE
feat(region): add TV2 service

### DIFF
--- a/src/region.py
+++ b/src/region.py
@@ -2309,6 +2309,7 @@ async def get_service(
         "TRVL": "TRVL",
         "TUBI": "TUBI",
         "TubiTV": "TUBI",
+        "TV2": "TV2",
         "TV3": "TV3",
         "TV3 Ireland": "TV3",
         "TV4": "TV4",


### PR DESCRIPTION
## Summary
- add TV2 to the recognized streaming-service mappings
- detect TV2 releases as service TV2

## Tests
- verified get_service with the reported release name