### PR TITLE
feat(avistaz): add tracker routing and rules

### DIFF
--- a/src/trackers/AVISTAZ/__init__.py
+++ b/src/trackers/AVISTAZ/__init__.py
@@ -788,9 +788,14 @@ class AZTrackerBase:
 
             if self.tracker == "CINEMAZ":
                 # CinemaZ requires HYBRID immediately after the video quality.
-                has_hybrid = bool(re.search(r"\bHYBRID\b", upload_name, flags=re.IGNORECASE))
-                if has_hybrid:
-                    upload_name_without_hybrid = re.sub(r"\bHYBRID\b", "", upload_name, flags=re.IGNORECASE)
+                has_hybrid_marker = bool(meta.webdv) or "hybrid" in (meta.edition or "").casefold()
+                title_match = re.search(re.escape(meta.title), upload_name, flags=re.IGNORECASE) if meta.title else None
+                marker_search_start = title_match.end() if title_match else 0
+                hybrid_match = re.search(r"\bHYBRID\b", upload_name[marker_search_start:], flags=re.IGNORECASE) if has_hybrid_marker else None
+                if hybrid_match:
+                    hybrid_start = marker_search_start + hybrid_match.start()
+                    hybrid_end = marker_search_start + hybrid_match.end()
+                    upload_name_without_hybrid = f"{upload_name[:hybrid_start]}{upload_name[hybrid_end:]}"
                     resolution_match = re.search(r"\b(?:\d{3,4}[pi]|4K|UHD|SD)\b", upload_name_without_hybrid, flags=re.IGNORECASE)
                     if resolution_match:
                         upload_name = upload_name_without_hybrid

--- a/src/trackers/AVISTAZ/__init__.py
+++ b/src/trackers/AVISTAZ/__init__.py
@@ -769,14 +769,33 @@ class AZTrackerBase:
         daily_episode_title = meta.daily_episode_title or ""
         upload_name: str = meta.name.replace(aka_name, "").replace("Dubbed", "").replace("Dual-Audio", "").replace(manual_episode_title, "").replace(daily_episode_title, "")
 
-        if self.tracker == "PRIVATEHD":
+        if self.tracker in ("CINEMAZ", "PRIVATEHD"):
+            # Both sites prohibit these release descriptors in torrent titles.
             forbidden_terms = [r"\bLIMITED\b", r"\bCriterion Collection\b", r"\b\d{1,3}(?:st|nd|rd|th)\s+Anniversary Edition\b"]
             for term in forbidden_terms:
                 upload_name = re.sub(term, "", upload_name, flags=re.IGNORECASE).strip()
 
             upload_name = re.sub(r"\bDirector[’\'`]s\s+Cut\b", "DC", upload_name, flags=re.IGNORECASE)  # noqa: RUF001
-            upload_name = re.sub(r"\bExtended\s+Cut\b", "Extended", upload_name, flags=re.IGNORECASE)
-            upload_name = re.sub(r"\bTheatrical\s+Cut\b", "Theatrical", upload_name, flags=re.IGNORECASE)
+            if self.tracker == "CINEMAZ":
+                upload_name = re.sub(r"\bExtended\s+Cut\b", "EXT", upload_name, flags=re.IGNORECASE)
+                upload_name = re.sub(r"\bTheatrical\s+Cut\b", "TC", upload_name, flags=re.IGNORECASE)
+            else:
+                upload_name = re.sub(r"\bExtended\s+Cut\b", "Extended", upload_name, flags=re.IGNORECASE)
+                upload_name = re.sub(r"\bTheatrical\s+Cut\b", "Theatrical", upload_name, flags=re.IGNORECASE)
+
+            # CinemaZ and PrivateHD prohibit brackets in torrent titles.
+            upload_name = upload_name.replace("[", "").replace("]", "")
+
+            if self.tracker == "CINEMAZ":
+                # CinemaZ requires HYBRID immediately after the video quality.
+                has_hybrid = bool(re.search(r"\bHYBRID\b", upload_name, flags=re.IGNORECASE))
+                if has_hybrid:
+                    upload_name_without_hybrid = re.sub(r"\bHYBRID\b", "", upload_name, flags=re.IGNORECASE)
+                    resolution_match = re.search(r"\b(?:\d{3,4}[pi]|4K|UHD|SD)\b", upload_name_without_hybrid, flags=re.IGNORECASE)
+                    if resolution_match:
+                        upload_name = upload_name_without_hybrid
+                        upload_name = f"{upload_name[: resolution_match.end()]} HYBRID{upload_name[resolution_match.end() :]}"
+
             upload_name = re.sub(r"\s{2,}", " ", upload_name).strip()
 
         if meta.has_encode_settings:

--- a/src/trackers/AVISTAZ/avistaz.py
+++ b/src/trackers/AVISTAZ/avistaz.py
@@ -1,4 +1,5 @@
 # Upload Assistant © 2025 Audionut & wastaken7 — Licensed under UAPL v1.0
+import re
 from typing import Any
 
 from src.meta import Meta
@@ -42,13 +43,9 @@ class AvistaZ(AZTrackerBase):
         if video_encode:
             video_encode = video_encode.strip().lower()
 
-        release_type = meta.type
-        if release_type:
-            release_type = release_type.strip().lower()
+        release_type = str(meta.type or "").strip().lower()
 
-        source = meta.source
-        if source:
-            source = source.strip().lower()
+        source = str(meta.source or "").strip().lower()
 
         # This also checks the rule 'FANRES content is not allowed'
         if meta.category not in ("MOVIE", "TV"):
@@ -388,10 +385,17 @@ class AvistaZ(AZTrackerBase):
         elif any(code in cinemaz_countries for code in origin_countries_codes):
             warnings.append("DO NOT upload non-allowed Asian or Western content. Upload this content to our sister site CINEMAZ.to instead.")
 
-        if not is_disc and meta.container not in ["mkv", "mp4", "avi"]:
-            warnings.append("Allowed containers: MKV, MP4, AVI.")
+        container = str(meta.container or "").strip().lower().lstrip(".")
+        allowed_containers = {"mkv", "mp4", "avi"}
+        if release_type == "hdtv":
+            allowed_containers.update({"ts", "tp"})
+        if not is_disc and container not in allowed_containers:
+            allowed = ", ".join(sorted(allowed_containers)).upper()
+            warnings.append(f"Container not allowed for this rip type: {container or 'unknown'}. Allowed: {allowed}.")
 
-        if not is_disc and video_codec not in ("avc", "h.264", "h.265", "x264", "x265", "hevc", "divx", "xvid"):
+        allowed_video_codecs = {"avc", "h.264", "h.265", "x264", "x265", "hevc", "divx", "xvid"}
+        is_hdtv_mpeg2 = release_type == "hdtv" and video_codec in {"mpeg-2", "mpeg2"}
+        if not is_disc and video_codec not in allowed_video_codecs and not is_hdtv_mpeg2:
             warnings.append(
                 f"Video codec not allowed in your upload: {video_codec}.\n"
                 "Allowed: H264/x264/AVC, H265/x265/HEVC, DivX/Xvid\n"
@@ -400,10 +404,25 @@ class AvistaZ(AZTrackerBase):
                 "    VC-1/MPEG2 for Bluray only if that's what is on the disc"
             )
 
+        resolution_value = str(meta.resolution or "").lower()
+        resolution_match = re.search(r"(\d{3,4})", resolution_value)
+        resolution = int(resolution_match.group(1)) if resolution_match else 0
+        video_width = int(meta.video_width or 0)
+        if not is_disc and video_width and video_width < 600:
+            warnings.append(f"Video width is {video_width}px; AvistaZ requires a minimum width of 600px.")
+        if video_codec in {"divx", "xvid"} and (resolution >= 720 or video_width >= 720):
+            warnings.append("DivX/XviD is not allowed for HD video (720p and above).")
+
+        conditional_rip_types = {"webrip", "vodrip", "vhsrip"}
+        if release_type in conditional_rip_types:
+            warnings.append(f"{release_type.upper()} is allowed only when the video is unavailable in a preferred AvistaZ rip type; verify this manually before uploading.")
+        if source == "brrip" and resolution >= 720:
+            warnings.append("BRRip is allowed only for SD content (below 720p).")
+
         if is_disc:
             pass
         else:
-            allowed_keywords = ["AC3", "Audio Layer III", "MP3", "Dolby Digital", "Dolby TrueHD", "DTS", "DTS-HD", "FLAC", "AAC", "Dolby"]
+            allowed_keywords = ["AC3", "E-AC3", "E-AC-3", "Audio Layer III", "MP3", "Dolby Digital", "Dolby TrueHD", "DTS", "DTS-HD", "FLAC", "AAC", "HE-AAC", "Dolby"]
 
             is_untouched_opus = False
             audio_field = meta.audio
@@ -416,7 +435,7 @@ class AvistaZ(AZTrackerBase):
                 if track.get("@type") == "Audio":
                     codec_info = track.get("Format_Commercial_IfAny") or track.get("Format")
                     codec = codec_info if isinstance(codec_info, str) else ""
-                    audio_tracks.append({"codec": codec, "language": track.get("Language", "")})
+                    audio_tracks.append({"codec": codec, "language": track.get("Language", ""), "bitrate": track.get("BitRate", "")})
 
             invalid_codecs: list[str] = []
             for track in audio_tracks:
@@ -441,6 +460,23 @@ class AvistaZ(AZTrackerBase):
                     f"Allowed codecs: AC3 (Dolby Digital), Dolby TrueHD, DTS, DTS-HD (MA), FLAC, AAC, MP3, etc.\n"
                     f"Exceptions: Untouched Opus from source; Uncompressed codecs from Blu-ray discs (PCM, LPCM)."
                 )
+
+            if release_type != "webdl":
+                low_bitrate_tracks: list[str] = []
+                for track in audio_tracks:
+                    bitrate = str(track.get("bitrate", "") or "")
+                    if not bitrate:
+                        continue
+                    bitrate_match = re.search(r"\d+(?:\.\d+)?", bitrate)
+                    if not bitrate_match:
+                        continue
+                    bitrate_value = float(bitrate_match.group())
+                    if "k" in bitrate.lower():
+                        bitrate_value *= 1000
+                    if bitrate_value < 128000:
+                        low_bitrate_tracks.append(f"{track['codec']} ({bitrate})")
+                if low_bitrate_tracks:
+                    warnings.append(f"Audio bitrate must be at least 128 kbit/s outside WEB-DL uploads: {', '.join(low_bitrate_tracks)}.")
 
         if warnings:
             return "\n\n".join(filter(None, warnings))

--- a/src/trackers/AVISTAZ/avistaz.py
+++ b/src/trackers/AVISTAZ/avistaz.py
@@ -467,12 +467,12 @@ class AvistaZ(AZTrackerBase):
                     bitrate = str(track.get("bitrate", "") or "")
                     if not bitrate:
                         continue
-                    bitrate_match = re.search(r"\d+(?:\.\d+)?", bitrate)
+                    normalized_bitrate = re.sub(r"[\s,]", "", bitrate)
+                    bitrate_match = re.fullmatch(r"(\d+(?:\.\d+)?)([kmg]?)(?:bit/s|b/s|bps)?", normalized_bitrate, flags=re.IGNORECASE)
                     if not bitrate_match:
                         continue
-                    bitrate_value = float(bitrate_match.group())
-                    if "k" in bitrate.lower():
-                        bitrate_value *= 1000
+                    bitrate_value = float(bitrate_match.group(1))
+                    bitrate_value *= {"": 1, "k": 1_000, "m": 1_000_000, "g": 1_000_000_000}[bitrate_match.group(2).lower()]
                     if bitrate_value < 128000:
                         low_bitrate_tracks.append(f"{track['codec']} ({bitrate})")
                 if low_bitrate_tracks:

--- a/src/trackers/AVISTAZ/cinemaz.py
+++ b/src/trackers/AVISTAZ/cinemaz.py
@@ -1,4 +1,5 @@
 # Upload Assistant © 2025 Audionut & wastaken7 — Licensed under UAPL v1.0
+import re
 from datetime import UTC, datetime
 from typing import Any
 
@@ -30,6 +31,15 @@ class CinemaZ(AZTrackerBase):
 
     def rules(self, meta: Meta) -> str:
         warnings: list[str] = []
+        is_disc = bool(meta.is_disc)
+        release_type = str(meta.type or "").strip().lower()
+        video_codec = str(meta.video_codec or "").strip().lower()
+        video_encode = str(meta.video_encode or "").strip().lower()
+        container = str(meta.container or "").strip().lower().lstrip(".")
+        resolution_value = str(meta.resolution or "").lower()
+        resolution_match = re.search(r"(\d{3,4})", resolution_value)
+        resolution = int(resolution_match.group(1)) if resolution_match else 0
+        video_width = int(meta.video_width or 0)
 
         # This also checks the rule 'FANRES content is not allowed'
         if meta.category not in ("MOVIE", "TV"):
@@ -268,18 +278,23 @@ class CinemaZ(AZTrackerBase):
         )
 
         origin_countries_codes = meta.origin_country
-        year = meta.year
+        try:
+            year = int(meta.year)
+        except TypeError, ValueError:
+            year = 0
         is_older_than_50_years = False
 
-        if isinstance(year, int):
+        if year:
             current_year = datetime.now(UTC).year
             if (current_year - year) >= 50:
                 is_older_than_50_years = True
 
+        is_sd = bool(meta.sd) or (resolution and resolution < 720)
+
         # Case 1: The content is from a major English-speaking country
         if any(code in phd_countries for code in origin_countries_codes):
-            if is_older_than_50_years:
-                # It's old, so it's ALLOWED on CINEMAZ
+            if is_older_than_50_years or is_sd:
+                # Older and SD English-language content are allowed on CinemaZ.
                 pass
             else:
                 # It's new, so redirect to PRIVATEHD
@@ -301,7 +316,73 @@ class CinemaZ(AZTrackerBase):
                 "Africa, the Middle East, Russia, and the Americas (excluding recent mainstream English content)."
             )
 
+        allowed_containers = {"mkv", "mp4", "avi"}
+        if release_type == "hdtv":
+            allowed_containers.update({"ts", "tp"})
+        if not is_disc and container not in allowed_containers:
+            allowed = ", ".join(sorted(allowed_containers)).upper()
+            warnings.append(f"Container not allowed for this rip type: {container or 'unknown'}. Allowed: {allowed}.")
+
+        allowed_video_codecs = {"avc", "h.264", "h.265", "x264", "x265", "hevc", "vp9", "divx", "xvid"}
+        is_hdtv_mpeg2 = release_type == "hdtv" and video_codec in {"mpeg-2", "mpeg2"}
+        if not is_disc and video_codec not in allowed_video_codecs and not is_hdtv_mpeg2:
+            warnings.append("Video codec not allowed. CinemaZ allows H.264/x264/AVC, H.265/x265/HEVC, VP9, DivX/XviD, and MPEG-2 for HDTV recordings.")
+
+        if not is_disc and video_width and video_width < 600:
+            warnings.append(f"Video width is {video_width}px; CinemaZ requires a minimum width of 600px.")
+        if video_codec in {"divx", "xvid"} and (resolution >= 720 or video_width >= 720):
+            warnings.append("DivX/XviD is not allowed for HD video (720p and above).")
+
+        conditional_rip_types = {"webrip", "vodrip", "vhsrip", "vcdrip", "vcd"}
+        if release_type in conditional_rip_types:
+            warnings.append(f"{release_type.upper()} is allowed only when the video is unavailable in a preferred CinemaZ rip type; verify this manually before uploading.")
+        if "hybrid" in str(meta.edition or "").lower() or bool(meta.webdv):
+            warnings.append("HYBRID releases require substantially improved, perfectly synchronized audio or video streams; verify this manually before uploading.")
+
+        bitrate_thresholds = {
+            "x264": {"sd": 1000, 720: 1500, 1080: 3000, 2160: 12000},
+            "x265": {720: 1000, 1080: 2000, 2160: 8000},
+        }
+        codec_family = "x265" if any(codec in f"{video_codec} {video_encode}" for codec in ("x265", "h.265", "hevc")) else "x264"
+        video_bitrate = int(meta.video_bitrate or 0)
+        resolution_key: str | int = "sd" if is_sd else resolution
+        required_bitrate = bitrate_thresholds[codec_family].get(resolution_key)
+        if not is_disc and codec_family == "x265" and is_sd:
+            warnings.append("x265/HEVC is not allowed for SD content.")
+        elif not is_disc and video_bitrate and required_bitrate and video_bitrate < required_bitrate:
+            warnings.append(f"Video bitrate is {video_bitrate} kbit/s; CinemaZ requires at least {required_bitrate} kbit/s for this codec and resolution.")
+
+        audio_tracks: list[dict[str, str]] = []
+        for track in meta.mediainfo.get("media", {}).get("track", []):
+            if track.get("@type") == "Audio":
+                codec_info = track.get("Format_Commercial_IfAny") or track.get("Format")
+                codec = codec_info if isinstance(codec_info, str) else ""
+                audio_tracks.append({"codec": codec, "bitrate": str(track.get("BitRate", "") or "")})
+
+        if not is_disc:
+            allowed_audio_keywords = ["AC3", "E-AC3", "E-AC-3", "Audio Layer III", "MP3", "Dolby Digital", "Dolby TrueHD", "DTS", "DTS-HD", "FLAC", "AAC", "Dolby"]
+            invalid_codecs = sorted(
+                {track["codec"] for track in audio_tracks if track["codec"] and not any(keyword.lower() in track["codec"].lower() for keyword in allowed_audio_keywords)}
+            )
+            if invalid_codecs:
+                warnings.append(f"Unallowed audio codec(s) detected: {', '.join(invalid_codecs)}.")
+
+        audio_bitrate = int(meta.audio_bitrate or 0)
+        if not is_disc and audio_bitrate and audio_bitrate < 128:
+            warnings.append(f"Audio bitrate is {audio_bitrate} kbit/s; CinemaZ requires at least 128 kbit/s.")
+
         if warnings:
             return "\n\n".join(filter(None, warnings))
 
         return ""
+
+    def check_data(self, meta: Meta, data: dict[str, Any]):
+        issue = super().check_data(meta, data)
+        if issue or meta.debug:
+            return issue
+
+        minimum_screenshots = 6 if meta.is_disc == "BDMV" or meta.type == "REMUX" or meta.resolution == "2160p" else 3
+        if len(data["screenshots[]"]) < minimum_screenshots:
+            return f"UPLOAD FAILED: CinemaZ requires at least {minimum_screenshots} screenshots for this upload."
+
+        return False

--- a/src/trackers/AVISTAZ/privatehd.py
+++ b/src/trackers/AVISTAZ/privatehd.py
@@ -1,4 +1,5 @@
 # Upload Assistant © 2025 Audionut & wastaken7 — Licensed under UAPL v1.0
+import re
 from datetime import UTC, datetime
 from typing import Any, cast
 
@@ -77,13 +78,9 @@ class PrivateHD(AZTrackerBase):
         if video_encode:
             video_encode = video_encode.strip().lower()
 
-        release_type = str(meta.type)
-        if release_type:
-            release_type = release_type.strip().lower()
+        release_type = str(meta.type or "").strip().lower()
 
-        source = str(meta.source)
-        if source:
-            source = source.strip().lower()
+        source = str(meta.source or "").strip().lower()
 
         # This also checks the rule 'FANRES content is not allowed'
         if meta.category not in ("MOVIE", "TV"):
@@ -93,8 +90,12 @@ class PrivateHD(AZTrackerBase):
             warnings.append("Upload Anime content to our sister site AnimeTorrents.me instead. If it's on AniDB, it's an anime.")
 
         current_year = datetime.now(UTC).year
-        if meta.year is not None:
-            is_older_than_50_years = (current_year - int(meta.year)) >= 50
+        try:
+            year = int(meta.year)
+        except TypeError, ValueError:
+            year = 0
+        if year:
+            is_older_than_50_years = (current_year - year) >= 50
             if is_older_than_50_years:
                 warnings.append("Upload movies/series 50+ years old to our sister site CINEMAZ.to instead.")
 
@@ -434,8 +435,13 @@ class PrivateHD(AZTrackerBase):
         if meta.sd == 1:
             warnings.append("SD (Standard Definition) content is forbidden.")
 
-        if not is_bd_disc and meta.container not in ["mkv", "mp4"]:
-            warnings.append("Allowed containers: MKV, MP4.")
+        container = str(meta.container or "").strip().lower().lstrip(".")
+        allowed_containers = {"mkv", "mp4"}
+        if release_type == "hdtv":
+            allowed_containers.update({"ts", "tp"})
+        if not is_bd_disc and container not in allowed_containers:
+            allowed = ", ".join(sorted(allowed_containers)).upper()
+            warnings.append(f"Container not allowed for this rip type: {container or 'unknown'}. Allowed: {allowed}.")
 
         # Video codec
         # 1
@@ -477,7 +483,7 @@ class PrivateHD(AZTrackerBase):
             pass
         else:
             # 1
-            allowed_keywords = ["AC3", "Dolby Digital", "Dolby TrueHD", "DTS", "DTS-HD", "FLAC", "AAC", "Dolby"]
+            allowed_keywords = ["AC3", "E-AC3", "E-AC-3", "Dolby Digital", "Dolby TrueHD", "DTS", "DTS-HD", "FLAC", "AAC", "Dolby"]
 
             # 2
             forbidden_keywords = ["LPCM", "PCM", "Linear PCM"]
@@ -485,7 +491,7 @@ class PrivateHD(AZTrackerBase):
             audio_tracks: list[dict[str, str]] = []
             for track in media_tracks:
                 if track.get("@type") == "Audio":
-                    codec_info = track.get("Format_Commercial_IfAny")
+                    codec_info = track.get("Format_Commercial_IfAny") or track.get("Format")
                     codec = codec_info if isinstance(codec_info, str) else ""
                     audio_tracks.append({"codec": codec, "language": str(track.get("Language", ""))})
 
@@ -549,7 +555,7 @@ class PrivateHD(AZTrackerBase):
         web_sources = ("hdtv", "web", "hdrip")
 
         if release_type == "encode":
-            bitrate = 0
+            bitrate = int(meta.video_bitrate or 0) * 1000
             for track in media_tracks:
                 if track.get("@type") == "Video":
                     bitrate_value = track.get("BitRate")
@@ -576,6 +582,15 @@ class PrivateHD(AZTrackerBase):
                             f"Minimum bitrate for {resolution}p {source.upper()} {video_encode.upper()} is {min_bitrate / 1000} Kbps."
                         )
                         warnings.append(quality_rule_text + rule)
+
+            for track in media_tracks:
+                if track.get("@type") != "Video":
+                    continue
+                encoding_settings = str(track.get("Encoded_Library_Settings", "") or "")
+                crf_match = re.search(r"\bcrf[ =:]+(\d+(?:\.\d+)?)", encoding_settings, re.IGNORECASE)
+                if crf_match and float(crf_match.group(1)) > 20:
+                    warnings.append(f"CRF {crf_match.group(1)} exceeds PrivateHD's maximum CRF of 20.")
+                break
 
         if resolution < 720:
             rule = "Video must be at least 720p."

--- a/src/trackers/AVISTAZ/routing.py
+++ b/src/trackers/AVISTAZ/routing.py
@@ -235,16 +235,19 @@ class AvistaZNetworkRouter:
     network_trackers = frozenset({"AVISTAZ", "CINEMAZ", "PRIVATEHD"})
 
     def __init__(self, config: dict[str, Any], tracker_class_map: dict[str, Any]):
+        """Store configuration and tracker factories used for redirect validation."""
         self.config = config
         self.tracker_class_map = tracker_class_map
 
     @staticmethod
     def _countries(meta: Meta) -> set[str]:
+        """Return normalized production-country ISO codes from metadata."""
         raw_countries = meta.origin_country if isinstance(meta.origin_country, list) else []
         return {str(country).upper() for country in raw_countries if country}
 
     @staticmethod
     def _is_older_than_50_years(meta: Meta) -> bool:
+        """Determine whether the release year is at least fifty years old."""
         try:
             return datetime.now(UTC).year - int(meta.year) >= 50
         except TypeError, ValueError:
@@ -252,12 +255,19 @@ class AvistaZNetworkRouter:
 
     @staticmethod
     def _is_sd(meta: Meta) -> bool:
+        """Identify SD content from either the explicit flag or its resolution."""
         if bool(meta.sd):
             return True
         resolution_match = re.search(r"(\d{3,4})", str(meta.resolution or ""))
         return bool(resolution_match and int(resolution_match.group(1)) < 720)
 
+    @staticmethod
+    def _config_enabled(value: Any) -> bool:
+        """Interpret boolean configuration values without treating non-empty strings as true."""
+        return value if isinstance(value, bool) else str(value).strip().lower() in {"1", "true", "yes", "on"}
+
     def decide(self, source: str, meta: Meta) -> RoutingDecision | None:
+        """Return an automatic redirect or manual-review decision for one source tracker."""
         source = source.upper()
         countries = self._countries(meta)
         destinations: list[tuple[str, str]] = []
@@ -293,6 +303,7 @@ class AvistaZNetworkRouter:
         return RoutingDecision(source, destination, reason, automatic=True)
 
     async def apply(self, meta: Meta) -> None:
+        """Apply confirmed, cookie-validated redirects to the tracker upload list."""
         trackers = [str(tracker).upper() for tracker in meta.trackers]
         for source in tuple(trackers):
             if source not in self.network_trackers:
@@ -310,7 +321,7 @@ class AvistaZNetworkRouter:
 
             destination = decision.destination
             if meta.unattended:
-                enabled = bool(self.config.get("DEFAULT", {}).get("avistaz_network_auto_redirect", False))
+                enabled = self._config_enabled(self.config.get("DEFAULT", {}).get("avistaz_network_auto_redirect", False))
                 if not enabled:
                     source_status["routing_suggested_to"] = destination
                     logger.info(

--- a/src/trackers/AVISTAZ/routing.py
+++ b/src/trackers/AVISTAZ/routing.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+import cli_ui
+
+from src.console import logger
+from src.meta import Meta
+
+# These are the country groups used by the three tracker rule implementations.
+PRIVATEHD_COUNTRIES = frozenset(
+    ["AG", "AI", "AU", "BB", "BM", "BS", "BZ", "CA", "CW", "DM", "GB", "GD", "IE", "JM", "KN", "KY", "LC", "MS", "NZ", "PR", "TC", "TT", "US", "VC", "VG", "VI"]
+)
+AVISTAZ_COUNTRIES = frozenset(
+    ["BD", "BN", "BT", "CN", "HK", "ID", "IN", "JP", "KH", "KP", "KR", "LA", "LK", "MM", "MN", "MO", "MY", "NP", "PH", "PK", "SG", "TH", "TL", "TW", "VN"]
+)
+ASIAN_COUNTRIES = frozenset(
+    [
+        "AE",
+        "AF",
+        "AM",
+        "AZ",
+        "BD",
+        "BH",
+        "BN",
+        "BT",
+        "CN",
+        "CY",
+        "GE",
+        "HK",
+        "ID",
+        "IL",
+        "IN",
+        "IQ",
+        "IR",
+        "JO",
+        "JP",
+        "KG",
+        "KH",
+        "KP",
+        "KR",
+        "KW",
+        "KZ",
+        "LA",
+        "LB",
+        "LK",
+        "MM",
+        "MN",
+        "MO",
+        "MV",
+        "MY",
+        "NP",
+        "OM",
+        "PH",
+        "PK",
+        "PS",
+        "QA",
+        "SA",
+        "SG",
+        "SY",
+        "TH",
+        "TJ",
+        "TL",
+        "TM",
+        "TR",
+        "TW",
+        "UZ",
+        "VN",
+        "YE",
+    ]
+)
+CINEMAZ_COUNTRIES = frozenset(
+    [
+        "AO",
+        "BF",
+        "BI",
+        "BJ",
+        "BW",
+        "CD",
+        "CF",
+        "CG",
+        "CI",
+        "CM",
+        "CV",
+        "DJ",
+        "DZ",
+        "EG",
+        "EH",
+        "ER",
+        "ET",
+        "GA",
+        "GH",
+        "GM",
+        "GN",
+        "GQ",
+        "GW",
+        "IO",
+        "KE",
+        "KM",
+        "LR",
+        "LS",
+        "LY",
+        "MA",
+        "MG",
+        "ML",
+        "MR",
+        "MU",
+        "MW",
+        "MZ",
+        "NA",
+        "NE",
+        "NG",
+        "RE",
+        "RW",
+        "SC",
+        "SD",
+        "SH",
+        "SL",
+        "SN",
+        "SO",
+        "SS",
+        "ST",
+        "SZ",
+        "TD",
+        "TF",
+        "TG",
+        "TN",
+        "TZ",
+        "UG",
+        "YT",
+        "ZA",
+        "ZM",
+        "ZW",
+        "AR",
+        "AW",
+        "BL",
+        "BO",
+        "BQ",
+        "BR",
+        "CL",
+        "CO",
+        "CR",
+        "CU",
+        "DO",
+        "EC",
+        "FK",
+        "GF",
+        "GP",
+        "GS",
+        "GT",
+        "GY",
+        "HN",
+        "HT",
+        "MF",
+        "MQ",
+        "MX",
+        "NI",
+        "PA",
+        "PE",
+        "PM",
+        "PY",
+        "SR",
+        "SV",
+        "SX",
+        "UY",
+        "VE",
+        "AD",
+        "AL",
+        "AT",
+        "AX",
+        "BA",
+        "BE",
+        "BG",
+        "BY",
+        "CH",
+        "CZ",
+        "DE",
+        "DK",
+        "EE",
+        "ES",
+        "FI",
+        "FO",
+        "FR",
+        "GG",
+        "GI",
+        "GR",
+        "HR",
+        "HU",
+        "IS",
+        "IT",
+        "JE",
+        "LI",
+        "LT",
+        "LU",
+        "LV",
+        "MC",
+        "MD",
+        "ME",
+        "MK",
+        "MT",
+        "NL",
+        "NO",
+        "PL",
+        "PT",
+        "RO",
+        "RS",
+        "RU",
+        "SE",
+        "SI",
+        "SJ",
+        "SK",
+        "SM",
+        "SU",
+        "UA",
+        "VA",
+        "XC",
+    ]
+)
+
+
+@dataclass(frozen=True)
+class RoutingDecision:
+    source: str
+    destination: str | None
+    reason: str
+    automatic: bool
+
+
+class AvistaZNetworkRouter:
+    """Resolve unambiguous AvistaZ/CinemaZ/PrivateHD content routing."""
+
+    network_trackers = frozenset({"AVISTAZ", "CINEMAZ", "PRIVATEHD"})
+
+    def __init__(self, config: dict[str, Any], tracker_class_map: dict[str, Any]):
+        self.config = config
+        self.tracker_class_map = tracker_class_map
+
+    @staticmethod
+    def _countries(meta: Meta) -> set[str]:
+        raw_countries = meta.origin_country if isinstance(meta.origin_country, list) else []
+        return {str(country).upper() for country in raw_countries if country}
+
+    @staticmethod
+    def _is_older_than_50_years(meta: Meta) -> bool:
+        try:
+            return datetime.now(UTC).year - int(meta.year) >= 50
+        except TypeError, ValueError:
+            return False
+
+    @staticmethod
+    def _is_sd(meta: Meta) -> bool:
+        if bool(meta.sd):
+            return True
+        resolution_match = re.search(r"(\d{3,4})", str(meta.resolution or ""))
+        return bool(resolution_match and int(resolution_match.group(1)) < 720)
+
+    def decide(self, source: str, meta: Meta) -> RoutingDecision | None:
+        source = source.upper()
+        countries = self._countries(meta)
+        destinations: list[tuple[str, str]] = []
+
+        if source == "PRIVATEHD":
+            if self._is_older_than_50_years(meta):
+                destinations.append(("CINEMAZ", "content is 50+ years old"))
+            if countries & ASIAN_COUNTRIES:
+                destinations.append(("AVISTAZ", "Asian production"))
+            elif countries & CINEMAZ_COUNTRIES:
+                destinations.append(("CINEMAZ", "production belongs to CinemaZ's region"))
+
+        elif source == "CINEMAZ":
+            if countries & AVISTAZ_COUNTRIES:
+                destinations.append(("AVISTAZ", "Asian production"))
+            elif countries & PRIVATEHD_COUNTRIES and not self._is_older_than_50_years(meta) and not self._is_sd(meta):
+                # Mainstream status cannot be inferred safely, so this remains a suggestion.
+                return RoutingDecision(source, "PRIVATEHD", "recent HD content from a major English-speaking country may belong on PrivateHD", automatic=False)
+
+        elif source == "AVISTAZ":
+            if countries & PRIVATEHD_COUNTRIES:
+                destinations.append(("PRIVATEHD", "production belongs to a major English-speaking country"))
+            elif countries & (CINEMAZ_COUNTRIES | (ASIAN_COUNTRIES - AVISTAZ_COUNTRIES)):
+                destinations.append(("CINEMAZ", "production belongs to CinemaZ's region"))
+
+        if not destinations:
+            return None
+        target_names = {target for target, _reason in destinations}
+        if len(target_names) != 1:
+            reasons = "; ".join(reason for _target, reason in destinations)
+            return RoutingDecision(source, None, f"conflicting routing rules: {reasons}", automatic=False)
+        destination, reason = destinations[0]
+        return RoutingDecision(source, destination, reason, automatic=True)
+
+    async def apply(self, meta: Meta) -> None:
+        trackers = [str(tracker).upper() for tracker in meta.trackers]
+        for source in tuple(trackers):
+            if source not in self.network_trackers:
+                continue
+            decision = self.decide(source, meta)
+            if decision is None:
+                continue
+
+            source_status = meta.tracker_status.setdefault(source, {})
+            source_status["routing_reason"] = decision.reason
+            if not decision.automatic or not decision.destination:
+                source_status["routing_suggested_to"] = decision.destination
+                logger.info(f"{source}: [yellow]Routing requires review: {decision.reason}[/yellow]")
+                continue
+
+            destination = decision.destination
+            if meta.unattended:
+                enabled = bool(self.config.get("DEFAULT", {}).get("avistaz_network_auto_redirect", False))
+                if not enabled:
+                    source_status["routing_suggested_to"] = destination
+                    logger.info(
+                        f"{source}: [yellow]Suggested redirect to {destination}: {decision.reason}. Set avistaz_network_auto_redirect=true to enable this in unattended mode.[/yellow]"
+                    )
+                    continue
+            else:
+                prompt = f"{source}: {decision.reason}. Redirect this upload to {destination}?"
+                if not cli_ui.ask_yes_no(prompt, default=True):
+                    source_status["routing_suggested_to"] = destination
+                    continue
+
+            destination_class = self.tracker_class_map.get(destination)
+            if destination_class is None:
+                source_status["routing_error"] = f"Destination {destination} is not available."
+                continue
+            try:
+                destination_tracker = destination_class(config=self.config)
+                if not await destination_tracker.validate_credentials(meta):
+                    source_status["routing_error"] = f"Destination {destination} has no valid cookie session."
+                    logger.info(f"{source}: [yellow]Not redirecting to {destination}: cookie validation failed.[/yellow]")
+                    continue
+            except Exception as exc:
+                source_status["routing_error"] = f"Could not validate {destination} credentials: {exc}"
+                logger.info(f"{source}: [yellow]Not redirecting to {destination}: credential validation failed.[/yellow]")
+                continue
+
+            trackers = [tracker for tracker in trackers if tracker != source]
+            if destination not in trackers:
+                trackers.append(destination)
+            source_status.update({"upload": False, "skipped": True, "redirected_to": destination, "status_message": f"Redirected to {destination}: {decision.reason}"})
+            destination_status = meta.tracker_status.setdefault(destination, {})
+            destination_status.setdefault("redirected_from", []).append(source)
+            logger.info(f"{source}: [green]Redirected to {destination}: {decision.reason}.[/green]")
+
+        meta.trackers = trackers

--- a/src/trackerstatus.py
+++ b/src/trackerstatus.py
@@ -17,9 +17,18 @@ from src.imdb import imdb_manager
 from src.meta import Meta
 from src.metadata_searching import get_douban_id
 from src.torrentcreate import TorrentCreator
+from src.trackers.AVISTAZ.routing import AvistaZNetworkRouter
 from src.trackers.passthepopcorn import PassThePopcorn
 from src.trackersetup import TrackerSetup, tracker_class_map
 from src.uphelper import UploadHelper
+
+
+def merge_tracker_status(processed: dict[str, dict[str, Any]], existing: Mapping[str, Mapping[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Preserve routing metadata while keeping fresh processing results authoritative."""
+    merged = {tracker: dict(status) for tracker, status in existing.items()}
+    for tracker, status in processed.items():
+        merged.setdefault(tracker, {}).update(status)
+    return merged
 
 
 class TrackerStatusManager:
@@ -28,11 +37,12 @@ class TrackerStatusManager:
         self.trackers_config = cast(Mapping[str, Mapping[str, Any]], config.get("TRACKERS", {}))
 
     async def process_all_trackers(self, meta: Meta) -> int:
-        tracker_status: dict[str, dict[str, bool]] = {}
+        tracker_status: dict[str, dict[str, Any]] = {}
         successful_trackers = 0
         client: Any = Clients(config=self.config)
         tracker_setup: Any = TrackerSetup(config=self.config)
         tracker_setup.filter_unsupported_trackers(meta)
+        await AvistaZNetworkRouter(self.config, tracker_class_map).apply(meta)
         helper: Any = UploadHelper(self.config)
         dupe_checker = DupeChecker(self.config)
         if any(tracker in meta.trackers for tracker in ["MTEAM", "LAJIDUI", "PTFANS", "PTGTK", "RAILGUNPT"]):
@@ -391,7 +401,7 @@ class TrackerStatusManager:
             logger.debug("", extra={"markup": False})
             logger.debug("[bold red]DEBUG MODE does not upload to sites")
 
-        meta.tracker_status = tracker_status
+        meta.tracker_status = merge_tracker_status(tracker_status, status_map)
         return successful_trackers
 
 

--- a/tests/test_avistaz_names.py
+++ b/tests/test_avistaz_names.py
@@ -29,6 +29,8 @@ def make_meta(**overrides):
         "region": "",
         "resolution": "1080p",
         "video_codec": "",
+        "edition": "",
+        "webdv": False,
     }
     values.update(overrides)
     return SimpleNamespace(**values)
@@ -40,7 +42,7 @@ def tracker(name):
 
 @pytest.mark.asyncio
 async def test_cinemaz_title_rules_are_normalized():
-    meta = make_meta(name="[Example] 2024 LIMITED Director's Cut Extended Cut 1080p Hybrid WEB-DL H.264-NOGRP", tag="NOGRP")
+    meta = make_meta(name="[Example] 2024 LIMITED Director's Cut Extended Cut 1080p Hybrid WEB-DL H.264-NOGRP", tag="NOGRP", webdv=True)
 
     name = await tracker("CINEMAZ").get_name(meta)
 
@@ -67,8 +69,17 @@ async def test_cinemaz_keeps_hybrid_when_no_quality_marker_exists():
 
 @pytest.mark.asyncio
 async def test_cinemaz_places_hybrid_after_a_4k_quality_marker():
-    meta = make_meta(name="Example 2024 Hybrid 4K WEB-DL H.264-GROUP")
+    meta = make_meta(name="Example 2024 Hybrid 4K WEB-DL H.264-GROUP", webdv=True)
 
     name = await tracker("CINEMAZ").get_name(meta)
 
     assert name == "Example 2024 4K HYBRID WEB-DL H.264-GROUP"  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_cinemaz_preserves_hybrid_in_the_title_when_repositioning_marker():
+    meta = make_meta(title="Hybrid", name="Hybrid 2007 Hybrid 1080p WEB-DL H.264-GROUP", webdv=True)
+
+    name = await tracker("CINEMAZ").get_name(meta)
+
+    assert name == "Hybrid 2007 1080p HYBRID WEB-DL H.264-GROUP"  # noqa: S101

--- a/tests/test_avistaz_names.py
+++ b/tests/test_avistaz_names.py
@@ -1,0 +1,74 @@
+from types import SimpleNamespace
+
+import pytest
+
+from src.trackers.AVISTAZ import AZTrackerBase
+
+
+def make_meta(**overrides):
+    values = {
+        "aka": "",
+        "manual_episode_title": "",
+        "daily_episode_title": "",
+        "name": "Example 2024 1080p WEB-DL DD 5.1 H.264-GROUP",
+        "has_encode_settings": False,
+        "tag": "GROUP",
+        "category": "MOVIE",
+        "year": "2024",
+        "no_year": False,
+        "search_year": "",
+        "season_int": 0,
+        "imdb_info": {},
+        "tv_pack": 0,
+        "title": "Example",
+        "season": "S01",
+        "source": "",
+        "audio": "",
+        "type": "WEBDL",
+        "is_disc": "",
+        "region": "",
+        "resolution": "1080p",
+        "video_codec": "",
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def tracker(name):
+    return AZTrackerBase({"TRACKERS": {name: {}}}, name)
+
+
+@pytest.mark.asyncio
+async def test_cinemaz_title_rules_are_normalized():
+    meta = make_meta(name="[Example] 2024 LIMITED Director's Cut Extended Cut 1080p Hybrid WEB-DL H.264-NOGRP", tag="NOGRP")
+
+    name = await tracker("CINEMAZ").get_name(meta)
+
+    assert name == "Example 2024 DC EXT 1080p HYBRID WEB-DL H.264-NoGroup"  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_privatehd_removes_brackets_and_preserves_its_cut_terms():
+    meta = make_meta(name="[Example] 2024 Criterion Collection Theatrical Cut 1080p WEB-DL H.264-GROUP")
+
+    name = await tracker("PRIVATEHD").get_name(meta)
+
+    assert name == "Example 2024 Theatrical 1080p WEB-DL H.264-GROUP"  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_cinemaz_keeps_hybrid_when_no_quality_marker_exists():
+    meta = make_meta(name="Example 2024 Hybrid WEB-DL H.264-GROUP")
+
+    name = await tracker("CINEMAZ").get_name(meta)
+
+    assert name == "Example 2024 Hybrid WEB-DL H.264-GROUP"  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_cinemaz_places_hybrid_after_a_4k_quality_marker():
+    meta = make_meta(name="Example 2024 Hybrid 4K WEB-DL H.264-GROUP")
+
+    name = await tracker("CINEMAZ").get_name(meta)
+
+    assert name == "Example 2024 4K HYBRID WEB-DL H.264-GROUP"  # noqa: S101

--- a/tests/test_avistaz_network_routing.py
+++ b/tests/test_avistaz_network_routing.py
@@ -1,0 +1,106 @@
+from types import SimpleNamespace
+
+import pytest
+
+from src.trackers.AVISTAZ.routing import AvistaZNetworkRouter
+from src.trackerstatus import merge_tracker_status
+
+
+class FakeTracker:
+    cookie_valid = True
+
+    def __init__(self, config):
+        self.config = config
+
+    async def validate_credentials(self, _meta):
+        return self.cookie_valid
+
+
+def make_meta(**overrides):
+    values = {
+        "origin_country": ["US"],
+        "year": 2020,
+        "sd": False,
+        "resolution": "1080p",
+        "trackers": ["PRIVATEHD"],
+        "tracker_status": {},
+        "unattended": True,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def router():
+    return AvistaZNetworkRouter({"DEFAULT": {"avistaz_network_auto_redirect": True}}, {"AVISTAZ": FakeTracker, "CINEMAZ": FakeTracker, "PRIVATEHD": FakeTracker})
+
+
+@pytest.mark.asyncio
+async def test_old_privatehd_content_is_redirected_after_cookie_validation():
+    meta = make_meta(year=1970)
+
+    await router().apply(meta)
+
+    assert meta.trackers == ["CINEMAZ"]  # noqa: S101
+    assert meta.tracker_status["PRIVATEHD"]["redirected_to"] == "CINEMAZ"  # noqa: S101
+    assert meta.tracker_status["CINEMAZ"]["redirected_from"] == ["PRIVATEHD"]  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_redirect_keeps_source_when_destination_cookie_is_invalid():
+    meta = make_meta(year=1970)
+    FakeTracker.cookie_valid = False
+    try:
+        await router().apply(meta)
+    finally:
+        FakeTracker.cookie_valid = True
+
+    assert meta.trackers == ["PRIVATEHD"]  # noqa: S101
+    assert "routing_error" in meta.tracker_status["PRIVATEHD"]  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_conflicting_rules_require_manual_review():
+    meta = make_meta(year=1970, origin_country=["JP"])
+
+    await router().apply(meta)
+
+    assert meta.trackers == ["PRIVATEHD"]  # noqa: S101
+    assert meta.tracker_status["PRIVATEHD"]["routing_suggested_to"] is None  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_asian_privatehd_content_is_redirected_to_avistaz():
+    meta = make_meta(origin_country=["JP"])
+
+    await router().apply(meta)
+
+    assert meta.trackers == ["AVISTAZ"]  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_recent_english_content_on_cinemaz_is_only_suggested():
+    meta = make_meta(trackers=["CINEMAZ"])
+
+    await router().apply(meta)
+
+    assert meta.trackers == ["CINEMAZ"]  # noqa: S101
+    assert meta.tracker_status["CINEMAZ"]["routing_suggested_to"] == "PRIVATEHD"  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_sd_resolution_prevents_cinemaz_to_privatehd_suggestion():
+    meta = make_meta(trackers=["CINEMAZ"], resolution="480p", sd=False)
+
+    await router().apply(meta)
+
+    assert meta.tracker_status == {}  # noqa: S101
+
+
+def test_merge_tracker_status_preserves_routing_metadata():
+    merged = merge_tracker_status(
+        {"CINEMAZ": {"upload": True, "skipped": False}},
+        {"PRIVATEHD": {"redirected_to": "CINEMAZ", "skipped": True}, "CINEMAZ": {"redirected_from": ["PRIVATEHD"]}},
+    )
+
+    assert merged["PRIVATEHD"]["redirected_to"] == "CINEMAZ"  # noqa: S101
+    assert merged["CINEMAZ"] == {"redirected_from": ["PRIVATEHD"], "upload": True, "skipped": False}  # noqa: S101

--- a/tests/test_avistaz_network_routing.py
+++ b/tests/test_avistaz_network_routing.py
@@ -30,8 +30,8 @@ def make_meta(**overrides):
     return SimpleNamespace(**values)
 
 
-def router():
-    return AvistaZNetworkRouter({"DEFAULT": {"avistaz_network_auto_redirect": True}}, {"AVISTAZ": FakeTracker, "CINEMAZ": FakeTracker, "PRIVATEHD": FakeTracker})
+def router(auto_redirect=True):
+    return AvistaZNetworkRouter({"DEFAULT": {"avistaz_network_auto_redirect": auto_redirect}}, {"AVISTAZ": FakeTracker, "CINEMAZ": FakeTracker, "PRIVATEHD": FakeTracker})
 
 
 @pytest.mark.asyncio
@@ -75,6 +75,16 @@ async def test_asian_privatehd_content_is_redirected_to_avistaz():
     await router().apply(meta)
 
     assert meta.trackers == ["AVISTAZ"]  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_disabled_string_value_does_not_enable_unattended_redirects():
+    meta = make_meta(year=1970)
+
+    await router("false").apply(meta)
+
+    assert meta.trackers == ["PRIVATEHD"]  # noqa: S101
+    assert meta.tracker_status["PRIVATEHD"]["routing_suggested_to"] == "CINEMAZ"  # noqa: S101
 
 
 @pytest.mark.asyncio

--- a/tests/test_avistaz_rules.py
+++ b/tests/test_avistaz_rules.py
@@ -1,0 +1,48 @@
+from types import SimpleNamespace
+
+from src.trackers.AVISTAZ.avistaz import AvistaZ
+
+
+def make_meta(**overrides):
+    values = {
+        "category": "MOVIE",
+        "anime": False,
+        "is_disc": "",
+        "video_codec": "H.264",
+        "video_encode": "H.264",
+        "type": "WEBDL",
+        "source": "WEB",
+        "container": "mkv",
+        "resolution": "1080p",
+        "video_width": 1920,
+        "audio": "AAC",
+        "untouched": False,
+        "mediainfo": {"media": {"track": [{"@type": "Audio", "Format": "AAC", "BitRate": "128000"}]}},
+        "origin_country": ["JP"],
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_hdtv_mpeg2_transport_stream_is_allowed():
+    meta = make_meta(type="HDTV", container="ts", video_codec="MPEG-2")
+
+    warnings = AvistaZ({"TRACKERS": {"AVISTAZ": {}}}).rules(meta)
+
+    assert warnings == ""  # noqa: S101
+
+
+def test_eac3_audio_is_allowed():
+    meta = make_meta(mediainfo={"media": {"track": [{"@type": "Audio", "Format": "E-AC-3", "BitRate": "768000"}]}})
+
+    warnings = AvistaZ({"TRACKERS": {"AVISTAZ": {}}}).rules(meta)
+
+    assert warnings == ""  # noqa: S101
+
+
+def test_low_audio_bitrate_is_reported_for_non_webdl():
+    meta = make_meta(type="HDTV", mediainfo={"media": {"track": [{"@type": "Audio", "Format": "AAC", "BitRate": "96 kb/s"}]}})
+
+    warnings = AvistaZ({"TRACKERS": {"AVISTAZ": {}}}).rules(meta)
+
+    assert "128 kbit/s" in warnings  # noqa: S101

--- a/tests/test_avistaz_rules.py
+++ b/tests/test_avistaz_rules.py
@@ -46,3 +46,12 @@ def test_low_audio_bitrate_is_reported_for_non_webdl():
     warnings = AvistaZ({"TRACKERS": {"AVISTAZ": {}}}).rules(meta)
 
     assert "128 kbit/s" in warnings  # noqa: S101
+
+
+def test_grouped_and_megabit_audio_bitrates_are_normalized():
+    for bitrate in ("1 024 kb/s", "1.5 Mb/s"):
+        meta = make_meta(type="HDTV", mediainfo={"media": {"track": [{"@type": "Audio", "Format": "AAC", "BitRate": bitrate}]}})
+
+        warnings = AvistaZ({"TRACKERS": {"AVISTAZ": {}}}).rules(meta)
+
+        assert warnings == ""  # noqa: S101

--- a/tests/test_cinemaz_rules.py
+++ b/tests/test_cinemaz_rules.py
@@ -1,0 +1,68 @@
+from types import SimpleNamespace
+
+from src.trackers.AVISTAZ.cinemaz import CinemaZ
+
+
+def make_meta(**overrides):
+    values = {
+        "category": "MOVIE",
+        "anime": False,
+        "is_disc": "",
+        "video_codec": "H.264",
+        "video_encode": "H.264",
+        "type": "WEBDL",
+        "source": "WEB",
+        "container": "mkv",
+        "resolution": "1080p",
+        "video_width": 1920,
+        "video_bitrate": 5000,
+        "audio_bitrate": 192,
+        "mediainfo": {"media": {"track": [{"@type": "Audio", "Format": "AAC", "BitRate": "192000"}]}},
+        "origin_country": ["FR"],
+        "year": 2020,
+        "sd": False,
+        "edition": "",
+        "webdv": False,
+        "debug": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def tracker():
+    return CinemaZ({"TRACKERS": {"CINEMAZ": {}}})
+
+
+def test_sd_content_from_major_english_country_is_allowed():
+    meta = make_meta(origin_country=["US"], resolution="480p", video_width=640, video_bitrate=1200, sd=True)
+
+    warnings = tracker().rules(meta)
+
+    assert warnings == ""  # noqa: S101
+
+
+def test_vp9_is_an_allowed_video_codec():
+    meta = make_meta(video_codec="VP9", video_encode="VP9")
+
+    warnings = tracker().rules(meta)
+
+    assert warnings == ""  # noqa: S101
+
+
+def test_low_video_bitrate_is_reported():
+    meta = make_meta(video_bitrate=2999)
+
+    warnings = tracker().rules(meta)
+
+    assert "at least 3000 kbit/s" in warnings  # noqa: S101
+
+
+def test_raw_remux_and_4k_uploads_require_six_screenshots():
+    meta = make_meta(type="REMUX")
+    cinema = tracker()
+    cinema.upload_url_step2 = "https://cinemaz.to/upload"
+    data = {"screenshots[]": ["a", "b", "c", "d", "e"], "task_id": "1", "info_hash": "hash", "rip_type_id": "2", "type_id": "1", "video_quality_id": "3"}
+
+    issue = cinema.check_data(meta, data)
+
+    assert issue == "UPLOAD FAILED: CinemaZ requires at least 6 screenshots for this upload."  # noqa: S101

--- a/tests/test_privatehd_rules.py
+++ b/tests/test_privatehd_rules.py
@@ -1,0 +1,63 @@
+from types import SimpleNamespace
+
+from src.trackers.AVISTAZ.privatehd import PrivateHD
+
+
+def make_meta(**overrides):
+    values = {
+        "category": "MOVIE",
+        "anime": False,
+        "is_disc": "",
+        "video_codec": "H.264",
+        "video_encode": "H.264",
+        "type": "WEBDL",
+        "source": "WEB",
+        "container": "mkv",
+        "resolution": "1080p",
+        "bit_depth": "8",
+        "video_bitrate": 5000,
+        "mediainfo": {"media": {"track": [{"@type": "Video", "BitRate": "5000000"}, {"@type": "Audio", "Format": "AAC", "Language": "en"}]}},
+        "original_language": "en",
+        "origin_country": ["US"],
+        "year": 2020,
+        "tag": "GROUP",
+        "sd": False,
+        "name": "Example 2020 1080p WEB-DL H.264-GROUP",
+        "bloated": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def tracker():
+    return PrivateHD({"TRACKERS": {"PRIVATEHD": {}}})
+
+
+def test_hdtv_transport_stream_is_allowed():
+    meta = make_meta(type="HDTV", source="HDTV", container="ts")
+
+    warnings = tracker().rules(meta)
+
+    assert warnings == ""  # noqa: S101
+
+
+def test_eac3_audio_is_allowed_when_format_commercial_name_is_missing():
+    meta = make_meta(mediainfo={"media": {"track": [{"@type": "Video", "BitRate": "5000000"}, {"@type": "Audio", "Format": "E-AC-3", "Language": "en"}]}})
+
+    warnings = tracker().rules(meta)
+
+    assert warnings == ""  # noqa: S101
+
+
+def test_crf_above_twenty_is_reported():
+    meta = make_meta(
+        type="ENCODE",
+        source="BluRay",
+        video_encode="x264",
+        video_bitrate=6000,
+        mediainfo={"media": {"track": [{"@type": "Video", "BitRate": "6000000", "Encoded_Library_Settings": "cabac=1 / crf=21.5"}, {"@type": "Audio", "Format": "AAC", "Language": "en"}]}},
+    )
+
+    warnings = tracker().rules(meta)
+
+    assert "CRF 21.5 exceeds" in warnings  # noqa: S101


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic routing across AvistaZ network trackers using release characteristics, origin, and SD/age signals, with optional unattended auto-redirects and routing suggestions.
  * Expanded validation for AVISTAZ/CINEMAZ/PRIVATEHD: stronger normalization, container/codec/audio checks, bitrate/CRF thresholds, and stricter screenshot requirements.
  * Improved title normalization for Director’s Cut and HYBRID, including site-specific “cut” wording and bracket handling.
* **Bug Fixes**
  * Preserved and merged existing tracker routing metadata instead of overwriting it.
* **Tests**
  * Added/expanded test coverage for routing decisions, title rules, audio/video quality thresholds, bitrate parsing formats, and screenshot failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->