### PR TITLE
fix(game): preserve selected subcategory

### DIFF
--- a/upload.py
+++ b/upload.py
@@ -662,7 +662,12 @@ async def _prompt_game_meta(meta: Meta) -> None:
 
                 elif field == "game_subcategory":
                     subcategory_choices = ["full_game (Full Game)", "full_game_dlc (Full Game + DLC)", "dlc (DLC only)", "update (Update only)"]
-                    subcategory_values = {"Full Game": "full_game", "Full Game + DLC": "full_game_dlc", "DLC": "dlc", "Update": "update"}
+                    subcategory_values = {
+                        "full_game (Full Game)": "full_game",
+                        "full_game_dlc (Full Game + DLC)": "full_game_dlc",
+                        "dlc (DLC only)": "dlc",
+                        "update (Update only)": "update",
+                    }
                     choice = CLI_UI.ask_choice("Select game subcategory (can be manually set with -gsc / --game-subcategory):", choices=subcategory_choices, sort=False)
                     meta.game_subcategory = subcategory_values.get(choice, "full_game")
                     name_needs_rebuild = True


### PR DESCRIPTION
## Summary
- map the prompt's displayed subcategory options to their internal values
- preserve the user's selected game release type through upload metadata

## Validation
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected game subcategory selection so the chosen option is saved accurately in game metadata.
  * Updated support for Full Game, Full Game + DLC, DLC only, and Update only options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->