### PR TITLE
fix(bjshare): preserve group identifier

### DIFF
--- a/src/trackers/bjshare.py
+++ b/src/trackers/bjshare.py
@@ -50,6 +50,7 @@ class BJShare:
     secret_token: str = ""
     already_has_the_info: bool = False
     database_title: str = ""
+    database_identifier: str = ""
     tmdb_localization_requirements: ClassVar = {
         "pt-BR": {
             "main": "credits,videos,content_ratings",
@@ -566,7 +567,7 @@ class BJShare:
             if BJShare.database_title:
                 original_title = BJShare.database_title
 
-            main_tmdb_data = meta.tmdb_localized_data.get("pt-BR", {}).get("main") or {}
+            main_tmdb_data = dict(meta.tmdb_localized_data.get("pt-BR", {}).get("main")) or {}
             tmdb_title = main_tmdb_data.get("name") or main_tmdb_data.get("title")
 
             original_titles_to_compare = (
@@ -700,24 +701,54 @@ class BJShare:
 
         return original_title
 
-    async def search_existing(self, meta: Meta) -> list[dict[str, str]]:
-        dupes: list[dict[str, str]] = []
+    def get_database_identifier(self, soup: BeautifulSoup) -> str:
+        """Return the IMDb or TMDb identifier used by an existing BJShare group."""
+        for box in soup.find_all("div", class_="box"):
+            header = box.find("div", class_="head")
+            if not header or "Informações" not in header.get_text():
+                continue
+
+            for row in box.find_all("tr"):
+                cells = row.find_all("td")
+                if len(cells) < 2:
+                    continue
+
+                label = cells[0].get_text(" ", strip=True).lower()
+                link = cells[1].find("a", href=True)
+                href = str(link.get("href", "")) if link else ""
+
+                if "imdb" in label:
+                    match = re.search(r"tt\d+", href, re.IGNORECASE)
+                    if match:
+                        return match.group(0).lower()
+
+                if "tmdb" in label:
+                    match = re.search(r"themoviedb\.org/(movie|tv)/(\d+)", href, re.IGNORECASE)
+                    if match:
+                        return f"{match.group(1).lower()}/{match.group(2)}"
+
+        return ""
+
+    async def search_existing(self, meta: Meta) -> list[dict[str, str | list[str]]]:
+        dupes: list[dict[str, str | list[str]]] = []
         category = meta.category
         title = meta.title
         if category == "BOOK" and meta.title:
             title = self.common.portuguese_title_capitalization(meta.title)
         search_url = f"{self.base_url}/torrents.php"
+        params = {"searchstr": title}
 
+        media_search_terms: list[str] = []
         if category in ("TV", "MOVIE"):
-            if not dict(meta.imdb_info).get("imdbID"):
-                logger.info(f"{self.tracker}: [bold red]IMDb ID not found in metadata. Skipping duplicate check.[/bold red]")
-                return dupes
+            imdb_id = str(dict(meta.imdb_info).get("imdbID", "")).strip()
+            if imdb_id:
+                media_search_terms.append(imdb_id)
 
-            params = {
-                "searchstr": meta.imdb_info["imdbID"],
-            }
+            tmdb_id = str(meta.tmdb_id or "").strip()
+            if tmdb_id:
+                media_search_terms.append(f"{category.lower()}/{tmdb_id}")
 
-        if category == "BOOK":
+        elif category == "BOOK":
             filter_cat = "11" if meta.audiobook else "10"
             params = {
                 "searchstr": title,
@@ -746,21 +777,57 @@ class BJShare:
 
         BJShare.already_has_the_info = False
         BJShare.database_title = ""
+        BJShare.database_identifier = ""
 
-        response = await self.session.get(search_url, params=params, follow_redirects=True)
-        response.raise_for_status()
-        if "login.php" in str(response.url) or "login.php" in response.text:
-            await self.cookie_validator.handle_validation_failure(meta, self.tracker, response.text)
-            meta.skipping = f"{self.tracker}"
-            return dupes
+        search_params = [params]
+        if category in ("TV", "MOVIE"):
+            # Query both exact IDs. The first group page found is retained, while
+            # a title search remains available for older groups lacking either ID.
+            search_params = [{"searchstr": term} for term in dict.fromkeys(media_search_terms)]
+            if not search_params:
+                search_params.append({"searchstr": title})
 
-        # Extract auth token if present
-        auth_match = re.search(r"logout\.php\?auth=([a-f0-9]+)", response.text)
-        if auth_match:
+        response: httpx.Response | None = None
+        fallback_response: httpx.Response | None = None
+        for query_params in search_params:
+            candidate = await self.session.get(search_url, params=query_params, follow_redirects=True)
+            candidate.raise_for_status()
+            if "login.php" in str(candidate.url) or "login.php" in candidate.text:
+                await self.cookie_validator.handle_validation_failure(meta, self.tracker, candidate.text)
+                meta.skipping = f"{self.tracker}"
+                return dupes
+
+            auth_match = re.search(r"logout\.php\?auth=([a-f0-9]+)", candidate.text)
+            if not auth_match:
+                logger.info(f"{self.tracker}: [bold red]Failed to find auth token on page.[/bold red]")
+                meta.skipping = f"{self.tracker}"
+                return dupes
             BJShare.secret_token = auth_match.group(1)
-        else:
-            logger.info(f"{self.tracker}: [bold red]Failed to find auth token on page.[/bold red]")
-            meta.skipping = f"{self.tracker}"
+
+            fallback_response = candidate
+            if response is None and BeautifulSoup(candidate.text, "html.parser").find("div", class_="main_column"):
+                response = candidate
+
+        if category in ("TV", "MOVIE") and response is None and title and title not in media_search_terms:
+            candidate = await self.session.get(search_url, params={"searchstr": title}, follow_redirects=True)
+            candidate.raise_for_status()
+            if "login.php" in str(candidate.url) or "login.php" in candidate.text:
+                await self.cookie_validator.handle_validation_failure(meta, self.tracker, candidate.text)
+                meta.skipping = f"{self.tracker}"
+                return dupes
+
+            auth_match = re.search(r"logout\.php\?auth=([a-f0-9]+)", candidate.text)
+            if not auth_match:
+                logger.info(f"{self.tracker}: [bold red]Failed to find auth token on page.[/bold red]")
+                meta.skipping = f"{self.tracker}"
+                return dupes
+            BJShare.secret_token = auth_match.group(1)
+            fallback_response = candidate
+            if BeautifulSoup(candidate.text, "html.parser").find("div", class_="main_column"):
+                response = candidate
+
+        response = response or fallback_response
+        if response is None:
             return dupes
 
         soup = BeautifulSoup(response.text, "html.parser")
@@ -773,6 +840,7 @@ class BJShare:
         if torrent_details_table:
             BJShare.already_has_the_info = True
             BJShare.database_title = self.get_database_title(soup)
+            BJShare.database_identifier = self.get_database_identifier(soup)
 
             for row in torrent_details_table.find_all("tr"):
                 row_id = row.get("id")
@@ -815,7 +883,7 @@ class BJShare:
                         names.append(BJShare.database_title.strip())
 
                     for n in names:
-                        dupe_entry = {
+                        dupe_entry: dict[str, str | list[str]] = {
                             "name": n,
                             "size": size,
                             "link": link,
@@ -1656,12 +1724,16 @@ class BJShare:
     def get_imdblink(self, meta: Meta) -> str:
         """
         Get the media identifier for the upload.
-        Uses IMDb ID as primary source, falling back to TMDb ID if unavailable.
+        Uses the identifier from an existing BJShare group when available, then
+        falls back to IMDb and TMDb metadata.
 
         Accepted formats:
             IMDb: tt12345
             TMDb: movie/12345 or tv/12345
         """
+        if BJShare.database_identifier:
+            return BJShare.database_identifier
+
         imdb_info = dict(meta.imdb_info)
         imdbid = str(imdb_info.get("imdbID", ""))
         if imdbid:

--- a/src/trackers/bjshare.py
+++ b/src/trackers/bjshare.py
@@ -780,10 +780,12 @@ class BJShare:
         BJShare.database_identifier = ""
 
         search_params = [params]
+        title_already_queried = False
         if category in ("TV", "MOVIE"):
             # Query both exact IDs. The first group page found is retained, while
             # a title search remains available for older groups lacking either ID.
             search_params = [{"searchstr": term} for term in dict.fromkeys(media_search_terms)]
+            title_already_queried = not search_params
             if not search_params:
                 search_params.append({"searchstr": title})
 
@@ -808,7 +810,7 @@ class BJShare:
             if response is None and BeautifulSoup(candidate.text, "html.parser").find("div", class_="main_column"):
                 response = candidate
 
-        if category in ("TV", "MOVIE") and response is None and title and title not in media_search_terms:
+        if category in ("TV", "MOVIE") and response is None and title and not title_already_queried and title not in media_search_terms:
             candidate = await self.session.get(search_url, params={"searchstr": title}, follow_redirects=True)
             candidate.raise_for_status()
             if "login.php" in str(candidate.url) or "login.php" in candidate.text:

--- a/tests/test_bjshare.py
+++ b/tests/test_bjshare.py
@@ -1,0 +1,65 @@
+import asyncio
+from types import SimpleNamespace
+
+from bs4 import BeautifulSoup
+
+from src.trackers.bjshare import BJShare
+
+
+class FakeResponse:
+    url = "https://bj-share.info/series.php?id=1"
+    text = '<a href="logout.php?auth=abcdef"></a><div class="main_column"></div>'
+
+    def raise_for_status(self):
+        pass
+
+
+class FakeSession:
+    def __init__(self):
+        self.calls: list[dict[str, str]] = []
+        self.cookies = None
+
+    async def get(self, _url, *, params, follow_redirects):
+        assert follow_redirects  # noqa: S101
+        self.calls.append(params)
+        return FakeResponse()
+
+
+class FakeCookieValidator:
+    async def load_session_cookies(self, _meta, _tracker):
+        return None
+
+
+def test_get_database_identifier_returns_imdb_id():
+    soup = BeautifulSoup(
+        '<div class="box"><div class="head">Informações</div><table><tr>'
+        '<td><b>Nota IMDB:</b></td><td><a href="https://href.li/?https://www.imdb.com/title/tt999999999">IMDb</a></td>'
+        "</tr></table></div>",
+        "html.parser",
+    )
+
+    assert BJShare.get_database_identifier(object.__new__(BJShare), soup) == "tt999999999"  # noqa: S101
+
+
+def test_get_database_identifier_returns_tmdb_id():
+    soup = BeautifulSoup(
+        '<div class="box"><div class="head">Informações</div><table><tr>'
+        '<td><b>TMDB:</b></td><td><a href="https://href.li/?https://www.themoviedb.org/tv/999999999">TMDB</a></td>'
+        "</tr></table></div>",
+        "html.parser",
+    )
+
+    assert BJShare.get_database_identifier(object.__new__(BJShare), soup) == "tv/999999999"  # noqa: S101
+
+
+def test_search_existing_queries_both_media_identifiers_before_title_fallback():
+    tracker = object.__new__(BJShare)
+    tracker.session = FakeSession()
+    tracker.cookie_validator = FakeCookieValidator()
+    tracker.base_url = "https://bj-share.info"
+    tracker.tracker = "BJSHARE"
+    meta = SimpleNamespace(category="TV", title="Example", imdb_info={"imdbID": "tt1234567"}, tmdb_id="76543")
+
+    asyncio.run(tracker.search_existing(meta))
+
+    assert tracker.session.calls == [{"searchstr": "tt1234567"}, {"searchstr": "tv/76543"}]  # noqa: S101

--- a/tests/test_bjshare.py
+++ b/tests/test_bjshare.py
@@ -14,15 +14,20 @@ class FakeResponse:
         pass
 
 
+class FakeSearchResponse(FakeResponse):
+    text = '<a href="logout.php?auth=abcdef"></a><table id="torrent_table"></table>'
+
+
 class FakeSession:
-    def __init__(self):
+    def __init__(self, response=None):
         self.calls: list[dict[str, str]] = []
         self.cookies = None
+        self.response = response or FakeResponse()
 
     async def get(self, _url, *, params, follow_redirects):
         assert follow_redirects  # noqa: S101
         self.calls.append(params)
-        return FakeResponse()
+        return self.response
 
 
 class FakeCookieValidator:
@@ -63,3 +68,16 @@ def test_search_existing_queries_both_media_identifiers_before_title_fallback():
     asyncio.run(tracker.search_existing(meta))
 
     assert tracker.session.calls == [{"searchstr": "tt1234567"}, {"searchstr": "tv/76543"}]  # noqa: S101
+
+
+def test_search_existing_queries_title_once_without_media_identifiers():
+    tracker = object.__new__(BJShare)
+    tracker.session = FakeSession(FakeSearchResponse())
+    tracker.cookie_validator = FakeCookieValidator()
+    tracker.base_url = "https://bj-share.info"
+    tracker.tracker = "BJSHARE"
+    meta = SimpleNamespace(category="TV", title="Example", imdb_info={}, tmdb_id="")
+
+    asyncio.run(tracker.search_existing(meta))
+
+    assert tracker.session.calls == [{"searchstr": "Example"}]  # noqa: S101


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved duplicate detection using IMDb and TMDb identifiers, with title-based fallback.
  * Uploads now preserve the most accurate available IMDb or TMDb link.
  * Existing media details are matched more reliably, including localized metadata.

* **Bug Fixes**
  * Improved handling of authentication and search results when checking existing entries.

* **Tests**
  * Added coverage for IMDb and TMDb identifier extraction and multi-step duplicate searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->