### PR TITLE
fix: default to full MediaInfo descriptions

### DIFF
--- a/data/example_config.py
+++ b/data/example_config.py
@@ -1296,6 +1296,8 @@ config: dict[str, Any] = {
             "link_dir_name": "",
             "announce_url": "",
             "anon": True,
+            # Set to True if you want to include the full MediaInfo in your upload description or False to include only the most relevant parts.
+            "full_mediainfo": False,
             # The configurations below override the DEFAULT configuration
             "add_logo": True,
             "logo_size": "",
@@ -1358,6 +1360,8 @@ config: dict[str, Any] = {
             # It also does not have the option to set the IMDb during upload.
             # Set this to True to edit the torrent after the upload to force the correct naming and IMDb.
             "force_data": False,
+            # Set to True if you want to include the full MediaInfo in your upload description or False to include only the most relevant parts.
+            "full_mediainfo": False,
             "anon": True,
             # The configurations below override the DEFAULT configuration
             "add_logo": True,

--- a/src/get_desc.py
+++ b/src/get_desc.py
@@ -361,7 +361,7 @@ class DescriptionBuilder:
         if meta.is_disc == "BDMV" or meta.category in ("GAME", "BOOK", "MUSIC"):
             return ""
 
-        if self._get_bool_config("full_mediainfo", False) or meta.is_disc:
+        if self._get_bool_config("full_mediainfo", True) or meta.is_disc:
             mi_path = f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/MEDIAINFO_CLEANPATH.txt"
             if await self.common.path_exists(mi_path):
                 async with aiofiles.open(mi_path, encoding="utf-8") as mi:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to display the full cleaned MediaInfo output for supported trackers.
  * Full MediaInfo is now enabled by default, while configuration can disable it when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->