### PR TITLE
fix: qBittorrent proxy retry

### DIFF
--- a/src/torrent_clients/qbittorrent.py
+++ b/src/torrent_clients/qbittorrent.py
@@ -271,6 +271,42 @@ class QbittorrentClientMixin:
                     raise
         return None
 
+    @staticmethod
+    def _raise_for_proxy_response(response: httpx.Response) -> None:
+        if response.status_code == 200:
+            return
+        if response.status_code in (502, 503, 504):
+            raise _RetryableProxyResponseError(f"proxy returned HTTP {response.status_code}")
+        raise _ProxyResponseError(f"proxy returned HTTP {response.status_code}")
+
+    async def _add_torrent_via_proxy(
+        self, qbt_session: httpx.AsyncClient, qbt_proxy_url: str, infohash: str, data: dict[str, str], files: dict[str, Any]
+    ) -> None:
+        add_attempt = 0
+
+        async def add_via_proxy() -> None:
+            nonlocal add_attempt
+            # A timeout or 5xx response may mean qBittorrent accepted the first
+            # request while the proxy failed to return its response. Check before
+            # submitting the same infohash again.
+            if add_attempt:
+                info_response = await qbt_session.get(f"{qbt_proxy_url}/api/v2/torrents/info", params={"hashes": infohash})
+                self._raise_for_proxy_response(info_response)
+                if info_response.json():
+                    logger.info("[green]Torrent was added to qBittorrent despite the previous proxy failure.")
+                    return
+
+            add_attempt += 1
+            response = await qbt_session.post(f"{qbt_proxy_url}/api/v2/torrents/add", data=data, files=files)
+            self._raise_for_proxy_response(response)
+
+        await self.retry_qbt_operation(
+            add_via_proxy,
+            "Add torrent to qBittorrent via proxy",
+            initial_timeout=14.0,
+            retryable_errors=(TimeoutError, httpx.HTTPError, _RetryableProxyResponseError),
+        )
+
     async def init_qbittorrent_client(self, client: dict[str, Any]) -> qbittorrentapi.Client | None:
         # Creates and logs into a qbittorrent client, with caching to avoid redundant logins
         # If login fails, returns None
@@ -876,33 +912,7 @@ class QbittorrentClientMixin:
                     f"[cyan]POSTing to {Redaction.redact_private_info(qbt_proxy_url)}/api/v2/torrents/add with data: savepath={save_path}, autoTMM={auto_management}, skip_checking={skip_checking}, paused={paused_on_add}, contentLayout={content_layout}, category={qbt_category}, tags={tag}"
                 )
 
-                add_attempt = 0
-
-                async def add_via_proxy() -> None:
-                    nonlocal add_attempt
-                    # A timeout or 5xx response may mean qBittorrent accepted the first
-                    # request while the proxy failed to return its response. Check before
-                    # submitting the same infohash again.
-                    if add_attempt:
-                        info_response = await qbt_session.get(f"{qbt_proxy_url}/api/v2/torrents/info", params={"hashes": torrent.infohash})
-                        if info_response.status_code == 200 and info_response.json():
-                            logger.info("[green]Torrent was added to qBittorrent despite the previous proxy failure.")
-                            return
-
-                    add_attempt += 1
-                    response = await qbt_session.post(f"{qbt_proxy_url}/api/v2/torrents/add", data=data, files=files)
-                    if response.status_code == 200:
-                        return
-                    if response.status_code in (502, 503, 504):
-                        raise _RetryableProxyResponseError(f"proxy returned HTTP {response.status_code}")
-                    raise _ProxyResponseError(f"proxy returned HTTP {response.status_code}")
-
-                await self.retry_qbt_operation(
-                    add_via_proxy,
-                    "Add torrent to qBittorrent via proxy",
-                    initial_timeout=14.0,
-                    retryable_errors=(TimeoutError, httpx.HTTPError, _RetryableProxyResponseError),
-                )
+                await self._add_torrent_via_proxy(qbt_session, qbt_proxy_url, torrent.infohash, data, files)
             else:
                 if qbt_client is None:
                     raise RuntimeError("qbt_client cannot be None")

--- a/src/torrent_clients/qbittorrent.py
+++ b/src/torrent_clients/qbittorrent.py
@@ -42,6 +42,14 @@ class _TorrentFileEntry(TypedDict):
     length: int | None
 
 
+class _RetryableProxyResponseError(Exception):
+    """A qBittorrent proxy response which is safe to retry."""
+
+
+class _ProxyResponseError(Exception):
+    """A non-success qBittorrent proxy response which must not be retried."""
+
+
 class QbittorrentClientMixin:
     config: dict[str, Any]
 
@@ -239,7 +247,14 @@ class QbittorrentClientMixin:
             ssl_context.verify_mode = ssl.CERT_NONE
         return ssl_context
 
-    async def retry_qbt_operation(self, operation_func: Callable[[], Awaitable[Any]], operation_name: str, max_retries: int = 2, initial_timeout: float = 10.0) -> Any:
+    async def retry_qbt_operation(
+        self,
+        operation_func: Callable[[], Awaitable[Any]],
+        operation_name: str,
+        max_retries: int = 2,
+        initial_timeout: float = 10.0,
+        retryable_errors: tuple[type[BaseException], ...] = (TimeoutError,),
+    ) -> Any:
         for attempt in range(max_retries + 1):
             timeout = initial_timeout * (2**attempt)  # Exponential backoff: 10s, 20s, 40s
             try:
@@ -247,13 +262,13 @@ class QbittorrentClientMixin:
                 if attempt > 0:
                     logger.info(f"[green]{operation_name} succeeded on attempt {attempt + 1}")
                 return result
-            except TimeoutError:
+            except retryable_errors as error:
                 if attempt < max_retries:
-                    logger.info(f"[yellow]{operation_name} timed out after {timeout}s (attempt {attempt + 1}/{max_retries + 1}), retrying...")
+                    logger.info(f"[yellow]{operation_name} failed ({error}) after {timeout}s (attempt {attempt + 1}/{max_retries + 1}), retrying...")
                     await asyncio.sleep(1)  # Brief pause before retry
                 else:
-                    logger.info(f"[bold red]{operation_name} failed after {max_retries + 1} attempts (final timeout: {timeout}s)")
-                    raise  # Re-raise the TimeoutError so caller can handle it
+                    logger.info(f"[bold red]{operation_name} failed after {max_retries + 1} attempts (final attempt timeout: {timeout}s)")
+                    raise
         return None
 
     async def init_qbittorrent_client(self, client: dict[str, Any]) -> qbittorrentapi.Client | None:
@@ -861,11 +876,33 @@ class QbittorrentClientMixin:
                     f"[cyan]POSTing to {Redaction.redact_private_info(qbt_proxy_url)}/api/v2/torrents/add with data: savepath={save_path}, autoTMM={auto_management}, skip_checking={skip_checking}, paused={paused_on_add}, contentLayout={content_layout}, category={qbt_category}, tags={tag}"
                 )
 
-                response = await qbt_session.post(f"{qbt_proxy_url}/api/v2/torrents/add", data=data, files=files)
-                if response.status_code != 200:
-                    logger.info(f"[bold red]Failed to add torrent via proxy: {response.status_code}")
-                    await qbt_session.aclose()
-                    return
+                add_attempt = 0
+
+                async def add_via_proxy() -> None:
+                    nonlocal add_attempt
+                    # A timeout or 5xx response may mean qBittorrent accepted the first
+                    # request while the proxy failed to return its response. Check before
+                    # submitting the same infohash again.
+                    if add_attempt:
+                        info_response = await qbt_session.get(f"{qbt_proxy_url}/api/v2/torrents/info", params={"hashes": torrent.infohash})
+                        if info_response.status_code == 200 and info_response.json():
+                            logger.info("[green]Torrent was added to qBittorrent despite the previous proxy failure.")
+                            return
+
+                    add_attempt += 1
+                    response = await qbt_session.post(f"{qbt_proxy_url}/api/v2/torrents/add", data=data, files=files)
+                    if response.status_code == 200:
+                        return
+                    if response.status_code in (502, 503, 504):
+                        raise _RetryableProxyResponseError(f"proxy returned HTTP {response.status_code}")
+                    raise _ProxyResponseError(f"proxy returned HTTP {response.status_code}")
+
+                await self.retry_qbt_operation(
+                    add_via_proxy,
+                    "Add torrent to qBittorrent via proxy",
+                    initial_timeout=14.0,
+                    retryable_errors=(TimeoutError, httpx.HTTPError, _RetryableProxyResponseError),
+                )
             else:
                 if qbt_client is None:
                     raise RuntimeError("qbt_client cannot be None")
@@ -884,7 +921,12 @@ class QbittorrentClientMixin:
                     "Add torrent to qBittorrent",
                     initial_timeout=14.0,
                 )
-        except TimeoutError, qbittorrentapi.APIConnectionError:
+        except _ProxyResponseError as e:
+            logger.info(f"[bold red]Failed to add torrent via proxy: {e}")
+            if qbt_session:
+                await qbt_session.aclose()
+            return
+        except TimeoutError, httpx.HTTPError, qbittorrentapi.APIConnectionError:
             logger.info("[bold red]Failed to add torrent to qBittorrent")
             if qbt_session:
                 await qbt_session.aclose()

--- a/tests/test_qbittorrent_proxy_retry.py
+++ b/tests/test_qbittorrent_proxy_retry.py
@@ -1,0 +1,62 @@
+import asyncio
+
+import httpx
+import pytest
+
+from src.torrent_clients.qbittorrent import QbittorrentClientMixin, _RetryableProxyResponseError
+
+
+@pytest.mark.asyncio
+async def test_proxy_retry_retries_a_transient_http_status(monkeypatch):
+    client = QbittorrentClientMixin()
+    attempts = 0
+
+    async def no_sleep(_seconds):
+        return None
+
+    async def operation():
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise _RetryableProxyResponseError("proxy returned HTTP 502")
+        return "added"
+
+    monkeypatch.setattr(asyncio, "sleep", no_sleep)
+
+    result = await client.retry_qbt_operation(
+        operation,
+        "Add torrent to qBittorrent via proxy",
+        max_retries=1,
+        retryable_errors=(TimeoutError, httpx.HTTPError, _RetryableProxyResponseError),
+    )
+
+    assert result == "added"  # noqa: S101
+    assert attempts == 2  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_proxy_retry_retries_httpx_connection_errors(monkeypatch):
+    client = QbittorrentClientMixin()
+    attempts = 0
+
+    async def no_sleep(_seconds):
+        return None
+
+    async def operation():
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise httpx.ConnectError("proxy unavailable")
+        return "added"
+
+    monkeypatch.setattr(asyncio, "sleep", no_sleep)
+
+    result = await client.retry_qbt_operation(
+        operation,
+        "Add torrent to qBittorrent via proxy",
+        max_retries=1,
+        retryable_errors=(TimeoutError, httpx.HTTPError, _RetryableProxyResponseError),
+    )
+
+    assert result == "added"  # noqa: S101
+    assert attempts == 2  # noqa: S101

--- a/tests/test_qbittorrent_proxy_retry.py
+++ b/tests/test_qbittorrent_proxy_retry.py
@@ -6,6 +6,22 @@ import pytest
 from src.torrent_clients.qbittorrent import QbittorrentClientMixin, _RetryableProxyResponseError
 
 
+class FakeProxySession:
+    def __init__(self, post_responses, get_responses):
+        self.post_responses = iter(post_responses)
+        self.get_responses = iter(get_responses)
+        self.post_calls = 0
+        self.get_calls = 0
+
+    async def post(self, *_args, **_kwargs):
+        self.post_calls += 1
+        return next(self.post_responses)
+
+    async def get(self, *_args, **_kwargs):
+        self.get_calls += 1
+        return next(self.get_responses)
+
+
 @pytest.mark.asyncio
 async def test_proxy_retry_retries_a_transient_http_status(monkeypatch):
     client = QbittorrentClientMixin()
@@ -60,3 +76,22 @@ async def test_proxy_retry_retries_httpx_connection_errors(monkeypatch):
 
     assert result == "added"  # noqa: S101
     assert attempts == 2  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_proxy_retry_checks_for_existing_torrent_before_second_post(monkeypatch):
+    client = QbittorrentClientMixin()
+    session = FakeProxySession(
+        post_responses=[httpx.Response(502)],
+        get_responses=[httpx.Response(502), httpx.Response(200, json=[{"hash": "abc123"}])],
+    )
+
+    async def no_sleep(_seconds):
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", no_sleep)
+
+    await client._add_torrent_via_proxy(session, "https://qbit-proxy.example", "abc123", {"savepath": "/data"}, {})
+
+    assert session.post_calls == 1  # noqa: S101
+    assert session.get_calls == 2  # noqa: S101


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when adding torrents through qBittorrent proxies.
  * Automatically retries temporary connection failures, timeouts, and transient server errors.
  * Prevents unnecessary retries after a previous attempt has already succeeded.
  * Handles permanent proxy failures separately to avoid repeated unsuccessful attempts.

* **Tests**
  * Added coverage for transient server responses and connection failures that succeed after retrying.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->