### PR TITLE
fix(midnightscene): require English for dual audio

### DIFF
--- a/src/trackers/UNIT3D/midnightscene.py
+++ b/src/trackers/UNIT3D/midnightscene.py
@@ -1,4 +1,5 @@
 # Upload Assistant © 2025 Audionut & wastaken7 — Licensed under UAPL v1.0
+import re
 from typing import Any
 
 from src.languages import languages_manager
@@ -232,8 +233,13 @@ class MidnightScene(UNIT3D):
 
         if not meta.language_checked:
             await languages_manager.process_desc_language(meta, tracker=self.tracker)
+
         audio_languages: list[str] = [] if not meta.audio_languages else meta.audio_languages
-        if audio_languages and not await languages_manager.has_english_language(audio_languages):
+        has_english_audio = await languages_manager.has_english_language(audio_languages)
+
+        if audio_languages and not has_english_audio:
+            ms_name = re.sub(r"\bDual-Audio\b", "", ms_name, flags=re.IGNORECASE)
+            ms_name = " ".join(ms_name.split())
             foreign_lang = audio_languages[0].upper()
             if name_type == "REMUX" and source in ("PAL DVD", "NTSC DVD", "DVD"):
                 if meta.year:

--- a/tests/test_midnightscene.py
+++ b/tests/test_midnightscene.py
@@ -1,4 +1,4 @@
-"""Regression tests for MidnightScene MUSIC support."""
+"""Regression tests for MidnightScene naming support."""
 
 import asyncio
 
@@ -45,3 +45,29 @@ def test_midnightscene_non_scene_music_name_uses_directory_style():
     )
 
     assert asyncio.run(_tracker().get_name(meta)) == {"name": "Björk - Vespertine (2001) [TPLP101CD] [CD - FLAC]"}
+
+
+def test_midnightscene_removes_dual_audio_without_english_audio():
+    meta = Meta(
+        category="TV",
+        name="Example Show S01 1080p BluRay Dual-Audio FLAC 2.0 x265-ExampleGroup",
+        resolution="1080p",
+        type="ENCODE",
+        audio_languages=["japanese", "portuguese"],
+        language_checked=True,
+    )
+
+    assert asyncio.run(_tracker().get_name(meta)) == {"name": "Example Show S01 JAPANESE 1080p BluRay FLAC 2.0 x265-ExampleGroup"}
+
+
+def test_midnightscene_keeps_dual_audio_with_english_audio():
+    meta = Meta(
+        category="TV",
+        name="Example Show S01 1080p BluRay Dual-Audio FLAC 2.0 x265-ExampleGroup",
+        resolution="1080p",
+        type="ENCODE",
+        audio_languages=["japanese", "english"],
+        language_checked=True,
+    )
+
+    assert asyncio.run(_tracker().get_name(meta)) == {"name": "Example Show S01 1080p BluRay Dual-Audio FLAC 2.0 x265-ExampleGroup"}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected TV release names so “Dual-Audio” is removed when English audio is unavailable.
  * Preserved the “Dual-Audio” label when English audio is present.
  * Improved formatting consistency by normalizing whitespace after label removal.

* **Tests**
  * Added regression coverage for both English-audio and non-English-audio naming scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->