### PR TITLE
fix(polishtorrent): correct TV category ID

### DIFF
--- a/src/trackers/UNIT3D/polishtorrent.py
+++ b/src/trackers/UNIT3D/polishtorrent.py
@@ -29,6 +29,21 @@ class PolishTorrent(UNIT3D):
         self.config: Config = config
         self.common = Common(config)
 
+    async def get_category_id(self, meta: Meta, category: str = "", reverse: bool = False, mapping_only: bool = False) -> dict[str, str]:
+        category_id = {
+            "MOVIE": "1",
+            "TV": "9",
+        }
+        if mapping_only:
+            return category_id
+        if reverse:
+            return {v: k for k, v in category_id.items()}
+        if category:
+            return {"category_id": category_id.get(category, "0")}
+        meta_category = meta.category
+        resolved_id = category_id.get(meta_category, "0")
+        return {"category_id": resolved_id}
+
     async def get_name(self, meta: Meta) -> dict[str, str]:
         ptt_name = meta.name
         imdb_info = meta.imdb_info


### PR DESCRIPTION
POLISHTORRENT's TV category ID is `9`, not the UNIT3D default of `2`. Uploading
a TV release currently fails with:

    data error: HTTP 404 - {"message": "No query results for model [App\\Models\\Category] 2"}

Adds a `get_category_id` override with the tracker's real category IDs
(`Filmy` = `1`, `Seriale/TV` = `9`), taken from the site's own upload form
category dropdown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added category mapping support for PolishTorrent uploads.
  * Supports movie and TV categories, reverse lookups, complete mapping retrieval, and automatic category detection.
  * Unknown or unsupported categories now default to a neutral category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->