### PR TITLE
fix(darkpeers): fix EVO and HDT group exceptions and hardcoded subtitle checks (#162)

### DIFF
--- a/src/trackers/UNIT3D/darkpeers.py
+++ b/src/trackers/UNIT3D/darkpeers.py
@@ -38,6 +38,8 @@ class DarkPeers(UNIT3D):
         "FiSTER",
         "flower",
         "GalaxyTV",
+        "Goki",
+        "H4XO",
         "HD2DVD",
         "HDTime",
         "HorribleSubs",
@@ -62,6 +64,7 @@ class DarkPeers(UNIT3D):
         "Rifftrax",
         "ROCKETRACCOON",
         "SANTi",
+        "SARTRE",
         "SasukeducK",
         "SEEDSTER",
         "ShAaNiG",
@@ -114,13 +117,20 @@ class DarkPeers(UNIT3D):
         if not await self.common.check_language_requirements(meta, self.tracker, languages_to_check=nordic_languages, check_audio=True, check_subtitle=True):
             return False
 
-        if meta.type not in ["WEBDL"] and meta.tag in ["EVO"]:
-            if not meta.unattended:
-                logger.info(f"{self.tracker}: [bold red]does not allow EVO for non-WEBDL types, skipping upload.")
+        group = str(meta.tag or "").lstrip("-").strip().upper()
+        release_type = str(meta.type or "").strip().upper()
+        category = str(meta.category or "").strip().upper()
+
+        if group == "EVO" and release_type != "WEBDL":
+            logger.info(f"{self.tracker}: [bold red]only allows EVO releases when they are WEB-DLs. Skipping upload.")
             return False
 
-        if meta.hardcoded_subs and not meta.unattended:
-            logger.info(f"{self.tracker}: [bold red]does not allow hardcoded subtitles.")
+        if group == "HDT" and release_type != "REMUX":
+            logger.info(f"{self.tracker}: [bold red]only allows HDT releases when they are Remuxes. Skipping upload.")
+            return False
+
+        if category in {"MOVIE", "TV"} and meta.hardcoded_subs:
+            logger.info(f"{self.tracker}: [bold red]does not allow Movies or TV releases with hardcoded subtitles. Skipping upload.")
             return False
 
         return should_continue

--- a/tests/test_darkpeers.py
+++ b/tests/test_darkpeers.py
@@ -58,3 +58,39 @@ def test_darkpeers_audiobook_name_includes_format_bitrate_isbn_and_tag():
     )
 
     assert _name(meta) == "Ernest Cline - Ready Player One 2011 MP3 64 9780307887436-GROUP"
+
+
+def _additional_checks(meta: Meta) -> bool:
+    config = {"DEFAULT": {"tmdb_api": "test-key"}, "TRACKERS": {"DARKPEERS": {}}}
+    return asyncio.run(DarkPeers(config).get_additional_checks(meta))
+
+
+def test_darkpeers_evo_webdl_allowed_and_non_webdl_blocked():
+    evo_webdl = Meta(category="MOVIE", type="WEBDL", tag="-EVO", audio_languages=["English"])
+    evo_encode = Meta(category="MOVIE", type="ENCODE", tag="-EVO", audio_languages=["English"])
+    evo_remux = Meta(category="MOVIE", type="REMUX", tag="EVO", audio_languages=["English"])
+
+    assert _additional_checks(evo_webdl) is True
+    assert _additional_checks(evo_encode) is False
+    assert _additional_checks(evo_remux) is False
+
+
+def test_darkpeers_hdt_remux_allowed_and_non_remux_blocked():
+    hdt_remux = Meta(category="MOVIE", type="REMUX", tag="-HDT", audio_languages=["English"])
+    hdt_webdl = Meta(category="MOVIE", type="WEBDL", tag="-HDT", audio_languages=["English"])
+    hdt_encode = Meta(category="MOVIE", type="ENCODE", tag="HDT", audio_languages=["English"])
+
+    assert _additional_checks(hdt_remux) is True
+    assert _additional_checks(hdt_webdl) is False
+    assert _additional_checks(hdt_encode) is False
+
+
+def test_darkpeers_hardcoded_subs_blocked_in_interactive_and_unattended():
+    subs_interactive = Meta(category="MOVIE", type="WEBDL", tag="-GRP", hardcoded_subs=True, unattended=False, audio_languages=["English"])
+    subs_unattended = Meta(category="MOVIE", type="WEBDL", tag="-GRP", hardcoded_subs=True, unattended=True, audio_languages=["English"])
+    no_subs_unattended = Meta(category="MOVIE", type="WEBDL", tag="-GRP", hardcoded_subs=False, unattended=True, audio_languages=["English"])
+
+    assert _additional_checks(subs_interactive) is False
+    assert _additional_checks(subs_unattended) is False
+    assert _additional_checks(no_subs_unattended) is True
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DarkPeers upload validation for release groups, formats, categories, and subtitle flags.
  * Restricted EVO releases to WEB-DL and HDT releases to Remux formats.
  * Rejected movie and TV releases with hardcoded subtitles.
  * Added additional banned release groups.
  * Rejection reasons are now logged consistently, including during unattended uploads.

* **Tests**
  * Added coverage for format restrictions, subtitle rejection, and allowed releases without subtitles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->