### PR TITLE
fix(peergarden): introduce exact_match_only tracker policy and dupe checker filtering

### DIFF
--- a/src/dupe_checking.py
+++ b/src/dupe_checking.py
@@ -904,10 +904,15 @@ class DupeChecker:
 
         # 5. Check if both have file lists
         if local_files and candidate_files:
-            return files_match
+            return files_match and same_size
 
         # 6. If file list unavailable for one or both (e.g. disc release)
         if same_size and same_file_count:
+            return True
+
+        # Disc releases have no reliable local file count, so compare their
+        # total size when neither side provides a file list.
+        if not local_files and not candidate_files and same_size:
             return True
 
         # 7. Exact name match fallback

--- a/src/dupe_checking.py
+++ b/src/dupe_checking.py
@@ -189,6 +189,11 @@ class DupeChecker:
             },
         ]
 
+        from src.trackersetup import tracker_class_map
+
+        tracker_cls = tracker_class_map.get(tracker_name.upper())
+        is_exact_match_only = bool(getattr(tracker_cls, "exact_match_only", False))
+
         async def log_exclusion(reason: str, item: str) -> None:
             if meta.debug:
                 logger.debug(f"[yellow]Excluding result due to {reason}: {item}")
@@ -200,6 +205,13 @@ class DupeChecker:
             """
             each = entry.get("name", "")
             sized = entry.get("size")  # This may come as a string, such as "1.5 GB"
+
+            if is_exact_match_only:
+                is_exact = await DupeChecker.is_exact_match(entry, meta)
+                if not is_exact:
+                    await log_exclusion("non-exact release (allowed on exact-match-only tracker)", each)
+                    return True
+                return False
 
             # Check dupe size difference tolerance
             tolerance = meta.dupe_size_difference_tolerance
@@ -816,6 +828,13 @@ class DupeChecker:
 
         new_dupes = [each for each in processed_dupes if not await process_exclusion(each)]
 
+        if is_exact_match_only:
+            if processed_dupes and not new_dupes:
+                logger.info(f"{tracker_name}: related releases found, but no exact renamed release was detected.")
+                logger.info(f"{tracker_name}: continuing upload.")
+            elif new_dupes:
+                logger.info(f"{tracker_name}: exact existing release detected from matching files and size.")
+
         if new_dupes and not meta.unattended and meta.debug:
             if len(processed_dupes) > 1:
                 logger.debug(f"[yellow]Filtered dupes on {tracker_name}: ")
@@ -839,6 +858,62 @@ class DupeChecker:
                 logger.debug(filtered_dupes_to_print)
 
         return new_dupes
+
+    @staticmethod
+    async def is_exact_match(candidate: dict[str, Any] | DupeEntry, meta: Meta) -> bool:
+        """Check if candidate torrent is an exact match / exact renamed release of local upload."""
+        from pathlib import Path
+
+        from src.uphelper import parse_size_to_bytes
+
+        # 1. Local files and file count
+        local_files: list[str] = []
+        if meta.filelist and not meta.is_disc:
+            local_files = [Path(str(f)).name.lower() for f in meta.filelist if f]
+
+        # 2. Local total size
+        local_size = parse_size_to_bytes(meta.source_size)
+        if local_size is None and not meta.is_disc and meta.mediainfo:
+            tracks = meta.mediainfo.get("media", {}).get("track", [])
+            if tracks and isinstance(tracks, list) and len(tracks) > 0:
+                local_size = parse_size_to_bytes(tracks[0].get("FileSize"))
+
+        # 3. Candidate files and file count
+        candidate_files: list[str] = []
+        raw_files = candidate.get("files", [])
+        if isinstance(raw_files, list):
+            candidate_files = [Path(str(f)).name.lower() for f in raw_files if f]
+        elif isinstance(raw_files, str) and raw_files:
+            candidate_files = [Path(f.strip()).name.lower() for f in raw_files.split(",") if f.strip()]
+
+        candidate_file_count_raw = candidate.get("file_count")
+        try:
+            candidate_file_count = int(candidate_file_count_raw) if candidate_file_count_raw is not None else len(candidate_files)
+        except ValueError, TypeError:
+            candidate_file_count = len(candidate_files)
+
+        local_file_count = len(local_files) if local_files else None
+
+        # 4. Candidate total size
+        candidate_size = parse_size_to_bytes(candidate.get("size"))
+
+        # Comparison flags
+        files_match = bool(local_files and candidate_files and sorted(local_files) == sorted(candidate_files))
+        same_file_count = local_file_count is not None and candidate_file_count > 0 and local_file_count == candidate_file_count
+        same_size = local_size is not None and candidate_size is not None and local_size == candidate_size
+
+        # 5. Check if both have file lists
+        if local_files and candidate_files:
+            return files_match
+
+        # 6. If file list unavailable for one or both (e.g. disc release)
+        if same_size and same_file_count:
+            return True
+
+        # 7. Exact name match fallback
+        candidate_name = str(candidate.get("name", "")).strip().lower()
+        local_name = str(meta.name or "").strip().lower()
+        return bool(candidate_name and local_name and candidate_name == local_name and (same_size or local_size is None or candidate_size is None))
 
     @staticmethod
     async def normalize_filename(filename: str | MutableMapping[str, Any]) -> str:

--- a/src/trackers/UNIT3D/peergarden.py
+++ b/src/trackers/UNIT3D/peergarden.py
@@ -30,6 +30,8 @@ class PeerGarden(UNIT3D):
         "MUSIC",
     )
     tracker_urls = ("peergarden",)
+    allows_dupes = True
+    exact_match_only = True
 
     def __init__(self, config: Config) -> None:
         """Initialize the PeerGarden tracker adapter."""

--- a/tests/test_peergarden.py
+++ b/tests/test_peergarden.py
@@ -171,6 +171,28 @@ def test_peergarden_filter_dupes_blocks_exact_renamed_release():
     assert result[0]["id"] == 202
 
 
+def test_peergarden_filter_dupes_allows_same_filename_with_different_size():
+    from src.dupe_checking import DupeChecker
+
+    meta = Meta()
+    meta.name = "Awesome.Movie.2024.1080p"
+    meta.filelist = ["/path/to/movie.2024.1080p.web-dl.x264-release.mkv"]
+    meta.source_size = 4000000000
+
+    candidate = {
+        "name": "Renamed.Movie.Title.2024",
+        "size": 4100000000,
+        "files": ["movie.2024.1080p.web-dl.x264-release.mkv"],
+        "file_count": 1,
+        "id": 203,
+    }
+
+    dupe_checker = DupeChecker({"DEFAULT": {}})
+    result = asyncio.run(dupe_checker.filter_dupes([candidate], meta, "PEERGARDEN"))
+
+    assert result == []
+
+
 def test_peergarden_filter_dupes_blocks_exact_disc_release():
     from src.dupe_checking import DupeChecker
 
@@ -194,6 +216,29 @@ def test_peergarden_filter_dupes_blocks_exact_disc_release():
     assert result[0]["id"] == 303
 
 
+def test_peergarden_filter_dupes_blocks_exact_renamed_disc_release():
+    from src.dupe_checking import DupeChecker
+
+    meta = Meta()
+    meta.is_disc = "BDMV"
+    meta.name = "Movie.2024.UHD.COMPLETE.BLURAY"
+    meta.source_size = 45000000000
+
+    candidate = {
+        "name": "Renamed.Movie.2024.UHD.COMPLETE.BLURAY",
+        "size": 45000000000,
+        "files": [],
+        "file_count": 120,
+        "id": 305,
+    }
+
+    dupe_checker = DupeChecker({"DEFAULT": {}})
+    result = asyncio.run(dupe_checker.filter_dupes([candidate], meta, "PEERGARDEN"))
+
+    assert len(result) == 1
+    assert result[0]["id"] == 305
+
+
 def test_peergarden_filter_dupes_allows_different_size_disc_release():
     from src.dupe_checking import DupeChecker
 
@@ -214,7 +259,3 @@ def test_peergarden_filter_dupes_allows_different_size_disc_release():
     result = asyncio.run(dupe_checker.filter_dupes([candidate], meta, "PEERGARDEN"))
 
     assert result == []
-
-
-
-

--- a/tests/test_peergarden.py
+++ b/tests/test_peergarden.py
@@ -120,5 +120,101 @@ def test_peergarden_anime_movie_uses_movie_category():
     assert category_data == {"category_id": "1"}
 
 
+def test_peergarden_has_exact_match_only_attr():
+    tracker = PeerGarden({"DEFAULT": {}, "TRACKERS": {"PEERGARDEN": {}}})
+    assert getattr(tracker, "exact_match_only", False) is True
+    assert getattr(tracker, "allows_dupes", False) is True
+
+
+def test_peergarden_filter_dupes_allows_different_release_group_or_encode():
+    from src.dupe_checking import DupeChecker
+
+    meta = Meta()
+    meta.name = "Movie.2024.1080p.WEB-DL.GroupB"
+    meta.filelist = ["/path/to/Movie.2024.1080p.WEB-DL.GroupB.mkv"]
+    meta.source_size = 4200000000
+
+    candidate = {
+        "name": "Movie.2024.1080p.WEB-DL.GroupA",
+        "size": 4000000000,
+        "files": ["Movie.2024.1080p.WEB-DL.GroupA.mkv"],
+        "file_count": 1,
+        "id": 101,
+    }
+
+    dupe_checker = DupeChecker({"DEFAULT": {}})
+    result = asyncio.run(dupe_checker.filter_dupes([candidate], meta, "PEERGARDEN"))
+
+    assert result == []
+
+
+def test_peergarden_filter_dupes_blocks_exact_renamed_release():
+    from src.dupe_checking import DupeChecker
+
+    meta = Meta()
+    meta.name = "Awesome.Movie.2024.1080p"
+    meta.filelist = ["/path/to/movie.2024.1080p.web-dl.x264-release.mkv"]
+    meta.source_size = 4000000000
+
+    candidate = {
+        "name": "Renamed.Movie.Title.2024",
+        "size": 4000000000,
+        "files": ["movie.2024.1080p.web-dl.x264-release.mkv"],
+        "file_count": 1,
+        "id": 202,
+    }
+
+    dupe_checker = DupeChecker({"DEFAULT": {}})
+    result = asyncio.run(dupe_checker.filter_dupes([candidate], meta, "PEERGARDEN"))
+
+    assert len(result) == 1
+    assert result[0]["id"] == 202
+
+
+def test_peergarden_filter_dupes_blocks_exact_disc_release():
+    from src.dupe_checking import DupeChecker
+
+    meta = Meta()
+    meta.is_disc = "BDMV"
+    meta.name = "Movie.2024.UHD.COMPLETE.BLURAY"
+    meta.source_size = 45000000000
+
+    candidate = {
+        "name": "Movie.2024.UHD.COMPLETE.BLURAY",
+        "size": 45000000000,
+        "files": [],
+        "file_count": 120,
+        "id": 303,
+    }
+
+    dupe_checker = DupeChecker({"DEFAULT": {}})
+    result = asyncio.run(dupe_checker.filter_dupes([candidate], meta, "PEERGARDEN"))
+
+    assert len(result) == 1
+    assert result[0]["id"] == 303
+
+
+def test_peergarden_filter_dupes_allows_different_size_disc_release():
+    from src.dupe_checking import DupeChecker
+
+    meta = Meta()
+    meta.is_disc = "BDMV"
+    meta.name = "Movie.2024.UHD.COMPLETE.BLURAY"
+    meta.source_size = 45000000000
+
+    candidate = {
+        "name": "Movie.2024.1080p.COMPLETE.BLURAY",
+        "size": 25000000000,
+        "files": [],
+        "file_count": 80,
+        "id": 304,
+    }
+
+    dupe_checker = DupeChecker({"DEFAULT": {}})
+    result = asyncio.run(dupe_checker.filter_dupes([candidate], meta, "PEERGARDEN"))
+
+    assert result == []
+
+
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved duplicate detection for trackers requiring exact matches.
  * Exact matching now considers normalized file lists, file counts, total size, and release name and size.
  * PeerGarden now supports duplicate torrents while filtering out non-exact matches.

* **Bug Fixes**
  * Improved detection and messaging when related releases exist but no exact match is found.
  * Added coverage for renamed releases, differing encodes, disc releases, and size variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->