### PR TITLE
refactor(rehostimages): isolate tracker image collections during concurrent uploads

### DIFF
--- a/src/get_desc.py
+++ b/src/get_desc.py
@@ -25,6 +25,7 @@ from src.languages import languages_manager
 from src.meta import Meta
 from src.screenshot_manifest import files as manifest_files
 from src.takescreens import TakeScreensManager
+from src.tracker_images import get_tracker_image_collection
 from src.trackers.common import Common
 from src.uploadscreens import UploadScreensManager
 
@@ -531,7 +532,8 @@ class DescriptionBuilder:
     async def menu_screenshot_header(self, meta: Meta) -> str:
         """Returns the screenshot header for menus if applicable."""
         try:
-            if meta.is_disc and meta.menu_images:
+            menu_images = get_tracker_image_collection(meta, self.tracker, "menu_images")
+            if meta.is_disc and menu_images:
                 disc_menu_header = self._get_str_config("disc_menu_header", "")
                 if disc_menu_header:
                     return disc_menu_header
@@ -614,7 +616,7 @@ class DescriptionBuilder:
             if not add_spec:
                 return ""
 
-            spectrograms_images = meta.spectrograms_images
+            spectrograms_images = get_tracker_image_collection(meta, self.tracker, "spectrograms_images")
             if not spectrograms_images:
                 return ""
             audio_spectrogram_header = self._get_str_config("audio_spectrogram_header", "[center][b]Audio Spectrogram[/b][/center]")
@@ -1076,7 +1078,7 @@ class DescriptionBuilder:
         signature: str = "",
         desc_header: str = "",
     ) -> str:
-        image_list = meta.get(f"{self.tracker}_images_key", meta.image_list)
+        image_list = get_tracker_image_collection(meta, self.tracker, "screenshots")
         image_list = cast(list[Any], image_list)
 
         if image_list is None:
@@ -1917,7 +1919,7 @@ class DescriptionBuilder:
             screens_per_row = await self.get_screens_per_row()
             if meta.is_disc:
                 menu_parts: list[str] = []
-                menu_images = meta.menu_images
+                menu_images = get_tracker_image_collection(meta, self.tracker, "menu_images")
                 if disc_menu_header and menu_images:
                     menu_parts.append(disc_menu_header + "\n")
                 if menu_images:

--- a/src/meta.py
+++ b/src/meta.py
@@ -322,7 +322,6 @@ class Meta:
     production_countries: list[Any] = field(default_factory=list)
     ptgen: dict[str, Any] = field(default_factory=dict)
     ptp_groupid: str | None = None
-    PTP_images_key: list[dict[str, Any]] = field(default_factory=list)
     ptp: str | int | None = None
     publisher: str = ""
     upload_order: str | None = None
@@ -427,6 +426,7 @@ class Meta:
     tonemapped: bool = False
     torrent_comments: list[Any] = field(default_factory=list)
     tracker_status: dict[str, Any] = field(default_factory=dict)
+    tracker_image_collections: dict[str, dict[str, list[dict[str, Any]]]] = field(default_factory=dict)
     trackers_pass: int | None = None
     trackers_remove: str | bool = False
     trackers: list[str] | str = field(default_factory=list)
@@ -436,7 +436,6 @@ class Meta:
     trumping_trackers: list[Any] = field(default_factory=list)
     tv_movie: bool = False
     tv_pack: bool = False
-    TVC_images_key: list[dict[str, Any]] = field(default_factory=list)
     tvdb_episode_data: dict[str, Any] = field(default_factory=dict)
     tvdb_episode_id: int | None = None
     tvdb_episode_int: int | None = None

--- a/src/rehostimages.py
+++ b/src/rehostimages.py
@@ -17,7 +17,11 @@ from src.console import logger
 from src.meta import Meta
 from src.takescreens import TakeScreensManager
 from src.temp_paths import covers_dir, menu_screenshots_dir, screenshots_dir, spectrograms_dir
-from src.tracker_images import get_tracker_image_collection, set_tracker_image_collection
+from src.tracker_images import (
+    get_tracker_image_collection,
+    has_tracker_image_collection,
+    set_tracker_image_collection,
+)
 from src.type_utils import to_int
 from src.uploadscreens import UploadScreensManager
 
@@ -280,6 +284,7 @@ async def _check_hosts(
         logger.debug(f"[yellow]Skipping image host upload for {tracker} as per meta.skip_imghost_upload setting.")
         return get_tracker_image_collection(meta, tracker, "screenshots"), False, False
 
+    has_tracker_override = has_tracker_image_collection(meta, tracker, "screenshots")
     tracker_images = get_tracker_image_collection(meta, tracker, "screenshots")
 
     logger.debug(
@@ -288,7 +293,7 @@ async def _check_hosts(
     )
 
     # Check if we have main image_list but no tracker-specific images yet
-    if meta.image_list and not tracker_images:
+    if meta.image_list and not has_tracker_override:
         logger.debug(f"[yellow]Checking if existing images in meta.image_list can be used for {tracker}...")
         # Check if the URLs in image_list are from approved hosts
         approved_images: list[dict[str, str]] = []

--- a/src/rehostimages.py
+++ b/src/rehostimages.py
@@ -4,19 +4,31 @@ import glob
 import json
 import re
 from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 from urllib.parse import urlparse
 
 import aiofiles
+import httpx
 from aiofiles import os as aio_os
 
 from src.console import logger
 from src.meta import Meta
 from src.takescreens import TakeScreensManager
-from src.temp_paths import covers_dir, screenshots_dir
+from src.temp_paths import covers_dir, menu_screenshots_dir, screenshots_dir, spectrograms_dir
+from src.tracker_images import get_tracker_image_collection, set_tracker_image_collection
 from src.type_utils import to_int
 from src.uploadscreens import UploadScreensManager
+
+
+@dataclass(frozen=True)
+class ImageHostPolicy:
+    """Declarative image-host requirements for a tracker adapter."""
+
+    url_host_mapping: Mapping[str, str]
+    approved_image_hosts: tuple[str, ...]
+    img_host_index: int = 1
 
 
 def _as_str(value: Any) -> str | None:
@@ -60,7 +72,7 @@ class RehostImagesManager:
         img_host_index: int = 1,
         approved_image_hosts: list[str] | None = None,
     ) -> tuple[list[dict[str, str]], bool, bool]:
-        return await _check_hosts(
+        images, retry_mode, images_reuploaded = await _check_hosts(
             meta,
             tracker,
             url_host_mapping,
@@ -69,6 +81,26 @@ class RehostImagesManager:
             default_config=self.default_config,
             takescreens_manager=self.takescreens_manager,
             uploadscreens_manager=self.uploadscreens_manager,
+        )
+        if tracker != "covers":
+            await _check_additional_image_collections(
+                meta,
+                tracker,
+                url_host_mapping,
+                approved_image_hosts=approved_image_hosts,
+                default_config=self.default_config,
+                uploadscreens_manager=self.uploadscreens_manager,
+            )
+        return images, retry_mode, images_reuploaded
+
+    async def check_policy(self, meta: Meta, tracker: str, policy: ImageHostPolicy) -> tuple[list[dict[str, str]], bool, bool]:
+        """Apply a tracker's declarative image-host policy."""
+        return await self.check_hosts(
+            meta,
+            tracker,
+            url_host_mapping=dict(policy.url_host_mapping),
+            img_host_index=policy.img_host_index,
+            approved_image_hosts=list(policy.approved_image_hosts),
         )
 
     async def handle_image_upload(
@@ -93,6 +125,139 @@ class RehostImagesManager:
         )
 
 
+def _image_host(raw_url: str, url_host_mapping: Mapping[str, str]) -> str:
+    hostname = (urlparse(raw_url).hostname or "").lower()
+    for source_host, mapped_host in url_host_mapping.items():
+        normalized_source = source_host.lower()
+        if hostname == normalized_source or hostname.endswith(f".{normalized_source}"):
+            return mapped_host
+    return hostname
+
+
+def _collection_directory(meta: Meta, collection_name: str) -> Path | None:
+    if collection_name == "menu_images":
+        return menu_screenshots_dir(meta.base_dir, meta.uuid)
+    if collection_name == "spectrograms_images":
+        return spectrograms_dir(meta.base_dir, meta.uuid)
+    return None
+
+
+async def _local_image_path(meta: Meta, collection_name: str, image: Mapping[str, Any]) -> Path | None:
+    local_file_path = _as_str(image.get("local_file_path"))
+    if local_file_path:
+        path = Path(local_file_path)
+        if path.is_file():
+            return path
+
+    raw_url = _as_str(image.get("raw_url"))
+    directory = _collection_directory(meta, collection_name)
+    filename = Path(urlparse(raw_url or "").path).name
+    if directory and filename:
+        candidate = directory / filename
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+async def _download_image_for_rehost(meta: Meta, collection_name: str, raw_url: str) -> Path | None:
+    directory = Path(meta.base_dir) / "tmp" / meta.uuid / "rehosted_images" / collection_name
+    directory.mkdir(parents=True, exist_ok=True)
+    parsed = urlparse(raw_url)
+    suffix = Path(parsed.path).suffix.lower()
+    if suffix not in {".avif", ".gif", ".jpeg", ".jpg", ".png", ".webp"}:
+        suffix = ".png"
+    filename = await sanitize_filename(Path(parsed.path).stem or "image")
+    destination = directory / f"{filename}{suffix}"
+    try:
+        async with httpx.AsyncClient(follow_redirects=True, timeout=60.0) as client:
+            response = await client.get(raw_url)
+            response.raise_for_status()
+        await asyncio.to_thread(destination.write_bytes, response.content)
+        return destination
+    except (httpx.HTTPError, OSError) as error:
+        logger.warning(f"[yellow]Could not download {collection_name} image for {raw_url}: {error!s}[/yellow]")
+        return None
+
+
+async def _check_additional_image_collections(
+    meta: Meta,
+    tracker: str,
+    url_host_mapping: Mapping[str, str],
+    *,
+    approved_image_hosts: Iterable[str] | None,
+    default_config: Mapping[str, Any],
+    uploadscreens_manager: UploadScreensManager,
+) -> None:
+    """Rehost uploaded assets kept outside ``meta.image_list``.
+
+    Disc-menu screenshots and audio spectrograms are submitted alongside normal
+    screenshots by several trackers.  They must therefore satisfy the same
+    tracker host policy, while retaining their own metadata collections.
+    """
+    if meta.skip_imghost_upload:
+        return
+
+    approved_hosts = set(approved_image_hosts or [])
+    if not approved_hosts:
+        return
+    configured_hosts = [value for key, value in default_config.items() if re.fullmatch(r"img_host_(\d+)", key) and isinstance(value, str) and value]
+    if not any(host in approved_hosts for host in configured_hosts):
+        logger.warning(f"[yellow]No configured image host is approved by {tracker} for supplemental images.[/yellow]")
+        return
+
+    original_imghost = meta.imghost
+    try:
+        for collection_name in ("menu_images", "spectrograms_images"):
+            collection = getattr(meta, collection_name, [])
+            if not isinstance(collection, list) or not collection:
+                continue
+
+            updated_images = list(collection)
+            pending: list[tuple[int, dict[str, Any], Path]] = []
+            for index, item in enumerate(collection):
+                if not isinstance(item, dict):
+                    continue
+                raw_url = _as_str(item.get("raw_url"))
+                if raw_url and _image_host(raw_url, url_host_mapping) in approved_hosts:
+                    continue
+                local_path = await _local_image_path(meta, collection_name, item)
+                if local_path is None and raw_url:
+                    local_path = await _download_image_for_rehost(meta, collection_name, raw_url)
+                if local_path is None:
+                    logger.warning(f"[yellow]{tracker}: cannot rehost {collection_name} image {index + 1}; keeping its original URL.[/yellow]")
+                    continue
+                pending.append((index, item, local_path))
+
+            if not pending:
+                continue
+
+            uploaded, _ = await uploadscreens_manager.upload_screens(
+                meta,
+                len(pending),
+                1,
+                0,
+                len(pending),
+                [str(path) for _, _, path in pending],
+                {},
+                allowed_hosts=list(approved_hosts),
+            )
+            if len(uploaded) != len(pending):
+                logger.warning(f"[yellow]{tracker}: only rehosted {len(uploaded)}/{len(pending)} {collection_name} images.[/yellow]")
+
+            for (index, original, local_path), uploaded_image in zip(pending, uploaded, strict=False):
+                raw_url = _as_str(uploaded_image.get("raw_url"))
+                if not raw_url or _image_host(raw_url, url_host_mapping) not in approved_hosts:
+                    logger.warning(f"[yellow]{tracker}: rehosted {collection_name} image is not on an approved host; keeping its original URL.[/yellow]")
+                    continue
+                replacement = dict(original)
+                replacement.update(uploaded_image)
+                replacement["local_file_path"] = str(local_path)
+                updated_images[index] = replacement
+            set_tracker_image_collection(meta, tracker, collection_name, updated_images)
+    finally:
+        meta.imghost = original_imghost
+
+
 async def _check_hosts(
     meta: Meta,
     tracker: str,
@@ -111,20 +276,19 @@ async def _check_hosts(
         raise ValueError("uploadscreens_manager is required")
     if approved_image_hosts is None:
         approved_image_hosts = []
-    new_images_key = f"{tracker}_images_key"
     if meta.skip_imghost_upload:
         logger.debug(f"[yellow]Skipping image host upload for {tracker} as per meta.skip_imghost_upload setting.")
-        return meta.get(new_images_key, []), False, False
-    if new_images_key not in meta:
-        meta[new_images_key] = []
+        return get_tracker_image_collection(meta, tracker, "screenshots"), False, False
+
+    tracker_images = get_tracker_image_collection(meta, tracker, "screenshots")
 
     logger.debug(
         f"[cyan]check_hosts debug: tracker={tracker} meta.imghost={meta.imghost} approved_image_hosts={approved_image_hosts} "
-        f"image_list={len(meta.image_list or [])} {new_images_key}={len(meta.get(new_images_key, []) or [])}[/cyan]"
+        f"image_list={len(meta.image_list or [])} tracker_screenshots={len(tracker_images)}[/cyan]"
     )
 
     # Check if we have main image_list but no tracker-specific images yet
-    if meta.image_list and not meta.get(new_images_key):
+    if meta.image_list and not tracker_images:
         logger.debug(f"[yellow]Checking if existing images in meta.image_list can be used for {tracker}...")
         # Check if the URLs in image_list are from approved hosts
         approved_images: list[dict[str, str]] = []
@@ -153,9 +317,9 @@ async def _check_hosts(
 
         # If all images are approved, use them directly
         if approved_images and len(approved_images) == len(meta.image_list) and not need_reupload:
-            meta[new_images_key] = approved_images.copy()
+            set_tracker_image_collection(meta, tracker, "screenshots", approved_images)
             logger.debug(f"[green]All existing images are from approved hosts for {tracker}.")
-            return meta[new_images_key], False, False
+            return get_tracker_image_collection(meta, tracker, "screenshots"), False, False
 
     if tracker == "covers":
         reuploaded_images_path = Path(meta.base_dir) / "tmp" / meta.uuid / "covers.json"
@@ -200,19 +364,18 @@ async def _check_hosts(
                 logger.info(f"[red]URL '{raw_url}' from reuploaded_images.json is not recognized as an approved host.")
 
     if valid_reuploaded_images:
-        meta[new_images_key] = valid_reuploaded_images
+        set_tracker_image_collection(meta, tracker, "screenshots", valid_reuploaded_images)
         if tracker == "covers":
             logger.info("[green]Using valid images from covers.json.")
         else:
             logger.info("[green]Using valid images from reuploaded_images.json.")
-        return meta[new_images_key], False, False
+        return get_tracker_image_collection(meta, tracker, "screenshots"), False, False
 
     # Check if the tracker-specific key has valid images
     has_valid_images = False
-    if meta.get(new_images_key):
+    if tracker_images:
         valid_hosts: list[bool] = []
-        tracker_images = cast(list[dict[str, str]], meta.get(new_images_key, []))
-        for image in tracker_images:
+        for image in cast(list[dict[str, str]], tracker_images):
             raw_url = _as_str(image.get("raw_url")) or ""
             netloc = urlparse(raw_url).netloc
             matched_host = await match_host(netloc, url_host_mapping.keys())
@@ -220,12 +383,12 @@ async def _check_hosts(
             valid_hosts.append(mapped_host in approved_image_hosts)
 
         # Then check if all are valid
-        if all(valid_hosts) and meta[new_images_key]:
+        if all(valid_hosts) and tracker_images:
             has_valid_images = True
 
     if has_valid_images:
-        logger.info(f"[green]Using valid images from {new_images_key}.")
-        return meta[new_images_key], False, False
+        logger.info(f"[green]Using valid tracker screenshots for {tracker}.")
+        return get_tracker_image_collection(meta, tracker, "screenshots"), False, False
 
     logger.debug(f"[yellow]No valid images found for {tracker}, will attempt to reupload...")
 
@@ -250,7 +413,7 @@ async def _check_hosts(
         )
 
         if image_list:
-            meta[new_images_key] = image_list
+            set_tracker_image_collection(meta, tracker, "screenshots", image_list)
 
         if retry_mode:
             logger.info(f"[yellow]Switching to the next image host. Current index: {current_index}")
@@ -259,12 +422,15 @@ async def _check_hosts(
 
         break
 
-    if not meta.get(new_images_key):
+    if not get_tracker_image_collection(meta, tracker, "screenshots"):
         logger.info("[red]All image hosts failed. Please check your configuration.")
 
-    logger.debug(f"[cyan]check_hosts debug: done tracker={tracker} image_list={len(meta.image_list or [])} {new_images_key}={len(meta.get(new_images_key, []) or [])}[/cyan]")
+    logger.debug(
+        f"[cyan]check_hosts debug: done tracker={tracker} image_list={len(meta.image_list or [])} "
+        f"tracker_screenshots={len(get_tracker_image_collection(meta, tracker, 'screenshots'))}[/cyan]"
+    )
 
-    return meta.get(new_images_key, []), False, images_reuploaded
+    return get_tracker_image_collection(meta, tracker, "screenshots"), False, images_reuploaded
 
 
 async def _handle_image_upload(
@@ -289,7 +455,6 @@ async def _handle_image_upload(
     original_imghost = meta.imghost
     retry_mode = False
     images_reuploaded = False
-    new_images_key = f"{tracker}_images_key"
     filelist: list[str] = []
     filelist_value = meta.video
     if isinstance(filelist_value, str):
@@ -307,7 +472,7 @@ async def _handle_image_upload(
     multi_screens = to_int(meta.screens, default_screens)
     base_dir = meta.base_dir
     folder_id = meta.uuid
-    meta[new_images_key] = []
+    set_tracker_image_collection(meta, tracker, "screenshots", [])
 
     screenshot_path = screenshots_dir(base_dir, folder_id)
     logger.debug(f"[yellow]Searching for screenshots in {screenshot_path}...")
@@ -550,17 +715,16 @@ async def _handle_image_upload(
             logger.info("[red]No approved image host was selected; skipping upload.")
             return [], True, images_reuploaded
 
-        uploaded_images, _ = await uploadscreens_manager.upload_screens(
-            meta, multi_screens, current_upload_index, 0, multi_screens, all_screenshots, {new_images_key: meta[new_images_key]}, retry_mode
-        )
+        uploaded_images, _ = await uploadscreens_manager.upload_screens(meta, multi_screens, current_upload_index, 0, multi_screens, all_screenshots, {}, retry_mode)
         if uploaded_images:
-            meta[new_images_key] = uploaded_images
+            set_tracker_image_collection(meta, tracker, "screenshots", uploaded_images)
 
-        logger.debug(f"[debug] Updated {new_images_key} with {len(uploaded_images)} images.")
+        logger.debug(f"[debug] Updated tracker screenshots for {tracker} with {len(uploaded_images)} images.")
         for image in uploaded_images:
             logger.debug(f"[debug] Response in upload_image_task: {image['img_url']}, {image['raw_url']}, {image['web_url']}")
 
-        for image in cast(list[dict[str, str]], meta.get(new_images_key, [])):
+        tracker_images = get_tracker_image_collection(meta, tracker, "screenshots")
+        for image in cast(list[dict[str, str]], tracker_images):
             raw_url = image["raw_url"]
             parsed_url = urlparse(raw_url)
             hostname = parsed_url.netloc
@@ -571,16 +735,16 @@ async def _handle_image_upload(
                 logger.info(f"[red]Unsupported image host detected in URL '{raw_url}'. Please use one of the approved image hosts.")
                 if original_imghost:
                     meta.imghost = original_imghost
-                return meta[new_images_key], True, images_reuploaded  # Trigger retry_mode if switching hosts
+                return tracker_images, True, images_reuploaded  # Trigger retry_mode if switching hosts
 
         # Ensure all uploaded images are valid
         valid_hosts: list[bool] = []
-        for image in cast(list[dict[str, str]], meta.get(new_images_key, [])):
+        for image in cast(list[dict[str, str]], tracker_images):
             netloc = urlparse(image["raw_url"]).netloc
             matched_host = await match_host(netloc, url_host_mapping.keys())
             mapped_host = url_host_mapping.get(matched_host, matched_host)
             valid_hosts.append(mapped_host in approved_image_hosts)
-        if uploaded_images and all(valid_hosts) and new_images_key in meta and isinstance(meta[new_images_key], list):
+        if uploaded_images and all(valid_hosts):
             output_file = Path(meta.base_dir) / "tmp" / meta.uuid / "covers.json" if tracker == "covers" else screenshot_path / "reuploaded_images.json"
 
             existing_data: list[dict[str, str]] = []
@@ -595,7 +759,7 @@ async def _handle_image_upload(
             except Exception:
                 existing_data = []
 
-            updated_data = existing_data + meta[new_images_key]
+            updated_data = existing_data + tracker_images
             updated_data = [dict(s) for s in {tuple(d.items()) for d in updated_data}]
 
             if tracker == "covers" and "release_url" in meta:
@@ -622,11 +786,11 @@ async def _handle_image_upload(
             except Exception as e:
                 logger.error(f"[red]Failed to save reuploaded images: {e}")
         else:
-            logger.info("[red]new_images_key is not a valid key in meta or is not a list.")
+            logger.info("[red]Tracker screenshots are not a valid list.")
 
         if original_imghost:
             meta.imghost = original_imghost
-        return meta[new_images_key], False, images_reuploaded
+        return tracker_images, False, images_reuploaded
     if original_imghost:
         meta.imghost = original_imghost
-    return meta[new_images_key], False, images_reuploaded
+    return get_tracker_image_collection(meta, tracker, "screenshots"), False, images_reuploaded

--- a/src/tracker_images.py
+++ b/src/tracker_images.py
@@ -1,0 +1,29 @@
+"""Tracker-scoped image collections used during concurrent uploads."""
+
+from collections.abc import Sequence
+from typing import Any, Literal
+
+from src.meta import Meta
+
+ImageCollection = Literal["screenshots", "menu_images", "spectrograms_images"]
+ImageDict = dict[str, Any]
+
+_BASE_COLLECTION_FIELDS: dict[ImageCollection, str] = {
+    "screenshots": "image_list",
+    "menu_images": "menu_images",
+    "spectrograms_images": "spectrograms_images",
+}
+
+
+def get_tracker_image_collection(meta: Meta, tracker: str, collection: ImageCollection) -> list[Any]:
+    """Return a tracker override or the release-wide collection as fallback."""
+    tracker_collections = meta.tracker_image_collections.get(tracker, {})
+    if collection in tracker_collections:
+        return tracker_collections[collection]
+    images = getattr(meta, _BASE_COLLECTION_FIELDS[collection])
+    return images if isinstance(images, list) else []
+
+
+def set_tracker_image_collection(meta: Meta, tracker: str, collection: ImageCollection, images: Sequence[ImageDict]) -> None:
+    """Store a tracker-local image collection without mutating shared metadata."""
+    meta.tracker_image_collections.setdefault(tracker, {})[collection] = list(images)

--- a/src/tracker_images.py
+++ b/src/tracker_images.py
@@ -24,6 +24,11 @@ def get_tracker_image_collection(meta: Meta, tracker: str, collection: ImageColl
     return images if isinstance(images, list) else []
 
 
+def has_tracker_image_collection(meta: Meta, tracker: str, collection: ImageCollection) -> bool:
+    """Return whether a tracker has an explicit collection override."""
+    return collection in meta.tracker_image_collections.get(tracker, {})
+
+
 def set_tracker_image_collection(meta: Meta, tracker: str, collection: ImageCollection, images: Sequence[ImageDict]) -> None:
     """Store a tracker-local image collection without mutating shared metadata."""
-    meta.tracker_image_collections.setdefault(tracker, {})[collection] = list(images)
+    meta.tracker_image_collections.setdefault(tracker, {})[collection] = [dict(image) for image in images]

--- a/src/trackerhandle.py
+++ b/src/trackerhandle.py
@@ -18,6 +18,7 @@ from src.get_desc import DescriptionBuilder
 from src.manualpackage import ManualPackageManager
 from src.meta import Meta
 from src.qbitwait import Wait
+from src.rehostimages import ImageHostPolicy
 from src.trackers.passthepopcorn import PassThePopcorn
 from src.trackers.torrenthr import TorrentHR
 from src.trackersetup import TrackerSetup
@@ -130,6 +131,17 @@ async def process_trackers(
         except Exception as e:
             logger.error(f"[red]Error printing {tracker} result: {e}[/red]")
 
+    async def check_tracker_image_hosts(tracker_class: Any) -> None:
+        """Run an adapter's optional host policy before it builds upload data."""
+        policy = getattr(tracker_class, "image_host_policy", None)
+        rehost_manager = getattr(tracker_class, "rehost_images_manager", None)
+        if isinstance(policy, ImageHostPolicy) and rehost_manager is not None:
+            await rehost_manager.check_policy(meta, tracker_class.tracker, policy)
+            return
+        check_hosts = getattr(tracker_class, "check_image_hosts", None)
+        if callable(check_hosts):
+            await check_hosts(meta)
+
     async def process_single_tracker(tracker: str) -> None:
         """
         try:
@@ -218,6 +230,7 @@ async def process_trackers(
                             status["status_message"] = "Skipped due to new dupe found after bandwidth wait"
                             print_tracker_result(tracker, tracker_class, status, False)
                             return
+                        await check_tracker_image_hosts(tracker_class)
                         upload_start_time = time.time()
                         is_uploaded = await tracker_class.upload(meta)
                         upload_duration = time.time() - upload_start_time
@@ -257,6 +270,7 @@ async def process_trackers(
                             status["status_message"] = "Skipped due to new dupe found after bandwidth wait"
                             print_tracker_result(tracker, tracker_class, status, False)
                             return
+                        await check_tracker_image_hosts(tracker_class)
                         upload_start_time = time.time()
                         is_uploaded = await tracker_class.upload(meta)
                         upload_duration = time.time() - upload_start_time
@@ -300,6 +314,7 @@ async def process_trackers(
                     if manual_tracker != "MANUAL":
                         manual_tracker = manual_tracker.replace(" ", "").upper().strip()
                         tracker_class = tracker_class_map[manual_tracker](config=config)
+                        await check_tracker_image_hosts(tracker_class)
                         if manual_tracker in api_trackers:
                             await DescriptionBuilder(manual_tracker, config).unit3d_edit_desc(meta, manual_tracker)
                         else:
@@ -345,6 +360,7 @@ async def process_trackers(
                 try:
                     ptp = PassThePopcorn(config=config)
                     group_id = meta.ptp_groupid
+                    await check_tracker_image_hosts(ptp)
                     ptp_url, ptp_data = await ptp.fill_upload_form(group_id, meta)
                     is_uploaded = False
                     try:

--- a/src/trackerhandle.py
+++ b/src/trackerhandle.py
@@ -314,11 +314,14 @@ async def process_trackers(
                     if manual_tracker != "MANUAL":
                         manual_tracker = manual_tracker.replace(" ", "").upper().strip()
                         tracker_class = tracker_class_map[manual_tracker](config=config)
-                        await check_tracker_image_hosts(tracker_class)
-                        if manual_tracker in api_trackers:
-                            await DescriptionBuilder(manual_tracker, config).unit3d_edit_desc(meta, manual_tracker)
-                        else:
-                            await tracker_class.edit_desc(meta)
+                        try:
+                            await check_tracker_image_hosts(tracker_class)
+                            if manual_tracker in api_trackers:
+                                await DescriptionBuilder(manual_tracker, config).unit3d_edit_desc(meta, manual_tracker)
+                            else:
+                                await tracker_class.edit_desc(meta)
+                        except Exception as e:
+                            logger.info(f"[red]{manual_tracker}: Error preparing manual upload files: {e}[/red]")
                 url = await manual_packager.package(meta)
                 if url is False:
                     logger.info(f"[yellow]Unable to upload prep files, they can be found at `tmp/{meta.uuid}")

--- a/src/trackers/UNIT3D/aura4k.py
+++ b/src/trackers/UNIT3D/aura4k.py
@@ -6,7 +6,7 @@ import cli_ui
 from src.console import logger
 from src.languages import languages_manager
 from src.meta import Meta
-from src.rehostimages import RehostImagesManager
+from src.rehostimages import ImageHostPolicy, RehostImagesManager
 from src.trackers.common import Common
 from src.trackers.UNIT3D import UNIT3D
 
@@ -23,6 +23,17 @@ class Aura4K(UNIT3D):
     allows_bloated_audio = True
     base_url = "https://aura4k.net"
     approved_image_hosts = ("onlyimage", "imgbox", "ptscreens", "imgbb", "imgur", "postimg")
+    image_host_policy = ImageHostPolicy(
+        {
+            "ibb.co": "imgbb",
+            "imgbox.com": "imgbox",
+            "imgur.com": "imgur",
+            "postimg.cc": "postimg",
+            "ptscreens.com": "ptscreens",
+            "onlyimage.org": "onlyimage",
+        },
+        approved_image_hosts,
+    )
     banned_groups = ("BiTOR", "DepraveD", "Flights", "SasukeducK", "SPDVD", "TEKNO3D")
     id_url = f"{base_url}/api/torrents/"
     upload_url = f"{base_url}/api/torrents/upload"
@@ -148,24 +159,6 @@ class Aura4K(UNIT3D):
         return {
             "mod_queue_opt_in": await self.get_flag(meta, "modq"),
         }
-
-    async def check_image_hosts(self, meta: Meta) -> None:
-        url_host_mapping = {
-            "ibb.co": "imgbb",
-            "imgbox.com": "imgbox",
-            "imgur.com": "imgur",
-            "postimg.cc": "postimg",
-            "ptscreens.com": "ptscreens",
-            "onlyimage.org": "onlyimage",
-        }
-        await self.rehost_images_manager.check_hosts(
-            meta,
-            self.tracker,
-            url_host_mapping=url_host_mapping,
-            img_host_index=1,
-            approved_image_hosts=self.approved_image_hosts,
-        )
-        return
 
     async def get_name(self, meta: Meta) -> dict[str, str]:
         a4k_name: str = meta.name

--- a/src/trackers/UNIT3D/hawkeuno.py
+++ b/src/trackers/UNIT3D/hawkeuno.py
@@ -11,7 +11,7 @@ from src.console import logger
 from src.get_desc import DescriptionBuilder
 from src.languages import languages_manager
 from src.meta import Meta
-from src.rehostimages import RehostImagesManager
+from src.rehostimages import ImageHostPolicy, RehostImagesManager
 from src.trackers.common import Common
 from src.trackers.UNIT3D import UNIT3D
 
@@ -80,6 +80,19 @@ class HawkeUno(UNIT3D):
         "ptscreens",
         "passtheimage",
         "hawke.pics",
+    )
+    image_host_policy = ImageHostPolicy(
+        {
+            "ibb.co": "imgbb",
+            "pixhost.to": "pixhost",
+            "imgbox.com": "imgbox",
+            "imagebam.com": "bam",
+            "hawke.pics": "hawke.pics",
+            "onlyimage.org": "onlyimage",
+            "ptscreens.com": "ptscreens",
+            "passtheimage.me": "passtheimage",
+        },
+        approved_image_hosts,
     )
     id_url = f"{base_url}/api/torrents/"
     upload_url = f"{base_url}/api/torrents/upload"
@@ -151,25 +164,6 @@ class HawkeUno(UNIT3D):
                                         return False
 
         return should_continue
-
-    async def check_image_hosts(self, meta: Meta) -> None:
-        url_host_mapping = {
-            "ibb.co": "imgbb",
-            "pixhost.to": "pixhost",
-            "imgbox.com": "imgbox",
-            "imagebam.com": "bam",
-            "hawke.pics": "hawke.pics",
-            "onlyimage.org": "onlyimage",
-            "ptscreens.com": "ptscreens",
-            "passtheimage.me": "passtheimage",
-        }
-        await self.rehost_images_manager.check_hosts(
-            meta,
-            self.tracker,
-            url_host_mapping=url_host_mapping,
-            img_host_index=1,
-            approved_image_hosts=self.approved_image_hosts,
-        )
 
     async def get_description(self, meta: Meta) -> None:
         desc = await DescriptionBuilder(self.tracker, self.config).unit3d_edit_desc(

--- a/src/trackers/UNIT3D/onlyencodes.py
+++ b/src/trackers/UNIT3D/onlyencodes.py
@@ -4,7 +4,7 @@ from typing import Any, cast
 
 from src.languages import languages_manager
 from src.meta import Meta
-from src.rehostimages import RehostImagesManager
+from src.rehostimages import ImageHostPolicy, RehostImagesManager
 from src.trackers.common import Common
 from src.trackers.UNIT3D import UNIT3D
 
@@ -21,6 +21,17 @@ class OnlyEncodes(UNIT3D):
     allows_bloated_audio = True
     base_url = "https://onlyencodes.cc"
     approved_image_hosts = ("imgbox", "imgbb", "onlyimage", "ptscreens", "passtheimage")
+    image_host_policy = ImageHostPolicy(
+        {
+            "ibb.co": "imgbb",
+            "imgbox.com": "imgbox",
+            "onlyimage.org": "onlyimage",
+            "imagebam.com": "bam",
+            "ptscreens.com": "ptscreens",
+            "img.passtheima.ge": "passtheimage",
+        },
+        approved_image_hosts,
+    )
     banned_groups = (
         "[Oj]",
         "$andra",
@@ -178,25 +189,6 @@ class OnlyEncodes(UNIT3D):
             meta.is_disc != "BDMV"
             and not await self.common.check_language_requirements(meta, self.tracker, languages_to_check=["english"], check_audio=True, check_subtitle=True)
         )
-
-    async def check_image_hosts(self, meta: Meta) -> None:
-        url_host_mapping = {
-            "ibb.co": "imgbb",
-            "imgbox.com": "imgbox",
-            "onlyimage.org": "onlyimage",
-            "imagebam.com": "bam",
-            "ptscreens.com": "ptscreens",
-            "img.passtheima.ge": "passtheimage",
-        }
-
-        await self.rehost_images_manager.check_hosts(
-            meta,
-            self.tracker,
-            url_host_mapping=url_host_mapping,
-            img_host_index=1,
-            approved_image_hosts=self.approved_image_hosts,
-        )
-        return
 
     async def get_name(self, meta: Meta) -> dict[str, str]:
         oe_name = meta.name

--- a/src/trackers/UNIT3D/skipthecommercials.py
+++ b/src/trackers/UNIT3D/skipthecommercials.py
@@ -7,7 +7,7 @@ import cli_ui
 from src.console import logger
 from src.get_desc import DescriptionBuilder
 from src.meta import Meta
-from src.rehostimages import RehostImagesManager
+from src.rehostimages import ImageHostPolicy, RehostImagesManager
 from src.trackers.common import Common
 from src.trackers.UNIT3D import UNIT3D
 
@@ -25,6 +25,7 @@ class SkipTheCommercials(UNIT3D):
     base_url = "https://skipthecommercials.xyz"
     banned_groups = ("",)
     approved_image_hosts = ("imgbox", "imgbb")
+    image_host_policy = ImageHostPolicy({"ibb.co": "imgbb", "imgbox.com": "imgbox"}, approved_image_hosts)
     id_url = f"{base_url}/api/torrents/"
     upload_url = f"{base_url}/api/torrents/upload"
     search_url = f"{base_url}/api/torrents/filter"
@@ -73,19 +74,6 @@ class SkipTheCommercials(UNIT3D):
                 return False
 
         return True
-
-    async def check_image_hosts(self, meta: Meta) -> None:
-        url_host_mapping = {
-            "ibb.co": "imgbb",
-            "imgbox.com": "imgbox",
-        }
-        await self.rehost_images_manager.check_hosts(
-            meta,
-            self.tracker,
-            url_host_mapping=url_host_mapping,
-            img_host_index=1,
-            approved_image_hosts=self.approved_image_hosts,
-        )
 
     async def get_description(self, meta: Meta) -> dict[str, str]:
         return {

--- a/src/trackers/USENET/curupira.py
+++ b/src/trackers/USENET/curupira.py
@@ -12,6 +12,7 @@ import langcodes
 from cogs.redaction import Redaction
 from src.console import logger
 from src.meta import Meta
+from src.tracker_images import get_tracker_image_collection
 from src.trackers.common import Common
 from src.trackers.USENET.search_helpers import build_newznab_search_query, parse_newznab_dupes
 
@@ -343,7 +344,7 @@ class Curupira:
 
     async def get_screens(self, meta: Meta) -> list[str]:
         menu_images = [cast(dict[str, Any], img) for img in meta.menu_images if isinstance(img, dict)]
-        images_value = meta.get(f"{self.tracker}_images_key", meta.image_list)
+        images_value = get_tracker_image_collection(meta, self.tracker, "screenshots")
         image_entries: list[Any] = cast(list[Any], images_value) if isinstance(images_value, list) else []
         images_list = [cast(dict[str, Any], img) for img in image_entries if isinstance(img, dict)]
         spectrograms_images = [cast(dict[str, Any], img) for img in meta.spectrograms_images if isinstance(img, dict)]

--- a/src/trackers/USENET/curupira.py
+++ b/src/trackers/USENET/curupira.py
@@ -343,11 +343,11 @@ class Curupira:
         return ""
 
     async def get_screens(self, meta: Meta) -> list[str]:
-        menu_images = [cast(dict[str, Any], img) for img in meta.menu_images if isinstance(img, dict)]
+        menu_images = [cast(dict[str, Any], img) for img in get_tracker_image_collection(meta, self.tracker, "menu_images") if isinstance(img, dict)]
         images_value = get_tracker_image_collection(meta, self.tracker, "screenshots")
         image_entries: list[Any] = cast(list[Any], images_value) if isinstance(images_value, list) else []
         images_list = [cast(dict[str, Any], img) for img in image_entries if isinstance(img, dict)]
-        spectrograms_images = [cast(dict[str, Any], img) for img in meta.spectrograms_images if isinstance(img, dict)]
+        spectrograms_images = [cast(dict[str, Any], img) for img in get_tracker_image_collection(meta, self.tracker, "spectrograms_images") if isinstance(img, dict)]
 
         combined_images: list[dict[str, Any]] = []
         if menu_images:

--- a/src/trackers/beyondhd.py
+++ b/src/trackers/beyondhd.py
@@ -12,7 +12,8 @@ from rich.markup import escape
 from cogs.redaction import Redaction
 from src.console import logger
 from src.meta import Meta
-from src.rehostimages import RehostImagesManager
+from src.rehostimages import ImageHostPolicy, RehostImagesManager
+from src.tracker_images import get_tracker_image_collection
 from src.trackers.common import Common
 
 
@@ -59,6 +60,16 @@ class BEYONDHD:
         "YIFY",
     )
     approved_image_hosts = ("imgbox", "imgbb", "pixhost", "bhd", "bam")
+    image_host_policy = ImageHostPolicy(
+        {
+            "ibb.co": "imgbb",
+            "pixhost.to": "pixhost",
+            "imgbox.com": "imgbox",
+            "beyondhd.co": "bhd",
+            "imagebam.com": "bam",
+        },
+        approved_image_hosts,
+    )
     base_url = "https://beyond-hd.me"
     upload_url = f"{base_url}/api/upload/"
     torrent_url = f"{base_url}/details/"
@@ -72,24 +83,6 @@ class BEYONDHD:
         self.tracker_config = cast(dict[str, Any], trackers_cfg.get("BEYONDHD", {}))
         api_key = str(self.tracker_config.get("api_key", "")).strip()
         self.requests_url = f"{self.base_url}/api/requests/{api_key}"
-
-    async def check_image_hosts(self, meta: Meta) -> None:
-        url_host_mapping = {
-            "ibb.co": "imgbb",
-            "pixhost.to": "pixhost",
-            "imgbox.com": "imgbox",
-            "beyondhd.co": "bhd",
-            "imagebam.com": "bam",
-        }
-
-        await self.rehost_images_manager.check_hosts(
-            meta,
-            self.tracker,
-            url_host_mapping=url_host_mapping,
-            img_host_index=1,
-            approved_image_hosts=self.approved_image_hosts,
-        )
-        return
 
     async def upload(self, meta: Meta) -> bool:
         common = Common(config=self.config)
@@ -278,6 +271,18 @@ class BEYONDHD:
         base_path = f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/DESCRIPTION.txt"
         async with aiofiles.open(base_path, encoding="utf-8") as f:
             base = await f.read()
+        for collection_name in ("menu_images", "spectrograms_images"):
+            original_images = getattr(meta, collection_name, [])
+            rehosted_images = get_tracker_image_collection(meta, self.tracker, collection_name)
+            if not isinstance(original_images, list) or not isinstance(rehosted_images, list):
+                continue
+            for original, rehosted in zip(original_images, rehosted_images, strict=False):
+                if not isinstance(original, dict) or not isinstance(rehosted, dict):
+                    continue
+                original_url = original.get("raw_url")
+                rehosted_url = rehosted.get("raw_url")
+                if isinstance(original_url, str) and isinstance(rehosted_url, str) and original_url != rehosted_url:
+                    base = base.replace(original_url, rehosted_url)
         async with aiofiles.open(desc_path, "w", encoding="utf-8") as desc:
             discs = cast(list[dict[str, Any]], meta.discs or [])
             if discs:
@@ -333,7 +338,7 @@ class BEYONDHD:
                     await desc.write("\n\n")
             except Exception as e:
                 logger.warning(f"{self.tracker}: [yellow]Warning: Error setting tonemapped header: {escape(str(e))}[/yellow]")
-            images = cast(list[dict[str, Any]], meta.get(f"{self.tracker}_images_key") or meta.image_list or [])
+            images = cast(list[dict[str, Any]], get_tracker_image_collection(meta, self.tracker, "screenshots"))
             if len(images) > 0:
                 await desc.write("[align=center]")
                 for each in range(len(images[: meta.screens])):

--- a/src/trackers/cathoderaytube.py
+++ b/src/trackers/cathoderaytube.py
@@ -13,7 +13,8 @@ from src.console import logger
 from src.cookie_auth import CookieValidator, extract_upload_error
 from src.get_desc import DescriptionBuilder
 from src.meta import Meta
-from src.rehostimages import RehostImagesManager
+from src.rehostimages import ImageHostPolicy, RehostImagesManager
+from src.tracker_images import get_tracker_image_collection
 from src.trackers.common import Common
 
 
@@ -33,14 +34,17 @@ class CathodeRayTube:
     banned_groups: tuple[str, ...] = ()
     auth_token: ClassVar[str] = ""
     approved_image_hosts = ("ptpimg", "catbox", "imgbb", "postimages", "freeimage", "imgbox")
-    image_host_mapping: ClassVar = {
-        "ptpimg.me": "ptpimg",
-        "catbox.moe": "catbox",
-        "ibb.co": "imgbb",
-        "postimg.cc": "postimages",
-        "iili.io": "freeimage",
-        "imgbox.com": "imgbox",
-    }
+    image_host_policy = ImageHostPolicy(
+        {
+            "ptpimg.me": "ptpimg",
+            "catbox.moe": "catbox",
+            "ibb.co": "imgbb",
+            "postimg.cc": "postimages",
+            "iili.io": "freeimage",
+            "imgbox.com": "imgbox",
+        },
+        approved_image_hosts,
+    )
 
     category_map: ClassVar = {"MOVIE": "1", "TV": "2", "GAME": "13"}
 
@@ -50,16 +54,6 @@ class CathodeRayTube:
         self.cookie_validator = CookieValidator(config)
         self.rehost_images_manager = RehostImagesManager(config)
         self.session = httpx.AsyncClient(timeout=60.0, follow_redirects=True)
-
-    async def check_image_hosts(self, meta: Meta) -> None:
-        """Reuse CRT-approved images or rehost them through a configured approved host."""
-        await self.rehost_images_manager.check_hosts(
-            meta,
-            self.tracker,
-            url_host_mapping=self.image_host_mapping,
-            img_host_index=1,
-            approved_image_hosts=list(self.approved_image_hosts),
-        )
 
     async def validate_credentials(self, meta: Meta) -> bool:
         cookie_jar = await self.cookie_validator.load_session_cookies(meta, self.tracker)
@@ -259,8 +253,10 @@ class CathodeRayTube:
         links = self._metadata_links(meta)
         overview = meta.overview or meta.overview_meta
         notes = "\n\n".join(part for part in (meta.description.strip(), await builder.get_user_description(meta)) if part)
-        images = meta.get(f"{self.tracker}_images_key", meta.image_list)
-        screenshots = "\n".join(image["raw_url"] for image in (meta.menu_images + images + meta.spectrograms_images) if image.get("raw_url"))
+        images = get_tracker_image_collection(meta, self.tracker, "screenshots")
+        menu_images = get_tracker_image_collection(meta, self.tracker, "menu_images")
+        spectrograms_images = get_tracker_image_collection(meta, self.tracker, "spectrograms_images")
+        screenshots = "\n".join(image["raw_url"] for image in (menu_images + images + spectrograms_images) if image.get("raw_url"))
 
         sections: list[str] = []
         if links:
@@ -343,7 +339,7 @@ class CathodeRayTube:
                 return False
 
             # Minimum 6 screenshots requirement
-            images = list(meta.get(f"{self.tracker}_images_key", meta.image_list)) or []
+            images = get_tracker_image_collection(meta, self.tracker, "screenshots")
             screens_count = len(meta.menu_images or []) + len(images) + len(meta.spectrograms_images or [])
             if screens_count == 0 and hasattr(meta, "screens"):
                 try:
@@ -510,7 +506,6 @@ class CathodeRayTube:
         return ""
 
     async def upload(self, meta: Meta) -> bool:
-        await self.check_image_hosts(meta)
         await self.common.create_torrent_for_upload(meta, self.tracker, self.source_flag)
         torrent_path = Path(meta.base_dir) / "tmp" / meta.uuid / f"[{self.tracker}].torrent"
         if meta.debug:

--- a/src/trackers/cathoderaytube.py
+++ b/src/trackers/cathoderaytube.py
@@ -340,7 +340,9 @@ class CathodeRayTube:
 
             # Minimum 6 screenshots requirement
             images = get_tracker_image_collection(meta, self.tracker, "screenshots")
-            screens_count = len(meta.menu_images or []) + len(images) + len(meta.spectrograms_images or [])
+            menu_images = get_tracker_image_collection(meta, self.tracker, "menu_images")
+            spectrograms_images = get_tracker_image_collection(meta, self.tracker, "spectrograms_images")
+            screens_count = len(menu_images) + len(images) + len(spectrograms_images)
             if screens_count == 0 and hasattr(meta, "screens"):
                 try:
                     screens_count = int(meta.screens or 0)

--- a/src/trackers/digitalcore.py
+++ b/src/trackers/digitalcore.py
@@ -9,7 +9,7 @@ from cogs.redaction import Redaction
 from src.console import logger
 from src.get_desc import DescriptionBuilder
 from src.meta import Meta
-from src.rehostimages import RehostImagesManager
+from src.rehostimages import ImageHostPolicy, RehostImagesManager
 from src.trackers.common import Common
 
 Config = dict[str, Any]
@@ -27,6 +27,18 @@ class DigitalCore:
     api_base_url = f"{base_url}/api/v1/torrents"
     banned_groups = ("",)
     approved_image_hosts = ("imgbox", "imgbb", "bhd", "imgur", "postimg", "sharex")
+    image_host_policy = ImageHostPolicy(
+        {
+            "ibb.co": "imgbb",
+            "imgbox.com": "imgbox",
+            "beyondhd.co": "bhd",
+            "imgur.com": "imgur",
+            "postimg.cc": "postimg",
+            "digitalcore.club": "sharex",
+            "img.digitalcore.club": "sharex",
+        },
+        approved_image_hosts,
+    )
     torrent_url = f"{base_url}/torrent/"
     supported_categories = ("TV", "MOVIE", "BOOK", "GAME", "MUSIC")
     tracker_urls = ("tracker.digitalcore.club", "trackerprxy.digitalcore.club")
@@ -206,25 +218,6 @@ class DigitalCore:
             tracker_name = f"{scene_name} [UNRAR]" if scene_name else meta.basename_no_ext
 
         return tracker_name
-
-    async def check_image_hosts(self, meta: Meta) -> None:
-        url_host_mapping = {
-            "ibb.co": "imgbb",
-            "imgbox.com": "imgbox",
-            "beyondhd.co": "bhd",
-            "imgur.com": "imgur",
-            "postimg.cc": "postimg",
-            "digitalcore.club": "sharex",
-            "img.digitalcore.club": "sharex",
-        }
-        await self.rehost_images_manager.check_hosts(
-            meta,
-            self.tracker,
-            url_host_mapping=url_host_mapping,
-            img_host_index=1,
-            approved_image_hosts=self.approved_image_hosts,
-        )
-        return
 
     async def get_firstpic(self, meta: Meta) -> str:
         if meta.category in ("BOOK", "MUSIC"):

--- a/src/trackers/morethantv.py
+++ b/src/trackers/morethantv.py
@@ -18,7 +18,7 @@ from cogs.redaction import Redaction
 from src.console import console, logger
 from src.get_desc import DescriptionBuilder
 from src.meta import Meta
-from src.rehostimages import RehostImagesManager
+from src.rehostimages import ImageHostPolicy, RehostImagesManager
 from src.torrentcreate import TorrentCreator
 from src.trackers.common import Common
 
@@ -36,6 +36,7 @@ class MoreThanTV:
     reject_english_original_bloat = True
     source_flag = "MTV"
     approved_image_hosts = ("imgbox", "imgbb")
+    image_host_policy = ImageHostPolicy({"ibb.co": "imgbb", "imgbox.com": "imgbox"}, approved_image_hosts)
     banned_groups = (
         "[Oj]",
         "3LTON",
@@ -107,21 +108,6 @@ class MoreThanTV:
     async def async_json_dumps(self, obj: Any) -> str:
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, json.dumps, obj)
-
-    async def check_image_hosts(self, meta: Meta) -> None:
-        url_host_mapping = {
-            "ibb.co": "imgbb",
-            "imgbox.com": "imgbox",
-        }
-
-        await self.rehost_images_manager.check_hosts(
-            meta,
-            self.tracker,
-            url_host_mapping=url_host_mapping,
-            img_host_index=1,
-            approved_image_hosts=self.approved_image_hosts,
-        )
-        return
 
     async def upload(self, meta: Meta) -> bool | None:
         common = Common(config=self.config)

--- a/src/trackers/passthepopcorn.py
+++ b/src/trackers/passthepopcorn.py
@@ -24,11 +24,12 @@ from src.cookie_auth import CookieValidator
 from src.exceptions import *  # noqa F403
 from src.exceptions import UploadError
 from src.meta import Meta
-from src.rehostimages import RehostImagesManager
+from src.rehostimages import ImageHostPolicy, RehostImagesManager
 from src.screenshot_manifest import files as manifest_files
 from src.takescreens import TakeScreensManager
 from src.temp_paths import posters_dir, screenshots_dir
 from src.torrentcreate import TorrentCreator
+from src.tracker_images import get_tracker_image_collection
 from src.trackers.common import Common
 from src.uploadscreens import UploadScreensManager
 
@@ -80,6 +81,7 @@ class PassThePopcorn:
         "WORLD",
     )
     approved_image_hosts = ("pixhost",)
+    image_host_policy = ImageHostPolicy({"pixhost.to": "pixhost"}, approved_image_hosts)
     sub_lang_map: ClassVar[dict[tuple[str, ...], int]] = {
         ("Arabic", "ara", "ar"): 22,
         ("Brazilian Portuguese", "Brazilian", "Portuguese-BR", "pt-br", "pt-BR"): 49,
@@ -822,20 +824,6 @@ class PassThePopcorn:
         desc = desc.replace("[ol]", "").replace("[/ol]", "")
         return re.sub(r"\[img=[^\]]+\]", "[img]", desc)
 
-    async def check_image_hosts(self, meta: Meta) -> None:
-        url_host_mapping = {
-            "pixhost.to": "pixhost",
-        }
-
-        await self.rehost_images_manager.check_hosts(
-            meta,
-            self.tracker,
-            url_host_mapping=url_host_mapping,
-            img_host_index=1,
-            approved_image_hosts=self.approved_image_hosts,
-        )
-        return
-
     async def edit_desc(self, meta: Meta) -> None:
         async with aiofiles.open(f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/DESCRIPTION.txt", encoding="utf-8") as base_file:
             base = await base_file.read()
@@ -853,7 +841,7 @@ class PassThePopcorn:
             multi_screens = 2
             logger.info(f"{self.tracker}: [yellow]requires at least 2 screenshots for multi disc/file content, overriding config")
 
-        image_list_value: Any = (meta.PTP_images_key if "PTP_images_key" in meta else meta.image_list) if not meta.skip_imghost_upload else []
+        image_list_value: Any = get_tracker_image_collection(meta, self.tracker, "screenshots") if not meta.skip_imghost_upload else []
         image_list = cast(list[dict[str, Any]], image_list_value) if isinstance(image_list_value, list) else []
         images: list[dict[str, Any]] = image_list
 

--- a/src/trackers/tvchaosuk.py
+++ b/src/trackers/tvchaosuk.py
@@ -18,7 +18,8 @@ from cogs.redaction import Redaction
 from src.bbcode import BBCODE
 from src.console import logger
 from src.meta import Meta
-from src.rehostimages import RehostImagesManager
+from src.rehostimages import ImageHostPolicy, RehostImagesManager
+from src.tracker_images import get_tracker_image_collection
 from src.trackers.common import Common
 
 Config = dict[str, Any]
@@ -39,6 +40,16 @@ class TVChaosUK:
     signature = ""
     banned_groups = ()
     approved_image_hosts = ("imgbb", "imgbox", "pixhost", "bam", "onlyimage")
+    image_host_policy = ImageHostPolicy(
+        {
+            "ibb.co": "imgbb",
+            "imgbox.com": "imgbox",
+            "pixhost.to": "pixhost",
+            "imagebam.com": "bam",
+            "onlyimage.org": "onlyimage",
+        },
+        approved_image_hosts,
+    )
     upload_url = f"{base_url}/api/torrents/upload"
     search_url = f"{base_url}/api/torrents/filter"
     torrent_url = f"{base_url}/torrents/"
@@ -435,22 +446,10 @@ class TVChaosUK:
 
         return await asyncio.to_thread(_read)
 
-    async def check_image_hosts(self, meta: Meta) -> None:
-        url_host_mapping = {
-            "ibb.co": "imgbb",
-            "imgbox.com": "imgbox",
-            "pixhost.to": "pixhost",
-            "imagebam.com": "bam",
-            "onlyimage.org": "onlyimage",
-        }
-
-        await self.rehost_images_manager.check_hosts(meta, self.tracker, url_host_mapping=url_host_mapping, img_host_index=1, approved_image_hosts=self.approved_image_hosts)
-        return
-
     async def upload(self, meta: Meta) -> bool | None:
         common = Common(config=self.config)
 
-        raw_images = meta.TVC_images_key if meta.TVC_images_key is not None else meta.get("image_list", [])
+        raw_images = get_tracker_image_collection(meta, self.tracker, "screenshots")
         image_list_seq: list[Any]
         if isinstance(raw_images, list):
             image_list_seq = raw_images

--- a/src/uploadscreens.py
+++ b/src/uploadscreens.py
@@ -856,11 +856,16 @@ async def _upload_screens(
         for _index, upload in successfully_uploaded:
             raw_url = upload["raw_url"]
             new_image = {"img_url": upload["img_url"], "raw_url": raw_url, "web_url": upload["web_url"]}
+            # Custom uploads (disc menus and spectrograms) are not added to
+            # ``meta.image_list``.  Keep their local source so a tracker that
+            # rejects the initially selected host can re-upload the same asset.
+            local_file_path = upload.get("local_file_path")
+            if local_file_path:
+                new_image["local_file_path"] = str(local_file_path)
             new_images.append(new_image)
             if not using_custom_img_list and raw_url not in {img["raw_url"] for img in image_list}:
                 logger.debug(f"[blue]Adding {raw_url} to image_list")
                 image_list.append(new_image)
-                local_file_path = upload.get("local_file_path")
                 if local_file_path:
                     image_size = Path(local_file_path).stat().st_size
                     meta.image_sizes[raw_url] = image_size

--- a/tests/test_cathoderaytube.py
+++ b/tests/test_cathoderaytube.py
@@ -49,6 +49,7 @@ def meta(**overrides):
         "image_list": [],
         "menu_images": [],
         "spectrograms_images": [],
+        "tracker_image_collections": {},
         "screens": 6,
         "base_dir": ".",
         "uuid": "test",
@@ -103,8 +104,8 @@ def test_formats_titles_to_crt_conventions():
 def test_uses_the_image_hosts_approved_by_crt():
     site = tracker()
     assert site.approved_image_hosts == ("ptpimg", "catbox", "imgbb", "postimages", "freeimage", "imgbox")  # noqa: S101
-    assert site.image_host_mapping["catbox.moe"] == "catbox"  # noqa: S101
-    assert site.image_host_mapping["postimg.cc"] == "postimages"  # noqa: S101
+    assert site.image_host_policy.url_host_mapping["catbox.moe"] == "catbox"  # noqa: S101
+    assert site.image_host_policy.url_host_mapping["postimg.cc"] == "postimages"  # noqa: S101
 
 
 def test_builds_common_category_tags_from_meta():

--- a/tests/test_rehostimages.py
+++ b/tests/test_rehostimages.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock
 
 from src.meta import Meta
 from src.rehostimages import ImageHostPolicy, RehostImagesManager
-from src.tracker_images import get_tracker_image_collection
+from src.tracker_images import get_tracker_image_collection, has_tracker_image_collection
 
 
 def test_rehosts_menu_and_spectrogram_images_without_touching_main_screens(tmp_path: Path):
@@ -33,6 +33,8 @@ def test_rehosts_menu_and_spectrogram_images_without_touching_main_screens(tmp_p
         spectrograms_images=[{"raw_url": "https://lostimg.cc/spectrogram.png", "local_file_path": str(spectrogram_source)}],
     )
 
+    assert not has_tracker_image_collection(meta, "TEST", "screenshots")
+
     result, _, _ = asyncio.run(
         manager.check_policy(
             meta,
@@ -46,6 +48,10 @@ def test_rehosts_menu_and_spectrogram_images_without_touching_main_screens(tmp_p
     assert meta.menu_images[0]["raw_url"] == "https://lostimg.cc/menu.png"
     assert meta.spectrograms_images[0]["raw_url"] == "https://lostimg.cc/spectrogram.png"
     tracker_images = meta.tracker_image_collections["TEST"]
+    assert has_tracker_image_collection(meta, "TEST", "screenshots")
+    assert tracker_images["screenshots"] == meta.image_list
+    assert tracker_images["screenshots"] is not meta.image_list
+    assert tracker_images["screenshots"][0] is not meta.image_list[0]
     assert tracker_images["menu_images"][0]["raw_url"] == "https://i.ibb.co/menu.png"
     assert tracker_images["menu_images"][0]["local_file_path"] == str(menu_source)
     assert tracker_images["spectrograms_images"][0]["raw_url"] == "https://i.ibb.co/spectrogram.png"

--- a/tests/test_rehostimages.py
+++ b/tests/test_rehostimages.py
@@ -1,0 +1,59 @@
+"""Regression coverage for tracker-specific image-host reuploads."""
+
+# ruff: noqa: S101
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+from src.meta import Meta
+from src.rehostimages import ImageHostPolicy, RehostImagesManager
+from src.tracker_images import get_tracker_image_collection
+
+
+def test_rehosts_menu_and_spectrogram_images_without_touching_main_screens(tmp_path: Path):
+    menu_source = tmp_path / "menu.png"
+    spectrogram_source = tmp_path / "spectrogram.png"
+    menu_source.write_bytes(b"menu")
+    spectrogram_source.write_bytes(b"spectrogram")
+
+    manager = RehostImagesManager({"DEFAULT": {"img_host_1": "imgbb"}})
+    manager.uploadscreens_manager.upload_screens = AsyncMock(
+        side_effect=[
+            ([{"img_url": "https://i.ibb.co/menu.png", "raw_url": "https://i.ibb.co/menu.png", "web_url": "https://ibb.co/menu"}], 1),
+            ([{"img_url": "https://i.ibb.co/spectrogram.png", "raw_url": "https://i.ibb.co/spectrogram.png", "web_url": "https://ibb.co/spectrogram"}], 1),
+        ]
+    )
+    meta = Meta(
+        base_dir=str(tmp_path),
+        uuid="release",
+        imghost="lostimg",
+        image_list=[{"raw_url": "https://i.ibb.co/main.png"}],
+        menu_images=[{"raw_url": "https://lostimg.cc/menu.png", "local_file_path": str(menu_source)}],
+        spectrograms_images=[{"raw_url": "https://lostimg.cc/spectrogram.png", "local_file_path": str(spectrogram_source)}],
+    )
+
+    result, _, _ = asyncio.run(
+        manager.check_policy(
+            meta,
+            "TEST",
+            ImageHostPolicy({"i.ibb.co": "imgbb", "lostimg.cc": "lostimg"}, ("imgbb",)),
+        )
+    )
+
+    assert result == meta.image_list
+    assert meta.image_list == [{"raw_url": "https://i.ibb.co/main.png"}]
+    assert meta.menu_images[0]["raw_url"] == "https://lostimg.cc/menu.png"
+    assert meta.spectrograms_images[0]["raw_url"] == "https://lostimg.cc/spectrogram.png"
+    tracker_images = meta.tracker_image_collections["TEST"]
+    assert tracker_images["menu_images"][0]["raw_url"] == "https://i.ibb.co/menu.png"
+    assert tracker_images["menu_images"][0]["local_file_path"] == str(menu_source)
+    assert tracker_images["spectrograms_images"][0]["raw_url"] == "https://i.ibb.co/spectrogram.png"
+    assert tracker_images["spectrograms_images"][0]["local_file_path"] == str(spectrogram_source)
+    assert get_tracker_image_collection(meta, "TEST", "menu_images") == tracker_images["menu_images"]
+    assert get_tracker_image_collection(meta, "OTHER", "menu_images") == meta.menu_images
+    assert meta.imghost == "lostimg"
+
+    calls = manager.uploadscreens_manager.upload_screens.await_args_list
+    assert [call.args[5] for call in calls] == [[str(menu_source)], [str(spectrogram_source)]]
+    assert all(call.kwargs["allowed_hosts"] == ["imgbb"] for call in calls)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tracker-specific image collections for screenshots, menu images, and spectrograms.
  * Added centralized image-host policies for supported trackers.
  * Rehosting now handles tracker-specific image types while preserving shared image metadata.
* **Bug Fixes**
  * Improved image uploads by preserving local file paths, including custom uploads.
  * Updated description generation and screenshot handling to use the correct tracker-specific images.
* **Tests**
  * Added coverage for tracker-specific image rehosting and metadata preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->