### PR TITLE
fix(screenshots): reuse registered main screenshots across title changes and upload steps

### DIFF
--- a/src/get_desc.py
+++ b/src/get_desc.py
@@ -1786,6 +1786,7 @@ class DescriptionBuilder:
                                     meta,
                                     multi_screens,
                                     True,
+                                    capture_group=f"FILE_{i}",
                                 )
                                 await asyncio.sleep(0.1)
                             except Exception as e:

--- a/src/prep.py
+++ b/src/prep.py
@@ -284,6 +284,7 @@ class Prep:
                     meta,
                     manual_frames=meta.manual_frames or "",
                     cleanup_after_capture=False,
+                    capture_group="main",
                 )
             logger.debug("[cyan]Early screenshot generation completed.[/cyan]")
         except asyncio.CancelledError:

--- a/src/rehostimages.py
+++ b/src/rehostimages.py
@@ -604,7 +604,9 @@ async def _handle_image_upload(
 
         try:
             if meta.is_disc == "BDMV":
-                await takescreens_manager.disc_screenshots(meta, filename, meta.bdinfo, folder_id, base_dir, meta.vapoursynth, [], meta.ffdebug, needed_screenshots, True)
+                await takescreens_manager.disc_screenshots(
+                    meta, filename, meta.bdinfo, folder_id, base_dir, meta.vapoursynth, [], meta.ffdebug, needed_screenshots, True, capture_group="main"
+                )
             elif meta.is_disc == "DVD":
                 await takescreens_manager.dvd_screenshots(meta, disc_num=0, retry_cap=True)
             else:
@@ -626,13 +628,7 @@ async def _handle_image_upload(
             if meta.is_disc == "DVD":
                 new_screens = await asyncio.to_thread(lambda: [str(p) for p in screenshots_dir(meta.base_dir, meta.uuid).glob(f"{glob.escape(meta.discs[0]['name'])}-*.png")])
             else:
-                # Use a more generic pattern to find any PNG files that aren't already in all_screenshots
-                new_screens = await asyncio.to_thread(lambda: [str(p) for p in screenshot_path.glob("*.png")])
-                indexed_pattern = re.compile(r".*-\d+\.png$")
-                new_screens = [s for s in new_screens if indexed_pattern.match(Path(s).name)]
-
-                # Filter out files we already have
-                new_screens = [screen for screen in new_screens if screen not in all_screenshots]
+                new_screens = [str(path) for path in manifest_files(base_dir, folder_id, "main")]
 
             # Add any new screenshots to our list (only those not already in all_screenshots)
             if new_screens and meta.debug:

--- a/src/rehostimages.py
+++ b/src/rehostimages.py
@@ -15,6 +15,7 @@ from aiofiles import os as aio_os
 
 from src.console import logger
 from src.meta import Meta
+from src.screenshot_manifest import files as manifest_files
 from src.takescreens import TakeScreensManager
 from src.temp_paths import covers_dir, menu_screenshots_dir, screenshots_dir, spectrograms_dir
 from src.tracker_images import (
@@ -481,7 +482,7 @@ async def _handle_image_upload(
 
     screenshot_path = screenshots_dir(base_dir, folder_id)
     logger.debug(f"[yellow]Searching for screenshots in {screenshot_path}...")
-    all_screenshots: list[str] = []
+    all_screenshots: list[str] = [str(path) for path in manifest_files(base_dir, folder_id, "main")]
 
     # First check if there are any saved screenshots matching those in the image_list
     if meta.image_list and isinstance(meta.image_list, list):
@@ -617,6 +618,7 @@ async def _handle_image_upload(
                         needed_screenshots,
                         True,
                         "",
+                        capture_group="main",
                     )
                 else:
                     logger.info("[red]No valid path available for screenshot generation.[/red]")

--- a/src/screenshot_manifest.py
+++ b/src/screenshot_manifest.py
@@ -83,6 +83,23 @@ def files(base_dir: str | Path, release_id: str, group: str | None = None) -> li
     return sorted(result, key=lambda path: path.name)
 
 
+def clear_group(base_dir: str | Path, release_id: str, group: str) -> None:
+    """Delete the active files and manifest entries for one capture group."""
+    with _lock(base_dir, release_id):
+        manifest = _load(base_dir, release_id)
+        entries = manifest.get("screenshots")
+        if not isinstance(entries, dict):
+            return
+        directory = screenshots_dir(base_dir, release_id)
+        for screenshot_id, value in list(entries.items()):
+            if not isinstance(value, dict) or value.get("group") != group:
+                continue
+            path = directory / str(value.get("file", f"{screenshot_id}.png"))
+            path.unlink(missing_ok=True)
+            entries.pop(screenshot_id)
+        _save(base_dir, release_id, manifest)
+
+
 def group_for(base_dir: str | Path, release_id: str, path: Path) -> str:
     """Return the logical capture group for a local screenshot."""
     entries = _load(base_dir, release_id).get("screenshots", {})

--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -27,6 +27,7 @@ from data import config as data_config
 from src.cleanup import cleanup_manager
 from src.console import logger
 from src.meta import Meta
+from src.screenshot_manifest import clear_group as clear_screenshot_group
 from src.screenshot_manifest import files as manifest_files
 from src.screenshot_manifest import register as register_screenshots
 from src.temp_paths import posters_dir, screenshots_dir
@@ -1517,16 +1518,24 @@ async def screenshots(
         return None
 
     group = capture_group or "main"
-    requested_screens = num_screens or (len([frame for frame in manual_frames.split(",") if frame.strip()]) if isinstance(manual_frames, str) and manual_frames else screens)
+    if num_screens:
+        requested_screens = num_screens
+    elif isinstance(manual_frames, str):
+        requested_screens = len([frame for frame in manual_frames.split(",") if frame.strip()]) if manual_frames else screens
+    elif manual_frames:
+        requested_screens = len(manual_frames)
+    else:
+        requested_screens = screens
+    if meta.retake:
+        clear_screenshot_group(base_dir, folder_id, group)
+    registered_screens = manifest_files(base_dir, folder_id, group)
     # Metadata enrichment can alter the display title (for example, by adding
     # punctuation). Reuse the logical capture group rather than deriving
     # identity from a display-derived filename. This must happen before reading
     # MediaInfo so an already-complete early capture is a true no-op.
-    if not force_screenshots and not meta.retake:
-        registered_screens = manifest_files(base_dir, folder_id, group)
-        if len(registered_screens) >= requested_screens:
-            logger.debug(f"[yellow]Reusing {len(registered_screens)} registered screenshots from group '{group}'.[/yellow]")
-            return [str(screen) for screen in registered_screens[:requested_screens]]
+    if not force_screenshots and not meta.retake and len(registered_screens) >= requested_screens:
+        logger.debug(f"[yellow]Reusing {len(registered_screens)} registered screenshots from group '{group}'.[/yellow]")
+        return [str(screen) for screen in registered_screens[:requested_screens]]
 
     try:
         mi_text = await asyncio.to_thread(Path(f"{base_dir}{'/' + 'tmp' + '/'}{folder_id}/MediaInfo.json").read_text, encoding="utf-8")
@@ -1599,8 +1608,10 @@ async def screenshots(
 
     if num_screens <= 0:
         num_screens = screens - len(existing_images)
+    if not force_screenshots and not meta.retake:
+        num_screens = max(0, num_screens - len(registered_screens))
     if num_screens <= 0:
-        return None
+        return [str(screen) for screen in registered_screens] or None
 
     sanitized_filename = await sanitize_filename(filename)
     screenshot_dir = screenshots_dir(base_dir, folder_id)
@@ -1917,8 +1928,10 @@ async def screenshots(
         unit="frames",
     )
 
-    registered_screens = register_screenshots(base_dir, folder_id, valid_results, group) if valid_results else []
-    return [str(screen) for screen in registered_screens] or None
+    new_screens = register_screenshots(base_dir, folder_id, valid_results, group) if valid_results else []
+    if not force_screenshots and not meta.retake:
+        return [str(screen) for screen in manifest_files(base_dir, folder_id, group)[:requested_screens]]
+    return [str(screen) for screen in new_screens] or None
 
 
 async def capture_screenshot(args: tuple[int, str, float, str, float, float, float, float, str, bool, Meta]) -> tuple[int, str | None] | None:

--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -1485,6 +1485,7 @@ async def screenshots(
     force_screenshots: bool = False,
     manual_frames: str | list[int] | list[str] = "",
     cleanup_after_capture: bool = True,
+    capture_group: str | None = None,
 ) -> list[str] | None:
     if meta.category == "GAME":
         return []
@@ -1514,6 +1515,18 @@ async def screenshots(
     if len(existing_images) >= cutoff and not force_screenshots:
         logger.info(f"[yellow]There are already at least {cutoff} images in the image list. Skipping additional screenshots.")
         return None
+
+    group = capture_group or "main"
+    requested_screens = num_screens or (len([frame for frame in manual_frames.split(",") if frame.strip()]) if isinstance(manual_frames, str) and manual_frames else screens)
+    # Metadata enrichment can alter the display title (for example, by adding
+    # punctuation). Reuse the logical capture group rather than deriving
+    # identity from a display-derived filename. This must happen before reading
+    # MediaInfo so an already-complete early capture is a true no-op.
+    if not force_screenshots and not meta.retake:
+        registered_screens = manifest_files(base_dir, folder_id, group)
+        if len(registered_screens) >= requested_screens:
+            logger.debug(f"[yellow]Reusing {len(registered_screens)} registered screenshots from group '{group}'.[/yellow]")
+            return [str(screen) for screen in registered_screens[:requested_screens]]
 
     try:
         mi_text = await asyncio.to_thread(Path(f"{base_dir}{'/' + 'tmp' + '/'}{folder_id}/MediaInfo.json").read_text, encoding="utf-8")
@@ -1904,7 +1917,8 @@ async def screenshots(
         unit="frames",
     )
 
-    return valid_results if valid_results else None
+    registered_screens = register_screenshots(base_dir, folder_id, valid_results, group) if valid_results else []
+    return [str(screen) for screen in registered_screens] or None
 
 
 async def capture_screenshot(args: tuple[int, str, float, str, float, float, float, float, str, bool, Meta]) -> tuple[int, str | None] | None:
@@ -2492,8 +2506,9 @@ class TakeScreensManager:
         force_screenshots: bool = False,
         manual_frames: str | list[int] | list[str] = "",
         cleanup_after_capture: bool = True,
+        capture_group: str | None = None,
     ) -> list[str] | None:
-        return await screenshots(path, filename, folder_id, base_dir, meta, num_screens, force_screenshots, manual_frames, cleanup_after_capture)
+        return await screenshots(path, filename, folder_id, base_dir, meta, num_screens, force_screenshots, manual_frames, cleanup_after_capture, capture_group)
 
     async def prepare_book_cover(self, path: str, folder_id: str, base_dir: str, meta: Meta) -> str | None:
         return await prepare_book_cover(path, folder_id, base_dir, meta)

--- a/src/trackers/passthepopcorn.py
+++ b/src/trackers/passthepopcorn.py
@@ -1247,7 +1247,9 @@ class PassThePopcorn:
                         new_screens = [f.name for f in manifest_files(meta.base_dir, meta.uuid, f"FILE_{i}")]
                         if not new_screens:
                             try:
-                                await self.takescreens_manager.screenshots(file, f"FILE_{i}", meta.uuid, meta.base_dir, meta, multi_screens, True, "")
+                                await self.takescreens_manager.screenshots(
+                                    file, f"FILE_{i}", meta.uuid, meta.base_dir, meta, multi_screens, True, "", capture_group=f"FILE_{i}"
+                                )
                             except Exception as e:
                                 logger.info(f"{self.tracker}: Error during generic screenshot capture: {e}", extra={"markup": False})
                         new_screens = [f.name for f in manifest_files(meta.base_dir, meta.uuid, f"FILE_{i}")]

--- a/src/uploadscreens.py
+++ b/src/uploadscreens.py
@@ -16,6 +16,7 @@ import pyimgbox
 
 from src.console import logger
 from src.meta import Meta
+from src.screenshot_manifest import files as manifest_files
 from src.temp_paths import screenshots_dir
 
 type ImageDict = dict[str, Any]
@@ -656,24 +657,28 @@ async def _upload_screens(
         existing_images: list[ImageDict] = []
         existing_count = 0
     else:
-        image_patterns = ["*.png", ".[!.]*.png"]
-        image_glob: list[str] = []
-        for pattern in image_patterns:
-            glob_results = await asyncio.to_thread(lambda p=pattern: [str(path.relative_to(Path.cwd())) for path in Path.cwd().glob(p)])
-            image_glob.extend(glob_results)
+        registered_screens = manifest_files(meta.base_dir, meta.uuid, "main")
+        if registered_screens:
+            image_glob = [str(path.relative_to(Path.cwd())) for path in registered_screens]
+        else:
+            image_patterns = ["*.png", ".[!.]*.png"]
+            image_glob = []
+            for pattern in image_patterns:
+                glob_results = await asyncio.to_thread(lambda p=pattern: [str(path.relative_to(Path.cwd())) for path in Path.cwd().glob(p)])
+                image_glob.extend(glob_results)
 
-        unwanted_patterns = ["FILE*", "PLAYLIST*", "POSTER*"]
-        unwanted_files: set[str] = set()
-        for pattern in unwanted_patterns:
-            glob_results = await asyncio.to_thread(lambda p=pattern: [str(path.relative_to(Path.cwd())) for path in Path.cwd().glob(p)])
-            unwanted_files.update(glob_results)
-            if pattern.startswith("FILE") or pattern.startswith("PLAYLIST") or pattern.startswith("POSTER"):
-                hidden_pattern = "." + pattern
-                hidden_glob_results = await asyncio.to_thread(lambda hp=hidden_pattern: [str(path.relative_to(Path.cwd())) for path in Path.cwd().glob(hp)])
-                unwanted_files.update(hidden_glob_results)
+            unwanted_patterns = ["FILE*", "PLAYLIST*", "POSTER*"]
+            unwanted_files: set[str] = set()
+            for pattern in unwanted_patterns:
+                glob_results = await asyncio.to_thread(lambda p=pattern: [str(path.relative_to(Path.cwd())) for path in Path.cwd().glob(p)])
+                unwanted_files.update(glob_results)
+                if pattern.startswith("FILE") or pattern.startswith("PLAYLIST") or pattern.startswith("POSTER"):
+                    hidden_pattern = "." + pattern
+                    hidden_glob_results = await asyncio.to_thread(lambda hp=hidden_pattern: [str(path.relative_to(Path.cwd())) for path in Path.cwd().glob(hp)])
+                    unwanted_files.update(hidden_glob_results)
 
-        image_glob = [file for file in image_glob if file not in unwanted_files]
-        image_glob = list(set(image_glob))
+            image_glob = [file for file in image_glob if file not in unwanted_files]
+            image_glob = list(set(image_glob))
 
         # Filter out menu screenshots from normal screenshot upload
         menu_basenames = set()

--- a/tests/test_prep_early_screenshots.py
+++ b/tests/test_prep_early_screenshots.py
@@ -59,12 +59,50 @@ def test_registered_main_screenshots_are_reused_when_title_changes(tmp_path: Pat
         image.write_bytes(b"image")
         original_paths.append(image)
     registered = register(tmp_path, release_id, original_paths, "main")
-    meta = Meta(category="MOVIE", base_dir=str(tmp_path), uuid=release_id, screens=2, imghost="imgbb")
+    meta = Meta(category="MOVIE", base_dir=str(tmp_path), uuid=release_id, screens=6, imghost="imgbb")
 
     with patch("src.takescreens.get_image_host", new=AsyncMock(return_value="imgbb")):
-        result = asyncio.run(screenshots("unused.mkv", "Punctuated, Title", release_id, str(tmp_path), meta))
+        result = asyncio.run(screenshots("unused.mkv", "Punctuated, Title", release_id, str(tmp_path), meta, manual_frames=[100, 200]))
 
     assert set(result or []) == {str(path) for path in registered}
+
+
+def test_partial_registered_group_captures_only_missing_screenshots(tmp_path: Path) -> None:
+    release_id = "release"
+    release_dir = tmp_path / "tmp" / release_id
+    screenshot_dir = release_dir / "screenshots"
+    screenshot_dir.mkdir(parents=True)
+    (release_dir / "MediaInfo.json").write_text(
+        '{"media": {"track": [{"Duration": "100"}, {"Duration": "100", "Width": "1920", "Height": "1080", "PixelAspectRatio": "1", "DisplayAspectRatio": "1.777", "FrameRate": "24"}]}}',
+        encoding="utf-8",
+    )
+    existing = []
+    for index in range(2):
+        image = screenshot_dir / f"existing-{index}.png"
+        image.write_bytes(b"image")
+        existing.append(image)
+    register(tmp_path, release_id, existing, "main")
+    meta = Meta(category="MOVIE", base_dir=str(tmp_path), uuid=release_id, screens=3, imghost="imgbb")
+    capture_calls: list[object] = []
+
+    async def capture_stub(args: tuple[object, ...]):
+        capture_calls.append(args)
+        output = Path(str(args[3]))
+        output.write_bytes(b"image")
+        return args[0], str(output)
+
+    async def no_op() -> None:
+        return None
+
+    with (
+        patch("src.takescreens.get_image_host", new=AsyncMock(return_value="imgbb")),
+        patch("src.takescreens.capture_screenshot", new=capture_stub),
+        patch("src.takescreens.kill_all_child_processes", new=no_op),
+    ):
+        result = asyncio.run(screenshots("unused.mkv", "Punctuated, Title", release_id, str(tmp_path), meta, manual_frames=[100, 200, 300]))
+
+    assert len(capture_calls) == 1
+    assert len(result or []) == 3
 
 
 def test_upload_uses_only_registered_main_screenshots(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_prep_early_screenshots.py
+++ b/tests/test_prep_early_screenshots.py
@@ -1,9 +1,14 @@
 # ruff: noqa: S101
 
 import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
 from src.meta import Meta
 from src.prep import Prep
+from src.screenshot_manifest import register
+from src.takescreens import screenshots
+from src.uploadscreens import _upload_screens
 
 
 class _TakeScreens:
@@ -41,6 +46,51 @@ def test_early_screenshots_remain_enabled_without_description_images() -> None:
     asyncio.run(prep._capture_early_screenshots(meta, "Release", "C:/media/Release.mkv", {}))
 
     assert len(screenshot_spy.calls) == 1
+    assert screenshot_spy.calls[0][1]["capture_group"] == "main"
+
+
+def test_registered_main_screenshots_are_reused_when_title_changes(tmp_path: Path) -> None:
+    release_id = "release"
+    screenshot_dir = tmp_path / "tmp" / release_id / "screenshots"
+    screenshot_dir.mkdir(parents=True)
+    original_paths = []
+    for index in range(2):
+        image = screenshot_dir / f"unpunctuated-title-{index}.png"
+        image.write_bytes(b"image")
+        original_paths.append(image)
+    registered = register(tmp_path, release_id, original_paths, "main")
+    meta = Meta(category="MOVIE", base_dir=str(tmp_path), uuid=release_id, screens=2, imghost="imgbb")
+
+    with patch("src.takescreens.get_image_host", new=AsyncMock(return_value="imgbb")):
+        result = asyncio.run(screenshots("unused.mkv", "Punctuated, Title", release_id, str(tmp_path), meta))
+
+    assert set(result or []) == {str(path) for path in registered}
+
+
+def test_upload_uses_only_registered_main_screenshots(tmp_path: Path, monkeypatch) -> None:
+    release_id = "release"
+    screenshot_dir = tmp_path / "tmp" / release_id / "screenshots"
+    screenshot_dir.mkdir(parents=True)
+    main_source = screenshot_dir / "main.png"
+    file_source = screenshot_dir / "file.png"
+    main_source.write_bytes(b"main")
+    file_source.write_bytes(b"file")
+    main_screen = register(tmp_path, release_id, [main_source], "main")[0]
+    register(tmp_path, release_id, [file_source], "FILE_1")
+    meta = Meta(base_dir=str(tmp_path), uuid=release_id, imghost="imgbb", image_list=[])
+    calls: list[str] = []
+
+    async def upload_stub(args: list[object]) -> dict[str, str]:
+        calls.append(str(args[0]))
+        return {"status": "success", "img_url": "https://images.example/main.png", "raw_url": "https://images.example/main.png", "web_url": "https://images.example/main.png"}
+
+    config = {"DEFAULT": {"img_host_1": "imgbb"}, "TRACKERS": {}}
+    monkeypatch.chdir(screenshot_dir)
+    with patch("src.uploadscreens.upload_image_task", new=upload_stub):
+        _, uploaded_count = asyncio.run(_upload_screens(config, meta, 1, 1, 0, 1, [], {}))
+
+    assert uploaded_count == 1
+    assert calls == [main_screen.name]
 
 
 def test_early_bdmv_capture_includes_alternate_playlists() -> None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added organized screenshot capture groups for primary content and additional files.
  - Added screenshot manifest support to reliably discover and reuse generated screenshots.
  - Reuses existing screenshots when suitable, reducing unnecessary captures and processing.

- **Bug Fixes**
  - Improved screenshot selection during uploads to ensure only the intended primary screenshots are included.
  - Improved screenshot handling when content titles change or multiple files are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->