### PR TITLE
fix: classify audiobook folders as BOOK category instead of MUSIC

### DIFF
--- a/src/audio_classifier.py
+++ b/src/audio_classifier.py
@@ -1,0 +1,397 @@
+# Upload Assistant © 2025 Audionut & wastaken7 — Licensed under UAPL v1.0
+"""Audio category classifier for distinguishing MUSIC vs AUDIOBOOK releases."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import mutagen
+
+from src.book_prep import BOOK_EXTENSIONS
+
+AUDIOBOOK_CONTAINER_EXTENSIONS = frozenset({".m4b", ".aax", ".aaxc"})
+SHARED_AUDIO_EXTENSIONS = frozenset({".mp3", ".flac", ".m4a", ".aac", ".ac3", ".dts", ".wav", ".aiff", ".alac", ".ogg", ".opus", ".ape", ".wv", ".wma"})
+
+SPOKEN_GENRES = frozenset(
+    {
+        "audiobook",
+        "audio book",
+        "audiobooks",
+        "audio books",
+        "spoken word",
+        "spokenword",
+        "speech",
+        "spoken",
+        "audio drama",
+        "podcast",
+        "radio play",
+        "story",
+        "nonfiction",
+        "fiction",
+        "novel",
+        "memoir",
+        "biography",
+        "lecture",
+        "talk",
+    }
+)
+
+MUSIC_GENRES = frozenset(
+    {
+        "rock",
+        "pop",
+        "jazz",
+        "metal",
+        "electronic",
+        "classical",
+        "hip hop",
+        "hip-hop",
+        "rap",
+        "indie",
+        "soundtrack",
+        "folk",
+        "blues",
+        "reggae",
+        "country",
+        "ambient",
+        "punk",
+        "house",
+        "techno",
+        "trance",
+        "disco",
+        "funk",
+        "soul",
+        "r&b",
+        "r & b",
+        "alternative",
+        "dance",
+        "industrial",
+        "instrumental",
+        "heavy metal",
+        "pop rock",
+        "hard rock",
+        "synthpop",
+        "lo-fi",
+        "ska",
+        "grunge",
+        "gospel",
+        "opera",
+        "symphony",
+        "bluegrass",
+        "new age",
+    }
+)
+
+AUDIOBOOK_FILENAME_REGEX = re.compile(
+    r"(?i)\b(?:chapter|part|pt|section|act|bk|book)\s*\d+|\b(?:part|ch|chapter)\d+\b|\btrack\s*\d+\s*[-_]\s*chapter\b|\b(?:audiobook|unabridged|abridged|read by|narrated by)\b"
+)
+
+MUSIC_FILENAME_REGEX = re.compile(r"^\s*\d{1,3}\s*[-._]\s*(?![cC]hapter|[pP]art|[bB]ook)\w+")
+
+
+@dataclass
+class AudioCategoryResult:
+    category: str  # "BOOK", "MUSIC", "AMBIGUOUS", or "NONE"
+    is_audiobook: bool = False
+    confidence: float = 0.0
+    evidence: list[str] = field(default_factory=list)
+
+
+def _inspect_audio_file(filepath: Path) -> dict[str, Any]:
+    info_dict: dict[str, Any] = {
+        "channels": 0,
+        "bitrate": 0,
+        "sample_rate": 0,
+        "length": 0.0,
+        "genres": [],
+        "title": "",
+        "artist": "",
+        "album": "",
+        "albumartist": "",
+        "narrator": "",
+        "author": "",
+        "publisher": "",
+        "isbn": "",
+        "asin": "",
+        "has_chapters": False,
+        "has_musicbrainz": False,
+        "has_discogs": False,
+        "has_catalog_no": False,
+        "raw_tag_text": "",
+    }
+
+    with contextlib.suppress(Exception):
+        easy_audio = mutagen.File(str(filepath), easy=True)
+        if easy_audio and easy_audio.tags:
+            for key in ("genre",):
+                vals = easy_audio.tags.get(key, [])
+                info_dict["genres"].extend([str(v).strip() for v in vals if v])
+            for key in ("title", "artist", "album", "albumartist"):
+                vals = easy_audio.tags.get(key, [])
+                if vals:
+                    info_dict[key] = str(vals[0]).strip()
+
+    with contextlib.suppress(Exception):
+        audio = mutagen.File(str(filepath))
+        if audio is not None:
+            if hasattr(audio, "info") and audio.info:
+                info_dict["channels"] = getattr(audio.info, "channels", 0) or 0
+                info_dict["bitrate"] = getattr(audio.info, "bitrate", 0) or 0
+                info_dict["sample_rate"] = getattr(audio.info, "sample_rate", 0) or 0
+                info_dict["length"] = getattr(audio.info, "length", 0.0) or 0.0
+
+            tags = getattr(audio, "tags", None)
+            if tags:
+                all_text_pieces: list[str] = []
+                if hasattr(tags, "keys"):
+                    for k in tags:
+                        k_str = str(k)
+                        k_lower = k_str.lower()
+                        if k_str.startswith("CHAP") or k_str.startswith("CTOC") or "chapter" in k_lower:
+                            info_dict["has_chapters"] = True
+
+                if hasattr(tags, "items"):
+                    for k, v in tags.items():
+                        k_str = str(k).lower()
+                        v_str = str(v)
+                        all_text_pieces.append(f"{k_str}={v_str}")
+
+                        if "narrator" in k_str or "read by" in k_str or "reader" in k_str:
+                            info_dict["narrator"] = v_str
+                        if "author" in k_str or "writer" in k_str:
+                            info_dict["author"] = v_str
+                        if "publisher" in k_str:
+                            info_dict["publisher"] = v_str
+                        if "isbn" in k_str:
+                            info_dict["isbn"] = v_str
+                        if "asin" in k_str:
+                            info_dict["asin"] = v_str
+                        if "musicbrainz" in k_str:
+                            info_dict["has_musicbrainz"] = True
+                        if "discogs" in k_str:
+                            info_dict["has_discogs"] = True
+                        if "catalognumber" in k_str or "catno" in k_str or "label" in k_str:
+                            info_dict["has_catalog_no"] = True
+                        if "genre" in k_str and not info_dict["genres"]:
+                            info_dict["genres"].append(v_str)
+
+                info_dict["raw_tag_text"] = " ".join(all_text_pieces).lower()
+                if "chapter00" in info_dict["raw_tag_text"] or "chapter01" in info_dict["raw_tag_text"]:
+                    info_dict["has_chapters"] = True
+
+    return info_dict
+
+
+async def detect_audio_category(_meta: Any, path: Path | str) -> AudioCategoryResult:
+    """Classify an audio directory or file as BOOK (audiobook), MUSIC, or AMBIGUOUS."""
+    path_obj = Path(path)
+    if not path_obj.exists():
+        return AudioCategoryResult(category="NONE")
+
+    all_files: list[Path] = []
+    if path_obj.is_dir():
+        for root, _, files in os.walk(path_obj):
+            all_files.extend(Path(root) / file for file in files)
+    else:
+        all_files = [path_obj]
+
+    video_extensions = {".mkv", ".mp4", ".ts", ".avi", ".m2ts"}
+    has_video = any(f.suffix.lower() in video_extensions for f in all_files)
+    if has_video:
+        return AudioCategoryResult(category="NONE", evidence=["Contains video files"])
+
+    ebook_extensions = BOOK_EXTENSIONS - {".txt", ".html", ".htm"}
+    has_ebook = any(f.suffix.lower() in ebook_extensions for f in all_files)
+    has_audiobook_container = any(f.suffix.lower() in AUDIOBOOK_CONTAINER_EXTENSIONS for f in all_files)
+
+    audio_files = [f for f in all_files if f.suffix.lower() in SHARED_AUDIO_EXTENSIONS or f.suffix.lower() in AUDIOBOOK_CONTAINER_EXTENSIONS]
+
+    if has_audiobook_container and not has_video:
+        exts = {f.suffix.lower() for f in all_files if f.suffix.lower() in AUDIOBOOK_CONTAINER_EXTENSIONS}
+        return AudioCategoryResult(
+            category="BOOK",
+            is_audiobook=True,
+            confidence=1.0,
+            evidence=[f"audiobook-specific container format ({', '.join(sorted(exts))})"],
+        )
+
+    if has_ebook and audio_files:
+        return AudioCategoryResult(
+            category="BOOK",
+            is_audiobook=True,
+            confidence=1.0,
+            evidence=["Directory contains both eBook and audio files"],
+        )
+
+    if has_ebook and not audio_files:
+        return AudioCategoryResult(
+            category="BOOK",
+            is_audiobook=False,
+            confidence=1.0,
+            evidence=["Directory contains eBook file"],
+        )
+
+    if not audio_files:
+        return AudioCategoryResult(category="NONE")
+
+    # Inspect shared audio files
+    book_evidence: list[str] = [f"{len(audio_files)} audio files detected"]
+    music_evidence: list[str] = [f"{len(audio_files)} audio files detected"]
+    book_score = 0.0
+    music_score = 0.0
+
+    # A. Filename patterns
+    chapter_part_matches = 0
+    music_track_matches = 0
+    for af in audio_files:
+        name = af.name
+        if AUDIOBOOK_FILENAME_REGEX.search(name):
+            chapter_part_matches += 1
+        elif MUSIC_FILENAME_REGEX.search(name):
+            music_track_matches += 1
+
+    if chapter_part_matches > 0 and chapter_part_matches >= len(audio_files) * 0.3:
+        book_score += 4.0
+        book_evidence.append(f"chapter/part filename pattern ({chapter_part_matches}/{len(audio_files)} files)")
+
+    if music_track_matches > 0 and music_track_matches >= len(audio_files) * 0.5:
+        music_score += 2.0
+        music_evidence.append(f"standard numbered song titles ({music_track_matches}/{len(audio_files)} files)")
+
+    parent_dir_name = path_obj.name.lower()
+    if any(w in parent_dir_name for w in ("audiobook", "audiobooks", "audio book", "audio books", "readarr", "libby")):
+        book_score += 2.0
+        book_evidence.append(f"parent directory hint ('{path_obj.name}')")
+
+    # B. Metadata and Technical characteristics inspection
+    sample_files = audio_files[:30]
+    genres_found: set[str] = set()
+    has_chapters = False
+    has_narrator = False
+    has_author = False
+    has_isbn_asin = False
+    has_musicbrainz = False
+    has_discogs = False
+    has_catalog_no = False
+
+    mono_count = 0
+    low_bitrate_count = 0
+    low_samplerate_count = 0
+    long_track_count = 0
+
+    for af in sample_files:
+        parsed = _inspect_audio_file(af)
+        for g in parsed["genres"]:
+            if g:
+                genres_found.add(g.lower())
+
+        if parsed["has_chapters"]:
+            has_chapters = True
+        if parsed["narrator"]:
+            has_narrator = True
+        if parsed["author"]:
+            has_author = True
+        if parsed["isbn"] or parsed["asin"]:
+            has_isbn_asin = True
+        if parsed["has_musicbrainz"]:
+            has_musicbrainz = True
+        if parsed["has_discogs"]:
+            has_discogs = True
+        if parsed["has_catalog_no"]:
+            has_catalog_no = True
+
+        if parsed["channels"] == 1:
+            mono_count += 1
+        if parsed["bitrate"] > 0 and (parsed["bitrate"] // 1000) <= 128:
+            low_bitrate_count += 1
+        if parsed["sample_rate"] > 0 and parsed["sample_rate"] <= 32000:
+            low_samplerate_count += 1
+        if parsed["length"] >= 900:  # 15 minutes
+            long_track_count += 1
+
+    for g in genres_found:
+        if any(sg in g for sg in SPOKEN_GENRES):
+            book_score += 5.0
+            book_evidence.append(f"spoken-word / audiobook genre ('{g}')")
+            break
+        if any(mg in g for mg in MUSIC_GENRES):
+            music_score += 4.0
+            music_evidence.append(f"recognized music genre ('{g}')")
+            break
+
+    if has_chapters:
+        book_score += 5.0
+        book_evidence.append("embedded chapter metadata")
+
+    if has_narrator:
+        book_score += 4.0
+        book_evidence.append("narrator metadata")
+
+    if has_author:
+        book_score += 3.0
+        book_evidence.append("author metadata")
+
+    if has_isbn_asin:
+        book_score += 4.0
+        book_evidence.append("ISBN or ASIN metadata")
+
+    if has_musicbrainz:
+        music_score += 5.0
+        music_evidence.append("MusicBrainz metadata tags")
+
+    if has_discogs:
+        music_score += 5.0
+        music_evidence.append("Discogs metadata tags")
+
+    if has_catalog_no:
+        music_score += 3.0
+        music_evidence.append("music label / catalogue number metadata")
+
+    if mono_count > 0 and mono_count >= len(sample_files) * 0.5:
+        book_score += 3.0
+        book_evidence.append(f"mono audio ({mono_count}/{len(sample_files)} files)")
+
+    if low_bitrate_count > 0 and low_bitrate_count >= len(sample_files) * 0.5:
+        book_score += 2.0
+        book_evidence.append(f"low bitrate audio ({low_bitrate_count}/{len(sample_files)} files)")
+
+    if low_samplerate_count > 0 and low_samplerate_count >= len(sample_files) * 0.5:
+        book_score += 2.0
+        book_evidence.append(f"low sample rate audio ({low_samplerate_count}/{len(sample_files)} files)")
+
+    if long_track_count > 0:
+        book_score += 3.0
+        book_evidence.append(f"long individual tracks (>15 min) ({long_track_count} files)")
+
+    # C. Decision logic
+    if book_score >= 3.0 and book_score > music_score:
+        return AudioCategoryResult(
+            category="BOOK",
+            is_audiobook=True,
+            confidence=min(1.0, book_score / 10.0),
+            evidence=book_evidence,
+        )
+
+    if music_score >= 3.0 and music_score > book_score:
+        return AudioCategoryResult(
+            category="MUSIC",
+            is_audiobook=False,
+            confidence=min(1.0, music_score / 10.0),
+            evidence=music_evidence,
+        )
+
+    return AudioCategoryResult(
+        category="AMBIGUOUS",
+        is_audiobook=False,
+        confidence=0.0,
+        evidence=[
+            f"shared {audio_files[0].suffix.lower()} extension",
+            "no audiobook-specific metadata",
+            "no reliable music metadata",
+        ],
+    )

--- a/src/book_prep.py
+++ b/src/book_prep.py
@@ -52,7 +52,27 @@ from src.meta import Meta
 BOOK_EXTENSIONS = frozenset(
     {".pdf", ".epub", ".mobi", ".azw", ".azw3", ".fb2", ".html", ".htm", ".chm", ".djvu", ".doc", ".docx", ".kfx", ".lit", ".pdb", ".txt", ".rtf", ".cbz", ".cbr"}
 )
-AUDIOBOOK_EXTENSIONS = frozenset({".mp3", ".m4b", ".flac", ".alac", ".aac", ".m4a", ".ogg", ".opus", ".wav"})
+AUDIOBOOK_EXTENSIONS = frozenset(
+    {
+        ".mp3",
+        ".m4b",
+        ".flac",
+        ".alac",
+        ".aac",
+        ".m4a",
+        ".ogg",
+        ".opus",
+        ".wav",
+        ".ac3",
+        ".dts",
+        ".aiff",
+        ".ape",
+        ".wv",
+        ".wma",
+        ".aax",
+        ".aaxc",
+    }
+)
 _TEXT_SIDECAR_STEMS = frozenset({"cover", "folder", "index", "info", "readme"})
 
 
@@ -770,8 +790,7 @@ async def get_audiobook_duration(filelist: list[str]) -> tuple[float, str]:
     """Calculate the sum of durations of all audio files in the file list using MediaInfo."""
     from pymediainfo import MediaInfo
 
-    audiobook_extensions = (".mp3", ".m4b", ".flac", ".alac", ".aac", ".m4a", ".ogg", ".opus", ".wav")
-    audio_files = [f for f in filelist if f.lower().endswith(audiobook_extensions)]
+    audio_files = [f for f in filelist if Path(f).suffix.lower() in AUDIOBOOK_EXTENSIONS]
 
     if not audio_files:
         return 0.0, ""
@@ -806,8 +825,7 @@ async def get_audiobook_bitrate(filelist: list[str]) -> int | None:
     """Calculate the average bitrate (in kbps) of a sample of audio files (max 5) in the file list using MediaInfo."""
     from pymediainfo import MediaInfo
 
-    audiobook_extensions = (".mp3", ".m4b", ".flac", ".alac", ".aac", ".m4a", ".ogg", ".opus", ".wav")
-    audio_files = [f for f in filelist if f.lower().endswith(audiobook_extensions)]
+    audio_files = [f for f in filelist if Path(f).suffix.lower() in AUDIOBOOK_EXTENSIONS]
 
     # Limit to a maximum of 5 files to optimize performance
     audio_files = audio_files[:5]

--- a/src/book_prep.py
+++ b/src/book_prep.py
@@ -95,7 +95,7 @@ def resolve_book_filelist(
     meta.imdb_id = 0
 
     primary_ext = Path(videopath).suffix.lower()
-    meta.audiobook = primary_ext in AUDIOBOOK_EXTENSIONS
+    meta.audiobook = bool(meta.audiobook or (primary_ext in AUDIOBOOK_EXTENSIONS) or any(Path(f).suffix.lower() in AUDIOBOOK_EXTENSIONS for f in filelist))
 
     search_term = Path(filelist[0]).name if filelist else ""
     search_file_folder = "file"

--- a/src/prep_helpers.py
+++ b/src/prep_helpers.py
@@ -208,16 +208,19 @@ async def detect_disc_and_category(prep_instance: Any, meta: Meta) -> tuple[str,
                             "Choose category for audio release:",
                             choices=["1. Music", "2. Audiobook"],
                         )
-                        if choice.startswith("1") or choice.lower() == "music":
-                            meta.category = "MUSIC"
-                            meta.audiobook = False
-                        else:
-                            meta.category = "BOOK"
-                            meta.audiobook = True
-                        logger.info(f"[cyan]Category selected interactively: {meta.category}[/cyan]")
-                    except Exception:
+                    except EOFError, KeyboardInterrupt:
                         logger.error("[bold red]Category selection cancelled or failed.[/bold red]")
                         sys.exit(1)
+                    if choice is None:
+                        logger.error("[bold red]Category selection cancelled or failed.[/bold red]")
+                        sys.exit(1)
+                    if choice.startswith("1") or choice.lower() == "music":
+                        meta.category = "MUSIC"
+                        meta.audiobook = False
+                    else:
+                        meta.category = "BOOK"
+                        meta.audiobook = True
+                    logger.info(f"[cyan]Category selected interactively: {meta.category}[/cyan]")
                 else:
                     logger.error("[bold red]Could not confidently distinguish MUSIC from AUDIOBOOK in unattended mode.[/bold red]")
                     logger.error("[yellow]Specify one of: -c book or -c music[/yellow]")

--- a/src/prep_helpers.py
+++ b/src/prep_helpers.py
@@ -160,25 +160,71 @@ async def detect_disc_and_category(prep_instance: Any, meta: Meta) -> tuple[str,
     if isinstance(meta.manual_category, str) and meta.manual_category.strip():
         meta.category = meta.manual_category.strip().upper()
 
-    # Auto-detect MUSIC before BOOK: music releases are commonly multi-file FLAC
-    # directories, whereas audiobooks remain BOOK through their dedicated flow.
-    if not meta.category and not meta.manual_category and not meta.is_disc:
-        music_extensions = {".flac", ".mp3", ".m4a", ".aac", ".ac3", ".dts", ".wav", ".aiff", ".alac", ".ogg", ".opus", ".ape", ".wv"}
+    # If category is manually set to BOOK, ensure meta.audiobook is set if audio files are present
+    if meta.category == "BOOK" and not meta.audiobook:
         path_to_check = Path(meta.path) if meta.path else None
         if path_to_check and path_to_check.exists():
-            if path_to_check.is_file() and path_to_check.suffix.lower() in music_extensions:
-                meta.category = "MUSIC"
-            elif path_to_check.is_dir():
-                # Stop as soon as representative content is found; do not scan an
-                # entire music library merely to classify a release.
-                for item in path_to_check.rglob("*"):
-                    if item.is_file() and item.suffix.lower() in music_extensions:
-                        meta.category = "MUSIC"
-                        break
-            if meta.category == "MUSIC":
-                logger.debug("[cyan]Auto-detected category: MUSIC[/cyan]")
+            from src.audio_classifier import AUDIOBOOK_CONTAINER_EXTENSIONS, SHARED_AUDIO_EXTENSIONS
 
-    # Auto-detect BOOK category if category/manual_category is not already set and it's not a disc
+            audio_exts = SHARED_AUDIO_EXTENSIONS | AUDIOBOOK_CONTAINER_EXTENSIONS
+            if path_to_check.is_file() and path_to_check.suffix.lower() in audio_exts:
+                meta.audiobook = True
+            elif path_to_check.is_dir():
+                for item in path_to_check.rglob("*"):
+                    if item.is_file() and item.suffix.lower() in audio_exts:
+                        meta.audiobook = True
+                        break
+
+    # Auto-detect audio release category (BOOK audiobook vs MUSIC) if category/manual_category is not already set and it's not a disc
+    if not meta.category and not meta.manual_category and not meta.is_disc:
+        path_to_check = Path(meta.path) if meta.path else None
+        if path_to_check and path_to_check.exists():
+            from src.audio_classifier import detect_audio_category
+
+            audio_res = await detect_audio_category(meta, path_to_check)
+            if audio_res.category in ("BOOK", "MUSIC"):
+                meta.category = audio_res.category
+                meta.audiobook = audio_res.is_audiobook
+                logger.info(f"[cyan]Auto-detected category: {meta.category}[/cyan]")
+                if audio_res.is_audiobook:
+                    logger.info("[cyan]Subtype: AUDIOBOOK[/cyan]")
+                if audio_res.evidence:
+                    logger.info("[cyan]Evidence:[/cyan]")
+                    for ev in audio_res.evidence:
+                        logger.info(f"[cyan]- {ev}[/cyan]")
+            elif audio_res.category == "AMBIGUOUS":
+                unattended = getattr(meta, "unattended", False)
+                unattended_confirm = getattr(meta, "unattended_confirm", False)
+
+                logger.warning("[yellow]Audio category is ambiguous: could not confidently determine whether this is MUSIC or an AUDIOBOOK.[/yellow]")
+                if audio_res.evidence:
+                    logger.warning("[yellow]Evidence evaluated:[/yellow]")
+                    for ev in audio_res.evidence:
+                        logger.warning(f"[yellow]- {ev}[/yellow]")
+
+                if not unattended or (unattended and unattended_confirm):
+                    try:
+                        choice = cli_ui.ask_choice(
+                            "Choose category for audio release:",
+                            choices=["1. Music", "2. Audiobook"],
+                        )
+                        if choice.startswith("1") or choice.lower() == "music":
+                            meta.category = "MUSIC"
+                            meta.audiobook = False
+                        else:
+                            meta.category = "BOOK"
+                            meta.audiobook = True
+                        logger.info(f"[cyan]Category selected interactively: {meta.category}[/cyan]")
+                    except Exception:
+                        logger.error("[bold red]Category selection cancelled or failed.[/bold red]")
+                        sys.exit(1)
+                else:
+                    logger.error("[bold red]Could not confidently distinguish MUSIC from AUDIOBOOK in unattended mode.[/bold red]")
+                    logger.error("[yellow]Specify one of: -c book or -c music[/yellow]")
+                    logger.error("[yellow]Skipping this release instead of assigning an unsafe category.[/yellow]")
+                    sys.exit(1)
+
+    # Fallback auto-detect BOOK category if category/manual_category is not already set and it's not a disc
     if not meta.category and not meta.manual_category and not meta.is_disc:
         is_book = False
         video_extensions = {".mkv", ".mp4", ".ts"}

--- a/tests/test_audio_classifier.py
+++ b/tests/test_audio_classifier.py
@@ -1,0 +1,111 @@
+"""Tests for audio category classification (BOOK/audiobook vs MUSIC vs ambiguous)."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from src.audio_classifier import detect_audio_category
+from src.meta import Meta
+from src.prep_helpers import detect_disc_and_category
+
+
+def test_m4b_audiobook_detected_as_book(tmp_path):
+    m4b_file = tmp_path / "testbook.m4b"
+    m4b_file.write_bytes(b"dummy m4b content")
+    meta = Meta(path=str(tmp_path))
+    prep = SimpleNamespace(disc_info_manager=SimpleNamespace(get_disc=AsyncMock(return_value=("", str(tmp_path), {}, []))))
+
+    asyncio.run(detect_disc_and_category(prep, meta))
+
+    assert meta.category == "BOOK"
+    assert meta.audiobook is True
+
+
+def test_mp3_audiobook_with_part_filenames_detected_as_book(tmp_path):
+    p1 = tmp_path / "Book-Part01.mp3"
+    p2 = tmp_path / "Book-Part02.mp3"
+    p3 = tmp_path / "Book-Part03.mp3"
+    p1.write_bytes(b"dummy mp3 content 1")
+    p2.write_bytes(b"dummy mp3 content 2")
+    p3.write_bytes(b"dummy mp3 content 3")
+
+    meta = Meta(path=str(tmp_path))
+    prep = SimpleNamespace(disc_info_manager=SimpleNamespace(get_disc=AsyncMock(return_value=("", str(tmp_path), {}, []))))
+
+    asyncio.run(detect_disc_and_category(prep, meta))
+
+    assert meta.category == "BOOK"
+    assert meta.audiobook is True
+
+
+def test_mixed_ebook_and_audiobook_folder_detected_as_book(tmp_path):
+    epub = tmp_path / "Book.epub"
+    mp3 = tmp_path / "Book-Part01.mp3"
+    epub.write_bytes(b"dummy epub")
+    mp3.write_bytes(b"dummy mp3")
+
+    meta = Meta(path=str(tmp_path))
+    prep = SimpleNamespace(disc_info_manager=SimpleNamespace(get_disc=AsyncMock(return_value=("", str(tmp_path), {}, []))))
+
+    asyncio.run(detect_disc_and_category(prep, meta))
+
+    assert meta.category == "BOOK"
+    assert meta.audiobook is True
+
+
+def test_explicit_book_category_override_takes_priority(tmp_path):
+    mp3 = tmp_path / "audio.mp3"
+    mp3.write_bytes(b"dummy mp3")
+
+    meta = Meta(path=str(tmp_path), manual_category="book")
+    prep = SimpleNamespace(disc_info_manager=SimpleNamespace(get_disc=AsyncMock(return_value=("", str(tmp_path), {}, []))))
+
+    asyncio.run(detect_disc_and_category(prep, meta))
+
+    assert meta.category == "BOOK"
+    assert meta.audiobook is True
+
+
+def test_explicit_music_category_override_takes_priority(tmp_path):
+    m4b = tmp_path / "book.m4b"
+    m4b.write_bytes(b"dummy m4b")
+
+    meta = Meta(path=str(tmp_path), manual_category="music")
+    prep = SimpleNamespace(disc_info_manager=SimpleNamespace(get_disc=AsyncMock(return_value=("", str(tmp_path), {}, []))))
+
+    asyncio.run(detect_disc_and_category(prep, meta))
+
+    assert meta.category == "MUSIC"
+    assert meta.audiobook is False
+
+
+def test_ambiguous_audio_folder_prompts_in_interactive_mode(tmp_path):
+    t1 = tmp_path / "track_alpha.mp3"
+    t2 = tmp_path / "track_beta.mp3"
+    t1.write_bytes(b"dummy mp3 1")
+    t2.write_bytes(b"dummy mp3 2")
+
+    meta = Meta(path=str(tmp_path), unattended=False)
+    prep = SimpleNamespace(disc_info_manager=SimpleNamespace(get_disc=AsyncMock(return_value=("", str(tmp_path), {}, []))))
+
+    with patch("cli_ui.ask_choice", return_value="2. Audiobook"):
+        asyncio.run(detect_disc_and_category(prep, meta))
+
+    assert meta.category == "BOOK"
+    assert meta.audiobook is True
+
+
+def test_ambiguous_audio_folder_fails_in_unattended_mode(tmp_path):
+    t1 = tmp_path / "track_alpha.mp3"
+    t2 = tmp_path / "track_beta.mp3"
+    t1.write_bytes(b"dummy mp3 1")
+    t2.write_bytes(b"dummy mp3 2")
+
+    meta = Meta(path=str(tmp_path), unattended=True, unattended_confirm=False)
+    prep = SimpleNamespace(disc_info_manager=SimpleNamespace(get_disc=AsyncMock(return_value=("", str(tmp_path), {}, []))))
+
+    with pytest.raises(SystemExit):
+        asyncio.run(detect_disc_and_category(prep, meta))

--- a/tests/test_audio_classifier.py
+++ b/tests/test_audio_classifier.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from src.audio_classifier import detect_audio_category
+
 from src.meta import Meta
 from src.prep_helpers import detect_disc_and_category
 
@@ -96,6 +96,19 @@ def test_ambiguous_audio_folder_prompts_in_interactive_mode(tmp_path):
 
     assert meta.category == "BOOK"
     assert meta.audiobook is True
+
+
+def test_ambiguous_audio_prompt_does_not_hide_unexpected_errors(tmp_path):
+    t1 = tmp_path / "track_alpha.mp3"
+    t2 = tmp_path / "track_beta.mp3"
+    t1.write_bytes(b"dummy mp3 1")
+    t2.write_bytes(b"dummy mp3 2")
+
+    meta = Meta(path=str(tmp_path), unattended=False)
+    prep = SimpleNamespace(disc_info_manager=SimpleNamespace(get_disc=AsyncMock(return_value=("", str(tmp_path), {}, []))))
+
+    with patch("cli_ui.ask_choice", side_effect=RuntimeError("unexpected prompt failure")), pytest.raises(RuntimeError, match="unexpected prompt failure"):
+        asyncio.run(detect_disc_and_category(prep, meta))
 
 
 def test_ambiguous_audio_folder_fails_in_unattended_mode(tmp_path):

--- a/tests/test_book_detection.py
+++ b/tests/test_book_detection.py
@@ -38,7 +38,7 @@ def test_azw_files_are_included_when_resolving_book_directories(extension, tmp_p
     assert meta.audiobook is False
 
 
-@pytest.mark.parametrize("extension", [".opus", ".alac"])
+@pytest.mark.parametrize("extension", [".opus", ".alac", ".aax", ".aaxc"])
 def test_new_audiobook_formats_are_detected(extension, tmp_path):
     audiobook = tmp_path / f"chapter01{extension}"
     audiobook.write_bytes(b"audiobook")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic classification of audio releases as audiobooks, music, ambiguous, or unsupported.
  * Improved audiobook recognition for M4B files, multipart audio filenames, mixed ebook/audio folders, and common shared audio formats.
  * Classification now considers filenames, folders, genres, tags, and audio characteristics for more accurate results.
* **Bug Fixes**
  * Preserves existing audiobook metadata during book preparation.
  * Manual book and music selections now take priority over automatic classification.
  * Ambiguous audio releases prompt for a choice interactively or fail clearly in unattended mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->