### PR TITLE
feat: add artwork validation and handling across CLI and WebUI

### DIFF
--- a/src/args.py
+++ b/src/args.py
@@ -270,6 +270,7 @@ class Args:
         parser.add_argument("-year", "--year", dest="manual_year", nargs=1, required=False, help="Override the year found", type=int, default=0)
         parser.add_argument("-author", "--author", nargs="*", required=False, help="Book/Audiobook author name (overrides auto-detected value)", type=str, dest="book_author")
         parser.add_argument("-btitle", "--book-title", nargs="*", required=False, help="Book/Audiobook title (overrides auto-detected value)", type=str, dest="book_title")
+        parser.add_argument("--book-cover", nargs=1, required=False, help="BOOK: public artwork URL or local cover image path", dest="book_cover")
         parser.add_argument("--comic", "-comic", action="store_true", required=False, help="Identify the book upload as a Comic", dest="comic", default=False)
         parser.add_argument("--manga", "-manga", action="store_true", required=False, help="Identify the book upload as a Manga", dest="manga", default=False)
         parser.add_argument("--magazine", "-magazine", action="store_true", required=False, help="Identify the book upload as a Magazine", dest="magazine", default=False)
@@ -1067,6 +1068,18 @@ class Args:
         book_publisher_arg = meta.book_publisher
         if book_publisher_arg not in (None, ""):
             meta.publisher = str(book_publisher_arg).strip()
+
+        book_cover_arg = meta.book_cover
+        if book_cover_arg not in (None, "", []):
+            cover = " ".join(str(x) for x in book_cover_arg if str(x)).strip() if isinstance(book_cover_arg, list) else str(book_cover_arg).strip()
+            if cover.startswith(("http://", "https://")):
+                meta.artwork_url = cover
+            elif cover:
+                cover_path = Path(cover).expanduser()
+                if cover_path.is_file():
+                    meta.artwork_path = str(cover_path.resolve())
+                else:
+                    logger.warning("[yellow]BOOK: --book-cover is neither a public HTTP(S) URL nor an existing image file; ignoring it.[/yellow]")
 
         book_translator_arg = meta.book_translator
         if book_translator_arg not in (None, ""):

--- a/src/artwork.py
+++ b/src/artwork.py
@@ -1,11 +1,26 @@
 """Shared artwork validation helpers."""
 
+import ipaddress
+import socket
 from io import BytesIO
 from pathlib import Path
+from urllib.parse import urlparse
 
 from PIL import Image
 
 _SUPPORTED_COVER_FORMATS = {"GIF", "JPEG", "PNG", "WEBP"}
+
+
+def is_public_http_url(value: str | None) -> bool:
+    """Return whether an HTTP(S) URL resolves exclusively to public IPs."""
+    parsed = urlparse(str(value or "").strip())
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return False
+    try:
+        addresses = {result[4][0] for result in socket.getaddrinfo(parsed.hostname, None, type=socket.SOCK_STREAM)}
+        return bool(addresses) and all(ipaddress.ip_address(address).is_global for address in addresses)
+    except OSError, ValueError:
+        return False
 
 
 def is_valid_image_bytes(image_bytes: bytes) -> bool:

--- a/src/artwork.py
+++ b/src/artwork.py
@@ -1,0 +1,36 @@
+"""Shared artwork validation helpers."""
+
+from io import BytesIO
+from pathlib import Path
+
+from PIL import Image
+
+_SUPPORTED_COVER_FORMATS = {"GIF", "JPEG", "PNG", "WEBP"}
+
+
+def is_valid_image_bytes(image_bytes: bytes) -> bool:
+    """Return whether bytes contain a decodable, non-empty supported image."""
+    if not image_bytes:
+        return False
+
+    try:
+        with Image.open(BytesIO(image_bytes)) as image:
+            if image.format not in _SUPPORTED_COVER_FORMATS or image.width <= 0 or image.height <= 0:
+                return False
+            image.verify()
+        return True
+    except OSError, SyntaxError, ValueError:
+        return False
+
+
+def is_valid_cover_image(path: str | Path | None) -> bool:
+    """Return whether *path* is a decodable cover image accepted by uploads."""
+    if not path:
+        return False
+    image_path = Path(path)
+    try:
+        if not image_path.is_file() or image_path.stat().st_size == 0:
+            return False
+        return is_valid_image_bytes(image_path.read_bytes())
+    except OSError:
+        return False

--- a/src/manualpackage.py
+++ b/src/manualpackage.py
@@ -14,7 +14,7 @@ from torf import Torrent
 
 from src.console import logger
 from src.meta import Meta
-from src.temp_paths import posters_dir
+from src.temp_paths import artwork_dir
 from src.uploadscreens import UploadScreensManager
 
 
@@ -48,7 +48,7 @@ class ManualPackageManager:
                 await generic.write(f"TVDB: https://www.thetvdb.com/?id={meta.tvdb_id}&tab=series\n")
             if "tvmaze_id" in meta and meta.tvmaze_id != 0:
                 await generic.write(f"TVMaze: https://www.tvmaze.com/shows/{meta.tvmaze_id}\n")
-            poster_img = str(posters_dir(meta.base_dir, meta.uuid) / "POSTER.png")
+            poster_img = str(artwork_dir(meta.base_dir, meta.uuid) / "POSTER.png")
             if meta.artwork_url not in ["", None] and not Path(poster_img).exists():
                 if meta.rehosted_artwork_url is None:
                     async with httpx.AsyncClient(timeout=30.0) as client:

--- a/src/music/prep.py
+++ b/src/music/prep.py
@@ -19,7 +19,7 @@ from src.music.analyzer import MusicReleaseAnalyzer
 from src.music.models import MetadataSource, MusicRelease
 from src.music.sources import DiscogsEnricher, MusicBrainzEnricher
 from src.music.validation import MusicValidator
-from src.temp_paths import covers_dir
+from src.temp_paths import artwork_dir
 
 
 def _preferred_artwork(release: Any) -> Path | None:
@@ -96,7 +96,7 @@ async def prepare_music_cover(meta: Meta, release: Any) -> str:
         meta.artwork_path = str(local_cover)
         return meta.artwork_path
 
-    output_dir = covers_dir(meta.base_dir, str(meta.uuid))
+    output_dir = artwork_dir(meta.base_dir, str(meta.uuid))
     extracted = await asyncio.to_thread(_extract_embedded_artwork, [track.path for track in release.tracks], output_dir)
     if extracted:
         meta.artwork_path = str(extracted)

--- a/src/prep_game.py
+++ b/src/prep_game.py
@@ -21,7 +21,7 @@ from src.console import logger
 from src.igdb import IGDBAPI
 from src.meta import Meta
 from src.metadata_cache import cache_for, is_cache_miss
-from src.temp_paths import posters_dir
+from src.temp_paths import artwork_dir
 
 
 def normalize_version(version_str: str) -> str:
@@ -674,7 +674,7 @@ async def gather_game_prep(
         meta.artwork_url = cover_url
 
         # Download and save cover locally as POSTER.png
-        poster_png_path = posters_dir(base_dir, meta.uuid) / "POSTER.png"
+        poster_png_path = artwork_dir(base_dir, meta.uuid) / "POSTER.png"
         try:
             async with httpx.AsyncClient(timeout=15.0) as client:
                 response = await client.get(cover_url)

--- a/src/rehostimages.py
+++ b/src/rehostimages.py
@@ -17,7 +17,7 @@ from src.console import logger
 from src.meta import Meta
 from src.screenshot_manifest import files as manifest_files
 from src.takescreens import TakeScreensManager
-from src.temp_paths import covers_dir, menu_screenshots_dir, screenshots_dir, spectrograms_dir
+from src.temp_paths import artwork_dir, menu_screenshots_dir, screenshots_dir, spectrograms_dir
 from src.tracker_images import (
     get_tracker_image_collection,
     has_tracker_image_collection,
@@ -597,7 +597,7 @@ async def _handle_image_upload(
 
     if tracker == "covers":
         all_screenshots = []
-        existing_screens = await asyncio.to_thread(lambda: [str(p) for p in covers_dir(meta.base_dir, meta.uuid).glob("cover_*.jpg")])
+        existing_screens = await asyncio.to_thread(lambda: [str(p) for p in artwork_dir(meta.base_dir, meta.uuid).glob("cover_*.jpg")])
         for screen in existing_screens:
             if screen not in all_screenshots:
                 all_screenshots.append(screen)

--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -24,7 +24,7 @@ import psutil
 from pymediainfo import MediaInfo
 
 from data import config as data_config
-from src.artwork import is_valid_cover_image, is_valid_image_bytes
+from src.artwork import is_public_http_url, is_valid_cover_image, is_valid_image_bytes
 from src.cleanup import cleanup_manager
 from src.console import logger
 from src.meta import Meta
@@ -971,19 +971,32 @@ async def download_artwork_from_meta(meta: Meta, artwork_path: str, *, force: bo
             if api_key:
                 cookies["mam_id"] = api_key
 
-        async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
-            response = await client.get(artwork_url, cookies=cookies, headers=headers)
-            if response.status_code == 200:
-                if not is_valid_image_bytes(response.content):
-                    logger.info("[yellow]Warning: Downloaded artwork is not a valid supported image and will be ignored.[/yellow]")
+        current_url = artwork_url
+        async with httpx.AsyncClient(timeout=30.0, follow_redirects=False) as client:
+            for _ in range(4):
+                if not is_public_http_url(current_url):
+                    logger.warning("[yellow]Warning: Artwork download target is not a public HTTP(S) URL.[/yellow]")
                     return False
-                await asyncio.to_thread(Path(artwork_path).write_bytes, response.content)
-                if not is_valid_cover_image(artwork_path):
-                    return False
-                meta.artwork_path = artwork_path
-                logger.info(f"[green]Successfully downloaded artwork from {artwork_url}[/green]")
-                return True
-            logger.warning(f"[yellow]Warning: Failed to download poster, status code {response.status_code}[/yellow]")
+                response = await client.get(current_url, cookies=cookies, headers=headers)
+                if response.is_redirect:
+                    location = response.headers.get("Location")
+                    if not location:
+                        return False
+                    current_url = urllib.parse.urljoin(current_url, location)
+                    continue
+                if response.status_code == 200:
+                    if not is_valid_image_bytes(response.content):
+                        logger.info("[yellow]Warning: Downloaded artwork is not a valid supported image and will be ignored.[/yellow]")
+                        return False
+                    await asyncio.to_thread(Path(artwork_path).write_bytes, response.content)
+                    if not is_valid_cover_image(artwork_path):
+                        return False
+                    meta.artwork_path = artwork_path
+                    logger.info(f"[green]Successfully downloaded artwork from {current_url}[/green]")
+                    return True
+                logger.warning(f"[yellow]Warning: Failed to download poster, status code {response.status_code}[/yellow]")
+                return False
+            logger.warning("[yellow]Warning: Artwork download exceeded the redirect limit.[/yellow]")
     except Exception as e:
         logger.warning(f"[yellow]Warning: Error downloading poster: {e}[/yellow]")
     return False

--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -24,13 +24,14 @@ import psutil
 from pymediainfo import MediaInfo
 
 from data import config as data_config
+from src.artwork import is_valid_cover_image, is_valid_image_bytes
 from src.cleanup import cleanup_manager
 from src.console import logger
 from src.meta import Meta
 from src.screenshot_manifest import clear_group as clear_screenshot_group
 from src.screenshot_manifest import files as manifest_files
 from src.screenshot_manifest import register as register_screenshots
-from src.temp_paths import posters_dir, screenshots_dir
+from src.temp_paths import artwork_dir, screenshots_dir
 from src.webui_progress import complete_progress, publish_progress
 
 default_config: dict[str, Any] = {}
@@ -850,8 +851,10 @@ async def load_local_cover_if_exists(path: str, dest_path: str) -> bool:
             for f in (p.name for p in Path(search_dir).iterdir()):
                 if f.lower() in valid_names:
                     local_file = Path(search_dir) / f
+                    if not is_valid_cover_image(local_file):
+                        continue
                     shutil.copy2(local_file, dest_path)
-                    return True
+                    return is_valid_cover_image(dest_path)
         return False
 
     try:
@@ -948,10 +951,7 @@ async def download_artwork_from_meta(meta: Meta, artwork_path: str, *, force: bo
     if not artwork_url:
         return False
 
-    min_size = 20480
-    if artwork_url.startswith("http://books.google.com/") or artwork_url.startswith("https://covers.openlibrary.org/b/id/"):
-        min_size = 10240
-    if not force and Path(artwork_path).exists() and Path(artwork_path).stat().st_size >= min_size:
+    if not force and is_valid_cover_image(artwork_path):
         meta.artwork_path = artwork_path
         return True
     try:
@@ -974,12 +974,12 @@ async def download_artwork_from_meta(meta: Meta, artwork_path: str, *, force: bo
         async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
             response = await client.get(artwork_url, cookies=cookies, headers=headers)
             if response.status_code == 200:
-                if len(response.content) < min_size:
-                    logger.info(
-                        f"[yellow]Warning: Downloaded artwork from {artwork_url} is too small ({len(response.content)} bytes < {min_size} bytes) and will be ignored.[/yellow]"
-                    )
+                if not is_valid_image_bytes(response.content):
+                    logger.info("[yellow]Warning: Downloaded artwork is not a valid supported image and will be ignored.[/yellow]")
                     return False
                 await asyncio.to_thread(Path(artwork_path).write_bytes, response.content)
+                if not is_valid_cover_image(artwork_path):
+                    return False
                 meta.artwork_path = artwork_path
                 logger.info(f"[green]Successfully downloaded artwork from {artwork_url}[/green]")
                 return True
@@ -1247,10 +1247,13 @@ async def extract_document_cover(path: str, dest_path: str) -> bool:
 
 
 async def prepare_book_cover(path: str, folder_id: str, base_dir: str, meta: Meta) -> str | None:
-    output_dir = posters_dir(base_dir, folder_id)
+    if meta.artwork_path and is_valid_cover_image(meta.artwork_path) and not meta.retake:
+        return meta.artwork_path
+
+    output_dir = artwork_dir(base_dir, folder_id)
     artwork_path = output_dir / "POSTER.png"
 
-    if Path(artwork_path).exists() and Path(artwork_path).stat().st_size >= 20480 and not meta.retake:
+    if is_valid_cover_image(artwork_path) and not meta.retake:
         meta.artwork_path = str(artwork_path)
         return str(artwork_path)
 
@@ -1337,7 +1340,7 @@ async def generate_ebook_screenshots(
     extension = Path(path).suffix.lower().lstrip(".")
     screenshots = []
 
-    poster_dir = posters_dir(base_dir, folder_id)
+    poster_dir = artwork_dir(base_dir, folder_id)
     cover_path = poster_dir / "POSTER.png"
     banner_path = poster_dir / "POSTER_BANNER.png"
 

--- a/src/temp_paths.py
+++ b/src/temp_paths.py
@@ -26,12 +26,9 @@ def screenshots_dir(base_dir: str | Path, release_id: str) -> Path:
     return image_dir(base_dir, release_id, "screenshots")
 
 
-def posters_dir(base_dir: str | Path, release_id: str) -> Path:
-    return image_dir(base_dir, release_id, "posters")
-
-
-def covers_dir(base_dir: str | Path, release_id: str) -> Path:
-    return image_dir(base_dir, release_id, "covers")
+def artwork_dir(base_dir: str | Path, release_id: str) -> Path:
+    """Return the per-release directory for all local artwork assets."""
+    return image_dir(base_dir, release_id, "artwork")
 
 
 def menu_screenshots_dir(base_dir: str | Path, release_id: str) -> Path:

--- a/src/trackerhandle.py
+++ b/src/trackerhandle.py
@@ -10,6 +10,7 @@ import cli_ui
 from rich.markup import escape
 
 from cogs.redaction import Redaction
+from src.artwork import is_valid_cover_image
 from src.cleanup import cleanup_manager
 from src.config_helpers import format_terminal_link
 from src.console import logger
@@ -146,6 +147,13 @@ async def process_trackers(
             meta.name = meta.name.replace(" DUPE?", "")
 
         tracker = tracker.replace(" ", "").upper().strip()
+
+        if meta.category == "BOOK" and not is_valid_cover_image(meta.artwork_path):
+            status = meta.tracker_status.setdefault(tracker, {})
+            status["upload"] = False
+            status["status_message"] = "Skipped: BOOK uploads require a valid cover image"
+            logger.info(f"[yellow]{tracker}: skipped because BOOK uploads require a valid cover image.[/yellow]")
+            return
 
         async def check_bandwidth_and_dupes(tracker_name: str, t_class: Any) -> bool:
             if t_class and getattr(t_class, "is_usenet", False):

--- a/src/trackers/UNIT3D/__init__.py
+++ b/src/trackers/UNIT3D/__init__.py
@@ -10,6 +10,7 @@ import aiofiles
 import httpx
 
 from cogs.redaction import Redaction
+from src.artwork import is_valid_image_bytes
 from src.console import logger
 from src.get_desc import DescriptionBuilder
 from src.meta import Meta
@@ -439,6 +440,10 @@ class UNIT3D:
                 image_bytes = await f.read()
         except OSError as e:
             logger.info(f"{self.tracker}: [yellow]Failed to read image {path}: {e}[/yellow]")
+            return None
+
+        if not is_valid_image_bytes(image_bytes):
+            logger.info(f"{self.tracker}: [yellow]Invalid or unsupported image: {path}[/yellow]")
             return None
 
         image_type: tuple[str, str] | None = None

--- a/src/trackers/UNIT3D/cinematik.py
+++ b/src/trackers/UNIT3D/cinematik.py
@@ -194,19 +194,16 @@ class Cinematik(UNIT3D):
 
         # Define the paths for both jpg and png poster images
         poster_dir = artwork_dir(meta.base_dir, meta.uuid)
-        poster_jpg_path = str(poster_dir / "poster.jpg")
-        poster_png_path = str(poster_dir / "poster.png")
+        poster_paths = [poster_dir / filename for filename in ("POSTER.png", "poster.png", "POSTER.jpg", "poster.jpg")]
 
         # Check if either poster.jpg or poster.png already exists
-        if Path(poster_jpg_path).exists():
-            poster_path = poster_jpg_path
-            logger.info(f"{self.tracker}: [green]Cover already exists as poster.jpg, skipping download.[/green]")
-        elif Path(poster_png_path).exists():
-            poster_path = poster_png_path
-            logger.info(f"{self.tracker}: [green]Cover already exists as poster.png, skipping download.[/green]")
+        existing_poster = next((path for path in poster_paths if path.is_file()), None)
+        if existing_poster is not None:
+            poster_path = str(existing_poster)
+            logger.info(f"{self.tracker}: [green]Cover already exists as {existing_poster.name}, skipping download.[/green]")
         else:
             # No poster file exists, download the poster image
-            poster_path = poster_jpg_path  # Default to saving as poster.jpg
+            poster_path = str(poster_dir / "poster.jpg")  # Default to saving as poster.jpg
             try:
                 parsed_url = urlparse(poster_url)
                 if parsed_url.scheme not in ("http", "https"):

--- a/src/trackers/UNIT3D/cinematik.py
+++ b/src/trackers/UNIT3D/cinematik.py
@@ -15,7 +15,7 @@ from rich.markup import escape
 from src.console import logger
 from src.get_desc import DescriptionBuilder
 from src.meta import Meta
-from src.temp_paths import posters_dir
+from src.temp_paths import artwork_dir
 from src.trackers.UNIT3D import UNIT3D
 from src.uploadscreens import UploadScreensManager
 
@@ -193,7 +193,7 @@ class Cinematik(UNIT3D):
         poster_url = f"https://image.tmdb.org/t/p/original{meta.tmdb_poster_path}"
 
         # Define the paths for both jpg and png poster images
-        poster_dir = posters_dir(meta.base_dir, meta.uuid)
+        poster_dir = artwork_dir(meta.base_dir, meta.uuid)
         poster_jpg_path = str(poster_dir / "poster.jpg")
         poster_png_path = str(poster_dir / "poster.png")
 

--- a/src/trackers/USENET/suio.py
+++ b/src/trackers/USENET/suio.py
@@ -16,7 +16,7 @@ from PIL import Image
 from cogs.redaction import Redaction
 from src.console import logger
 from src.meta import Meta
-from src.temp_paths import posters_dir
+from src.temp_paths import artwork_dir
 from src.trackers.common import Common
 from src.trackers.USENET.search_helpers import (
     build_newznab_search_query,
@@ -365,8 +365,8 @@ class Suio:
             files["nfo"] = (nfo_filename, nfo_content, "application/octet-stream")
         # Cover image file (optional)
         if meta.category not in ("TV", "MOVIE"):
-            cover_jpg_path = posters_dir(meta.base_dir, meta.uuid) / "POSTER.jpg"
-            cover_png_path = posters_dir(meta.base_dir, meta.uuid) / "POSTER.png"
+            cover_jpg_path = artwork_dir(meta.base_dir, meta.uuid) / "POSTER.jpg"
+            cover_png_path = artwork_dir(meta.base_dir, meta.uuid) / "POSTER.png"
             cover_path = None
             if Path(cover_jpg_path).exists():
                 cover_path = cover_jpg_path

--- a/src/trackers/passthepopcorn.py
+++ b/src/trackers/passthepopcorn.py
@@ -27,7 +27,7 @@ from src.meta import Meta
 from src.rehostimages import ImageHostPolicy, RehostImagesManager
 from src.screenshot_manifest import files as manifest_files
 from src.takescreens import TakeScreensManager
-from src.temp_paths import posters_dir, screenshots_dir
+from src.temp_paths import artwork_dir, screenshots_dir
 from src.torrentcreate import TorrentCreator
 from src.tracker_images import get_tracker_image_collection
 from src.trackers.common import Common
@@ -550,7 +550,7 @@ class PassThePopcorn:
         if self._poster_already_on_selected_host(image_url, selected_host):
             return image_url
 
-        tmp_dir = posters_dir(meta.base_dir, meta.uuid)
+        tmp_dir = artwork_dir(meta.base_dir, meta.uuid)
         try:
             tmp_dir.mkdir(parents=True, exist_ok=True)
             async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:

--- a/tests/test_artwork_requirements.py
+++ b/tests/test_artwork_requirements.py
@@ -37,7 +37,7 @@ async def test_prompt_book_meta_accepts_url() -> None:
 @pytest.mark.asyncio
 async def test_prompt_music_meta_accepts_file_path(tmp_path: Path) -> None:
     cover_file = tmp_path / "album_cover.png"
-    cover_file.write_bytes(b"fake album cover")
+    Image.new("RGB", (32, 48), "purple").save(cover_file)
 
     meta = Meta(
         category="MUSIC",
@@ -52,6 +52,28 @@ async def test_prompt_music_meta_accepts_file_path(tmp_path: Path) -> None:
         await _prompt_music_meta(meta)
 
     assert meta.artwork_path == str(cover_file.resolve())
+
+
+@pytest.mark.asyncio
+async def test_prompt_music_meta_rejects_invalid_file_before_accepting_cover(tmp_path: Path) -> None:
+    invalid_file = tmp_path / "invalid.png"
+    invalid_file.write_bytes(b"not an image")
+    valid_file = tmp_path / "valid.png"
+    Image.new("RGB", (32, 48), "orange").save(valid_file)
+
+    meta = Meta(
+        category="MUSIC",
+        artist="Test Artist",
+        title="Test Album",
+        year=2024,
+        source="CD",
+        music_release={"fields": {"release_type": {"value": "Album"}}},
+    )
+
+    with patch("upload.CLI_UI.ask_string", side_effect=[str(invalid_file), str(valid_file)]):
+        await _prompt_music_meta(meta)
+
+    assert meta.artwork_path == str(valid_file.resolve())
 
 
 def test_book_cover_cli_arg(tmp_path: Path) -> None:

--- a/tests/test_artwork_requirements.py
+++ b/tests/test_artwork_requirements.py
@@ -1,0 +1,88 @@
+# ruff: noqa: S101
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from PIL import Image
+
+from src.args import Args
+from src.meta import Meta
+from src.trackers.UNIT3D import UNIT3D
+from upload import _prompt_book_meta, _prompt_music_meta
+
+
+@pytest.mark.asyncio
+async def test_prompt_book_meta_accepts_file_path(tmp_path: Path) -> None:
+    cover_file = tmp_path / "cover.jpg"
+    Image.new("RGB", (32, 48), "red").save(cover_file)
+
+    meta = Meta(category="BOOK", title="Test Book", author="Test Author", year=2024, book_language="English", book_language_iso="eng")
+
+    with patch("upload.CLI_UI.ask_string", return_value=str(cover_file)):
+        await _prompt_book_meta(meta)
+
+    assert meta.artwork_path == str(cover_file.resolve())
+
+
+@pytest.mark.asyncio
+async def test_prompt_book_meta_accepts_url() -> None:
+    meta = Meta(category="BOOK", title="Test Book", author="Test Author", year=2024, book_language="English", book_language_iso="eng")
+
+    with patch("upload.CLI_UI.ask_string", return_value="https://example.com/cover.jpg"):
+        await _prompt_book_meta(meta)
+
+    assert meta.artwork_url == "https://example.com/cover.jpg"
+
+
+@pytest.mark.asyncio
+async def test_prompt_music_meta_accepts_file_path(tmp_path: Path) -> None:
+    cover_file = tmp_path / "album_cover.png"
+    cover_file.write_bytes(b"fake album cover")
+
+    meta = Meta(
+        category="MUSIC",
+        artist="Test Artist",
+        title="Test Album",
+        year=2024,
+        source="CD",
+        music_release={"fields": {"release_type": {"value": "Album"}}},
+    )
+
+    with patch("upload.CLI_UI.ask_string", return_value=str(cover_file)):
+        await _prompt_music_meta(meta)
+
+    assert meta.artwork_path == str(cover_file.resolve())
+
+
+def test_book_cover_cli_arg(tmp_path: Path) -> None:
+    cover_file = tmp_path / "cli_cover.png"
+    Image.new("RGB", (32, 48), "blue").save(cover_file)
+
+    parser = Args({"DEFAULT": {"screens": 4, "img_host_1": "imgbox"}})
+    meta = Meta(category="BOOK")
+    parser.parse([str(tmp_path), "--book-cover", str(cover_file)], meta)
+
+    assert meta.artwork_path == str(cover_file.resolve())
+
+
+def test_invalid_cover_is_not_accepted() -> None:
+    from src.artwork import is_valid_cover_image
+
+    assert not is_valid_cover_image(None)
+
+
+@pytest.mark.asyncio
+async def test_unit3d_attaches_only_a_decodable_book_cover(tmp_path: Path) -> None:
+    cover_file = tmp_path / "cover.png"
+    Image.new("RGB", (32, 48), "green").save(cover_file)
+    meta = Meta(category="BOOK", base_dir=str(tmp_path), uuid="book-1", artwork_path=str(cover_file))
+    tracker = UNIT3D({"DEFAULT": {}, "TRACKERS": {"TEST": {}}}, "TEST")
+
+    files = await tracker.get_additional_files(meta)
+
+    assert "torrent-cover" in files
+    assert files["torrent-cover"][2] == "image/png"
+
+    cover_file.write_bytes(b"not an image")
+    files = await tracker.get_additional_files(meta)
+    assert "torrent-cover" not in files

--- a/tests/test_music_cover_hosting.py
+++ b/tests/test_music_cover_hosting.py
@@ -25,5 +25,5 @@ def test_music_cover_reuses_cached_hosted_url_before_downloading(tmp_path):
 
 
 def test_music_cover_rejects_private_download_host():
-    with patch("upload.socket.getaddrinfo", return_value=[(None, None, None, None, ("127.0.0.1", 0))]):
+    with patch("src.artwork.socket.getaddrinfo", return_value=[(None, None, None, None, ("127.0.0.1", 0))]):
         assert not _is_public_music_cover_url("http://localhost/cover.jpg")  # noqa: S101

--- a/tests/test_screenshot_review.py
+++ b/tests/test_screenshot_review.py
@@ -64,8 +64,9 @@ def test_list_screenshots_includes_disc_video_frames_with_stable_opaque_ids(tmp_
     screenshots_dir = tmp_path / "screenshots"
     screenshots_dir.mkdir()
     (screenshots_dir / "Release-0.png").write_bytes(b"png")
-    (tmp_path / "posters").mkdir()
-    (tmp_path / "posters" / "POSTER.png").write_bytes(b"png")
+    artwork_dir = tmp_path / "artwork"
+    artwork_dir.mkdir()
+    (artwork_dir / "POSTER.png").write_bytes(b"png")
     (screenshots_dir / "Release-libplacebo-test.png").write_bytes(b"png")
 
     regular = list_screenshots(tmp_path, {"is_disc": ""})

--- a/tests/test_temp_paths.py
+++ b/tests/test_temp_paths.py
@@ -2,28 +2,26 @@
 
 from pathlib import Path
 
-from src.temp_paths import covers_dir, menu_screenshots_dir, posters_dir, screenshots_dir, spectrograms_dir
+from src.temp_paths import artwork_dir, menu_screenshots_dir, screenshots_dir, spectrograms_dir
 
 
 def test_typed_image_directories_are_isolated_per_release(tmp_path: Path) -> None:
     directories = {
         screenshots_dir(tmp_path, "release"),
-        posters_dir(tmp_path, "release"),
-        covers_dir(tmp_path, "release"),
+        artwork_dir(tmp_path, "release"),
         menu_screenshots_dir(tmp_path, "release"),
         spectrograms_dir(tmp_path, "release"),
     }
     other_directories = {
         screenshots_dir(tmp_path, "other-release"),
-        posters_dir(tmp_path, "other-release"),
-        covers_dir(tmp_path, "other-release"),
+        artwork_dir(tmp_path, "other-release"),
         menu_screenshots_dir(tmp_path, "other-release"),
         spectrograms_dir(tmp_path, "other-release"),
     }
 
-    assert len(directories) == 5
+    assert len(directories) == 4
     assert {path.parent.name for path in directories} == {"release"}
     assert {path.parent.name for path in other_directories} == {"other-release"}
     assert directories.isdisjoint(other_directories)
-    assert {path.name for path in directories} == {"screenshots", "posters", "covers", "menu_screenshots", "spectrograms"}
+    assert {path.name for path in directories} == {"screenshots", "artwork", "menu_screenshots", "spectrograms"}
     assert all(path.is_dir() for path in directories)

--- a/upload.py
+++ b/upload.py
@@ -38,6 +38,7 @@ from bin.get_mkbrr import MkbrrBinaryManager
 from cogs.redaction import PathAwareEncoder, Redaction
 from src.add_comparison import ComparisonManager
 from src.args import Args
+from src.artwork import is_valid_cover_image
 from src.audio_spectrogram import process_audio_spectrograms
 from src.book_prep import detect_newspaper, is_valid_book_language, resolve_book_language
 from src.cleanup import cleanup_manager
@@ -55,8 +56,8 @@ from src.get_tracker_data import TrackerDataManager
 from src.qbitwait import Wait
 from src.queuemanage import QueueManager
 from src.rehostimages import check_tracker_image_hosts
-from src.takescreens import TakeScreensManager
-from src.temp_paths import covers_dir, posters_dir, screenshots_dir
+from src.takescreens import TakeScreensManager, download_artwork_from_meta
+from src.temp_paths import artwork_dir, screenshots_dir
 from src.torrentcreate import TorrentCreator
 from src.trackerhandle import process_trackers
 from src.trackers.alpharatio import AlphaRatio
@@ -546,6 +547,10 @@ async def _prompt_book_meta(meta: Meta) -> None:
             iso = meta.book_language_iso
             if not is_valid_book_language(str(val), iso):
                 book_missing.append(f)
+    has_artwork = bool(is_valid_cover_image(meta.artwork_path) or _is_http_url(meta.artwork_url))
+    if not has_artwork:
+        book_missing.append("artwork")
+
     if not book_missing:
         return
 
@@ -553,7 +558,7 @@ async def _prompt_book_meta(meta: Meta) -> None:
         logger.info(
             f"[yellow]BOOK upload: the following required fields are missing: "
             f"{', '.join(book_missing)}. "
-            f"Re-run with -btitle / -author / -year / -blang to supply them, "
+            f"Re-run with -btitle / -author / -year / -blang / --book-cover to supply them, "
             f"or trackers that require them will be skipped.[/yellow]"
         )
         return
@@ -562,7 +567,7 @@ async def _prompt_book_meta(meta: Meta) -> None:
     name_needs_rebuild = False
     try:
         for field in book_missing:
-            prompt_label = "language" if field == "book_language" else field
+            prompt_label = "language" if field == "book_language" else ("cover artwork (path to image file or URL)" if field == "artwork" else field)
             if field == "book_language":
                 while True:
                     value = (CLI_UI.ask_string("Enter language (leave blank to skip): ") or "").strip()
@@ -587,6 +592,20 @@ async def _prompt_book_meta(meta: Meta) -> None:
                         name_needs_rebuild = True
                         break
                     logger.info("[red]Invalid year (must be a 4-digit number between 1000 and 3000). Please try again.[/red]")
+            elif field == "artwork":
+                while True:
+                    value = (CLI_UI.ask_string("Enter path to cover artwork image (or public image URL) for BOOK: ") or "").strip()
+                    if not value:
+                        logger.info("[red]Artwork is required for BOOK uploads. Please enter a valid file path or image URL.[/red]")
+                        continue
+                    if _is_http_url(value):
+                        meta.artwork_url = value
+                        break
+                    path_obj = Path(value).expanduser()
+                    if path_obj.is_file():
+                        meta.artwork_path = str(path_obj.resolve())
+                        break
+                    logger.info("[red]Invalid artwork path or URL. The file does not exist or URL is invalid. Please try again.[/red]")
             else:
                 value = (CLI_UI.ask_string(f"Enter {prompt_label} (leave blank to skip): ") or "").strip()
                 if value:
@@ -937,10 +956,11 @@ async def _host_music_cover(meta: Meta, uploadscreens_manager: UploadScreensMana
 
     artwork_path = Path(str(meta.artwork_path or ""))
     if not artwork_path.is_file() and _is_http_url(meta.artwork_url):
-        artwork_path = covers_dir(meta.base_dir, str(meta.uuid)) / "music_cover.jpg"
+        artwork_path = artwork_dir(meta.base_dir, str(meta.uuid)) / "music_cover.jpg"
         content = await asyncio.to_thread(_download_music_cover, meta.artwork_url)
         if content is None:
             return
+
         try:
             artwork_path.parent.mkdir(parents=True, exist_ok=True)
             await asyncio.to_thread(artwork_path.write_bytes, content)
@@ -969,6 +989,20 @@ async def _host_music_cover(meta: Meta, uploadscreens_manager: UploadScreensMana
     await _write_music_snapshot(meta)
 
 
+async def _ensure_valid_book_artwork(meta: Meta) -> bool:
+    """Ensure every BOOK upload has a local, decodable image before tracker checks."""
+    if is_valid_cover_image(meta.artwork_path):
+        return True
+
+    if not _is_http_url(meta.artwork_url):
+        return False
+
+    destination = artwork_dir(meta.base_dir, meta.uuid) / "manual_cover.jpg"
+    if await download_artwork_from_meta(meta, str(destination), force=True):
+        return is_valid_cover_image(meta.artwork_path)
+    return False
+
+
 async def _prompt_music_meta(meta: Meta) -> None:
     """Ask for minimum Orpheus music metadata, never technical stream fields."""
     required = list(MUSIC_REQUIRED_FIELDS)
@@ -977,6 +1011,10 @@ async def _prompt_music_meta(meta: Meta) -> None:
         for field in required
         if (field == "cover_url" and not _is_http_url(_music_field(meta, field))) or (field != "cover_url" and not str(_music_field(meta, field) or "").strip())
     ]
+    has_artwork = bool((meta.artwork_path and Path(meta.artwork_path).is_file()) or (_is_http_url(meta.artwork_url) or _is_http_url(_music_field(meta, "cover_url"))))
+    if not has_artwork and "artwork" not in missing:
+        missing.append("artwork")
+
     conflicts = meta.music_release.get("conflicts", {}) if isinstance(meta.music_release, dict) else {}
     contextual: list[str] = []
     if isinstance(conflicts, dict) and conflicts.get("year") and "year" not in missing:
@@ -1029,16 +1067,24 @@ async def _prompt_music_meta(meta: Meta) -> None:
                 if value:
                     _set_music_field(meta, field, value)
                     changed = True
-            elif field == "cover_url":
+            elif field in ("artwork", "cover_url"):
                 while True:
-                    value = (CLI_UI.ask_string("Enter public album-art URL for Orpheus (https://...; leave blank to skip): ") or "").strip()
+                    value = (CLI_UI.ask_string("Enter path to cover artwork image (or public image URL) for MUSIC: ") or "").strip()
                     if not value:
-                        break
+                        logger.info("[red]Artwork is required for MUSIC uploads. Please enter a valid file path or image URL.[/red]")
+                        continue
                     if _is_http_url(value):
-                        _set_music_field(meta, field, value)
+                        _set_music_field(meta, "cover_url", value)
+                        meta.artwork_url = value
                         changed = True
                         break
-                    logger.info("[red]Invalid artwork URL (must be an HTTP or HTTPS link).[/red]")
+                    path_obj = Path(value).expanduser()
+                    if path_obj.is_file():
+                        meta.artwork_path = str(path_obj.resolve())
+                        _set_music_field(meta, "cover_url", meta.artwork_path, source="user")
+                        changed = True
+                        break
+                    logger.info("[red]Invalid artwork path or URL. The file does not exist or URL is invalid. Please try again.[/red]")
     except EOFError:
         logger.info("[yellow]Input cancelled — continuing with missing music fields.[/yellow]")
         return
@@ -1144,6 +1190,14 @@ async def process_meta(meta: Meta, base_dir: str) -> bool:
     # and into get_name (which runs again below if any field was filled in).
     if meta.category == "BOOK":
         await _prompt_book_meta(meta)
+        while not await _ensure_valid_book_artwork(meta):
+            if meta.unattended:
+                logger.info("[yellow]BOOK upload: no valid cover could be obtained. Skipping all selected trackers.[/yellow]")
+                meta.trackers = []
+                break
+            meta.artwork_path = ""
+            meta.artwork_url = ""
+            await _prompt_book_meta(meta)
 
     if meta.category == "GAME":
         await _prompt_game_meta(meta)
@@ -1811,7 +1865,7 @@ async def process_meta(meta: Meta, base_dir: str) -> bool:
                     if Path(artwork_url).exists():
                         artwork_path = artwork_url
                     else:
-                        poster_jpg_path = str(posters_dir(meta.base_dir, meta.uuid) / "poster.jpg")
+                        poster_jpg_path = str(artwork_dir(meta.base_dir, meta.uuid) / "poster.jpg")
                         try:
                             import urllib.parse
                             import urllib.request
@@ -1836,7 +1890,10 @@ async def process_meta(meta: Meta, base_dir: str) -> bool:
                                 if isinstance(loaded_covers, list) and len(loaded_covers) > 0 and loaded_covers[0].get("raw_url"):
                                     use_cached_cover = True
                                     meta.hosted_artwork = loaded_covers
-                                    logger.debug(f"[green]Using cached cover from covers.json: {loaded_covers[0]['raw_url']}")
+                                    raw_url = loaded_covers[0]["raw_url"]
+                                    meta.artwork_url = raw_url
+                                    meta.rehosted_artwork_url = raw_url
+                                    logger.debug(f"[green]Using cached cover from covers.json: {raw_url}")
                         except Exception as e:
                             logger.debug(f"[red]Error reading covers.json cache: {e}")
 
@@ -1848,7 +1905,11 @@ async def process_meta(meta: Meta, base_dir: str) -> bool:
                                 async with aiofiles.open(covers_file, "w", encoding="utf-8") as f:
                                     await f.write(json.dumps(uploaded_cover, indent=4))
                                 meta.hosted_artwork = uploaded_cover
-                                logger.debug(f"[green]Successfully uploaded book cover and saved to covers.json: {uploaded_cover[0].get('raw_url')}")
+                                raw_url = uploaded_cover[0].get("raw_url", uploaded_cover[0].get("img_url", ""))
+                                if raw_url:
+                                    meta.artwork_url = raw_url
+                                    meta.rehosted_artwork_url = raw_url
+                                logger.debug(f"[green]Successfully uploaded book cover and saved to covers.json: {raw_url}")
                             else:
                                 logger.error("[red]Failed to upload book cover: upload_screens returned empty result")
                         except Exception as e:

--- a/upload.py
+++ b/upload.py
@@ -5,7 +5,6 @@ import asyncio
 import contextlib
 import filecmp
 import gc
-import ipaddress
 import json
 import os
 import platform
@@ -13,7 +12,6 @@ import re
 import shlex
 import shutil
 import signal
-import socket
 import sys
 import threading
 import time
@@ -38,7 +36,7 @@ from bin.get_mkbrr import MkbrrBinaryManager
 from cogs.redaction import PathAwareEncoder, Redaction
 from src.add_comparison import ComparisonManager
 from src.args import Args
-from src.artwork import is_valid_cover_image
+from src.artwork import is_public_http_url, is_valid_cover_image
 from src.audio_spectrogram import process_audio_spectrograms
 from src.book_prep import detect_newspaper, is_valid_book_language, resolve_book_language
 from src.cleanup import cleanup_manager
@@ -854,19 +852,7 @@ MUSIC_COVER_MAX_REDIRECTS = 3
 
 def _is_public_music_cover_url(value: Any) -> bool:
     """Allow artwork downloads only from public HTTP(S) hosts."""
-    if not _is_http_url(value):
-        return False
-    host = urlparse(str(value).strip()).hostname
-    if not host:
-        return False
-    try:
-        addresses = {result[4][0] for result in socket.getaddrinfo(host, None, type=socket.SOCK_STREAM)}
-    except OSError:
-        return False
-    try:
-        return bool(addresses) and all(ipaddress.ip_address(address).is_global for address in addresses)
-    except ValueError:
-        return False
+    return is_public_http_url(str(value or ""))
 
 
 def _download_music_cover(url: str) -> bytes | None:
@@ -968,7 +954,8 @@ async def _host_music_cover(meta: Meta, uploadscreens_manager: UploadScreensMana
         except OSError as error:
             logger.warning(f"[yellow]MUSIC: could not save downloaded artwork for image hosting: {error}[/yellow]")
             return
-    if not artwork_path.is_file():
+    if not is_valid_cover_image(artwork_path):
+        logger.warning("[yellow]MUSIC: local artwork is not a valid supported image.[/yellow]")
         return
 
     try:
@@ -1011,7 +998,7 @@ async def _prompt_music_meta(meta: Meta) -> None:
         for field in required
         if (field == "cover_url" and not _is_http_url(_music_field(meta, field))) or (field != "cover_url" and not str(_music_field(meta, field) or "").strip())
     ]
-    has_artwork = bool((meta.artwork_path and Path(meta.artwork_path).is_file()) or (_is_http_url(meta.artwork_url) or _is_http_url(_music_field(meta, "cover_url"))))
+    has_artwork = bool(is_valid_cover_image(meta.artwork_path) or (_is_http_url(meta.artwork_url) or _is_http_url(_music_field(meta, "cover_url"))))
     if not has_artwork and "artwork" not in missing:
         missing.append("artwork")
 
@@ -1079,7 +1066,7 @@ async def _prompt_music_meta(meta: Meta) -> None:
                         changed = True
                         break
                     path_obj = Path(value).expanduser()
-                    if path_obj.is_file():
+                    if is_valid_cover_image(path_obj):
                         meta.artwork_path = str(path_obj.resolve())
                         _set_music_field(meta, "cover_url", meta.artwork_path, source="user")
                         changed = True

--- a/web_ui/server.py
+++ b/web_ui/server.py
@@ -1326,7 +1326,7 @@ def _book_cover_from_meta(meta_data: Mapping[str, object], preview_session_id: s
     if not meta_uuid:
         return ""
 
-    tmp_dir = Path(__file__).parent.parent / "tmp" / meta_uuid / "posters"
+    tmp_dir = Path(__file__).parent.parent / "tmp" / meta_uuid / "artwork"
     for filename in ("POSTER.png", "poster.png", "POSTER.jpg", "poster.jpg", "cover.jpg", "cover.png"):
         if (tmp_dir / filename).exists():
             return f"/api/execution_preview_cover?session_id={preview_session_id}"
@@ -1849,9 +1849,9 @@ def _find_execution_preview_cover_file(session_id: str) -> Path | None:
     candidate_dirs: list[Path] = []
     if meta_uuid:
         release_tmp = Path(__file__).parent.parent / "tmp" / meta_uuid
-        candidate_dirs.extend((release_tmp / "covers", release_tmp / "posters"))
+        candidate_dirs.append(release_tmp / "artwork")
     release_tmp = Path(__file__).parent.parent / "tmp" / Path(execution_path).name
-    candidate_dirs.extend((release_tmp / "covers", release_tmp / "posters"))
+    candidate_dirs.append(release_tmp / "artwork")
 
     # A music sidecar cover may stay beside the release, while embedded art is
     # extracted into tmp/MUSIC_COVER.*.  Never serve an arbitrary configured

--- a/web_ui/server.py
+++ b/web_ui/server.py
@@ -1886,6 +1886,8 @@ def _find_execution_preview_cover_file(session_id: str) -> Path | None:
             "cover.jpg",
             "cover.png",
             "cover.webp",
+            "manual_cover.jpg",
+            "music_cover.jpg",
         ):
             candidate = tmp_dir / filename
             if candidate.is_file():

--- a/web_ui/static/js/app.js
+++ b/web_ui/static/js/app.js
@@ -410,6 +410,11 @@ const argumentCategories = [
         description: "Override detected book title",
       },
       {
+        label: "--book-cover",
+        placeholder: "PATH_OR_URL",
+        description: "Required BOOK cover image path or public image URL",
+      },
+      {
         label: "--book-overview",
         placeholder: "SYNOPSIS",
         description: "Book/Audiobook overview/synopsis (overrides auto-detected value)",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added book-cover support via local file paths or public image URLs.
  * Added artwork selection for music uploads using local files or URLs.
  * Added cover artwork configuration to the Books / Reading interface.
* **Bug Fixes**
  * Invalid, empty, unsupported, or unreadable images are now rejected.
  * Uploads without valid required artwork are skipped safely.
* **Improvements**
  * Consolidated poster and cover handling into a shared artwork location.
  * Valid artwork is reused consistently across downloads, previews, and uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->