### PR TITLE
fix: Aither full-dvd naming

### DIFF
--- a/src/trackers/UNIT3D/aither.py
+++ b/src/trackers/UNIT3D/aither.py
@@ -100,7 +100,14 @@ class Aither(UNIT3D):
             aither_name = aither_name.replace(f"{source}", f"{resolution} {source}", 1)
             aither_name = aither_name.replace((meta.audio), f"{meta.audio}{video_encode}", 1)
 
-        elif meta.is_disc == "DVD" or (name_type == "REMUX" and source in ("PAL DVD", "NTSC DVD", "DVD")):
+        elif meta.is_disc == "DVD":
+            region_and_source = " ".join(part for part in (meta.region, source) if part)
+            disc_details = " ".join(part for part in (resolution, meta.region, source) if part)
+            if region_and_source:
+                aither_name = aither_name.replace(region_and_source, disc_details, 1)
+            aither_name = aither_name.replace((meta.audio), f"{video_codec} {meta.audio}", 1)
+
+        elif name_type == "REMUX" and source in ("PAL DVD", "NTSC DVD", "DVD"):
             aither_name = aither_name.replace(meta.source or "", f"{resolution} {meta.source}", 1)
             aither_name = aither_name.replace((meta.audio), f"{video_codec} {meta.audio}", 1)
 


### PR DESCRIPTION
Title AKA Year Cut Hybrid REPACK Resolution Country Source HDR VideoCodec AudioCodec Channels Metadata-Tag

Put resolution before region/country.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DVD release naming to distinguish standard DVD discs from DVD remuxes.
  * DVD names now include available resolution, region, source, and video codec details for clearer identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->