### PR TITLE
fix(unit3d): use auth headers and map DVD metadata

### DIFF
--- a/src/prep_helpers.py
+++ b/src/prep_helpers.py
@@ -920,7 +920,7 @@ async def search_metadata(
 
     # if there's no region/distributor info, lets ping some unit3d trackers and see if we get it
     ping_unit3d_config = prep_instance.config["DEFAULT"].get("ping_unit3d", False)
-    if (not meta.region or not meta.distributor) and meta.is_disc == "BDMV" and ping_unit3d_config and not meta.edit and not meta.site_check:
+    if (not meta.region or not meta.distributor) and meta.is_disc in ("BDMV", "DVD") and ping_unit3d_config and not meta.edit and not meta.site_check:
         await prep_instance.tracker_data_manager.ping_unit3d(meta)
 
     # the first user override check that allows to set metadata ids.

--- a/src/trackers/common.py
+++ b/src/trackers/common.py
@@ -2582,10 +2582,14 @@ class Common:
         raw_api_key = self.config["TRACKERS"][tracker].get("api_key")
         api_key = str(raw_api_key).strip() if raw_api_key else ""
         params: dict[str, str] = {"api_token": api_key}
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Accept": "application/json",
+        }
         url = f"{torrent_url}{id}"
         try:
             async with httpx.AsyncClient(timeout=30.0) as client:
-                response = await client.get(url=url, params=params)
+                response = await client.get(url=url, params=params, headers=headers)
                 json_response = response.json()
         except (httpx.RequestError, httpx.TimeoutException) as e:
             logger.info(f"[yellow]Request error in unit3d_region_distributor: {e}[/yellow]")
@@ -2638,6 +2642,10 @@ class Common:
         raw_api_key = self.config["TRACKERS"][tracker].get("api_key")
         api_key = str(raw_api_key).strip() if raw_api_key else ""
         params: dict[str, Any] = {"api_token": api_key}
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Accept": "application/json",
+        }
 
         # Determine the search method and add parameters accordingly
         if file_name:
@@ -2655,7 +2663,7 @@ class Common:
         try:
             async with httpx.AsyncClient(timeout=5.0) as client:
                 logger.info(f"Searching for information on [bold cyan]{tracker}[/bold cyan]")
-                response = await client.get(url=url, params=params)
+                response = await client.get(url=url, params=params, headers=headers)
                 json_response = response.json()
         except (httpx.RequestError, httpx.TimeoutException) as e:
             logger.info(f"[yellow]Request error in unit3d_torrent_info: {e}[/yellow]")
@@ -2685,12 +2693,12 @@ class Common:
                 tvdb = 0 if tvdb == 0 else tvdb
                 mal = 0 if mal == 0 else mal
                 imdb = 0 if imdb == 0 else imdb
-                if not meta.region and meta.is_disc == "BDMV":
+                if not meta.region and meta.is_disc in ("BDMV", "DVD"):
                     region_id = attributes.get("region_id")
                     region_name = await self.unit3d_region_ids(reverse=True, region_id=region_id)
                     if region_name:
                         meta.region = region_name
-                if not meta.distributor and meta.is_disc == "BDMV":
+                if not meta.distributor and meta.is_disc in ("BDMV", "DVD"):
                     distributor_id = attributes.get("distributor_id")
                     distributor_name = await self.unit3d_distributor_ids(reverse=True, distributor_id=distributor_id)
                     if distributor_name:
@@ -2712,12 +2720,12 @@ class Common:
                     tvdb = 0 if tvdb == 0 else tvdb
                     mal = 0 if mal == 0 else mal
                     imdb = 0 if imdb == 0 else imdb
-                    if not meta.region and meta.is_disc == "BDMV":
+                    if not meta.region and meta.is_disc in ("BDMV", "DVD"):
                         region_id = attributes.get("region_id")
                         region_name = await self.unit3d_region_ids(reverse=True, region_id=region_id)
                         if region_name:
                             meta.region = region_name
-                    if not meta.distributor and meta.is_disc == "BDMV":
+                    if not meta.distributor and meta.is_disc in ("BDMV", "DVD"):
                         distributor_id = attributes.get("distributor_id")
                         distributor_name = await self.unit3d_distributor_ids(reverse=True, distributor_id=distributor_id)
                         if distributor_name:


### PR DESCRIPTION
Use Bearer authorization for UNIT3D metadata requests, while retaining the query token. Also fetch region and distributor metadata for DVD discs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metadata lookup for both BDMV and DVD discs when region or distributor information is missing.
  * Enhanced compatibility with different API response formats for region and distributor details.
  * Improved tracker API request handling to support reliable metadata and torrent information retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->