### PR TITLE
fix(hdbits): return 6-tuple on API error in search_filename

### DIFF
--- a/src/disc_menus.py
+++ b/src/disc_menus.py
@@ -12,8 +12,8 @@ from pymediainfo import MediaInfo
 
 from src.console import logger
 from src.meta import Meta
-from src.temp_paths import menu_screenshots_dir
 from src.takescreens import screenshot_par_scale_factors, should_scale_screenshots_for_par
+from src.temp_paths import menu_screenshots_dir
 from src.uploadscreens import UploadScreensManager
 
 

--- a/src/trackers/hdbits.py
+++ b/src/trackers/hdbits.py
@@ -842,7 +842,7 @@ class HDBits:
 
         return hdb_imdb, hdb_tvdb, hdb_name, hdb_torrenthash, hdb_description
 
-    async def search_filename(self, search_term: str, search_file_folder: str, meta: Meta):
+    async def search_filename(self, search_term: str, search_file_folder: str, meta: Meta) -> tuple[int | None, int | None, str | None, str | None, str | None, int | None]:
         hdb_imdb = hdb_tvdb = hdb_name = hdb_torrenthash = hdb_description = hdb_id = None
         url = f"{self.base_url}/api/torrents"
 
@@ -895,7 +895,7 @@ class HDBits:
                         logger.error(
                             f"{self.tracker}: [red]Error: 'data' key not found or empty in {self.tracker} API response. Full response: {escape(str(response_json))}[/red]"
                         )
-                        return hdb_imdb, hdb_tvdb, hdb_name, hdb_torrenthash, hdb_id
+                        return hdb_imdb, hdb_tvdb, hdb_name, hdb_torrenthash, hdb_description, hdb_id
 
                     for each in response_json["data"]:
                         hdb_imdb = int(each.get("imdb", {}).get("id") or 0)

--- a/tests/test_hdbits_search.py
+++ b/tests/test_hdbits_search.py
@@ -1,0 +1,35 @@
+import asyncio
+
+import pytest
+
+from src.meta import Meta
+from src.trackers.hdbits import HDBits
+
+
+class _AuthErrorResponse:
+    is_success = True
+
+    @staticmethod
+    def json() -> dict[str, object]:
+        return {"status": 4, "message": "Missing authentication data (username)"}
+
+
+class _FakeAsyncClient:
+    async def __aenter__(self) -> _FakeAsyncClient:
+        return self
+
+    async def __aexit__(self, *_args: object) -> None:
+        pass
+
+    @staticmethod
+    async def post(*_args: object, **_kwargs: object) -> _AuthErrorResponse:
+        return _AuthErrorResponse()
+
+
+def test_hdbits_search_returns_six_values_for_api_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("src.trackers.hdbits.httpx.AsyncClient", lambda **_kwargs: _FakeAsyncClient())
+    tracker = HDBits({"TRACKERS": {"HDBITS": {}}})
+
+    result = asyncio.run(tracker.search_filename("Gladiator.2000.mkv", "file", Meta(category="MOVIE")))
+
+    assert result == (None, None, None, None, None, None)  # noqa: S101


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HDBits search handling when no matching data is available.
  * Authentication failures now return a consistent empty result instead of causing unexpected behavior.
  * Search results can now preserve description information when provided.

* **Reliability**
  * Added coverage for authentication-error responses to help ensure stable search behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->