### PR TITLE
refactor(ffmpeg): inspect command node for output path and inject publish_preview in Prep

### DIFF
--- a/src/prep.py
+++ b/src/prep.py
@@ -1,8 +1,9 @@
 import asyncio
 import json
-from pathlib import Path
 
 # Upload Assistant © 2025 Audionut & wastaken7 — Licensed under UAPL v1.0
+from collections.abc import Callable
+from pathlib import Path
 from typing import Any, cast
 
 from src.cogs.redaction import PathAwareEncoder
@@ -60,10 +61,17 @@ class Prep:
         Create Name
     """
 
-    def __init__(self, screens: int, img_host: str, config: dict[str, Any]) -> None:
+    def __init__(
+        self,
+        screens: int,
+        img_host: str,
+        config: dict[str, Any],
+        publish_preview: Callable[[str, str | None], None] | None = None,
+    ) -> None:
         self.screens = screens
         self.config = config
         self.img_host = img_host.lower()
+        self.publish_preview = publish_preview
         self.tvdb_handler = TvdbData(config)
         self.overrides = ApplyOverrides(config)
         self.audio_manager = AudioManager(config)
@@ -125,13 +133,8 @@ class Prep:
         meta_file.parent.mkdir(parents=True, exist_ok=True)
         async with aiofiles.open(meta_file, "w", encoding="utf-8") as snapshot:
             await snapshot.write(json.dumps(meta.to_dict(), indent=4, cls=PathAwareEncoder))
-        try:
-            from upload import _publish_webui_preview_target
-
-            _publish_webui_preview_target(str(meta.path or ""), meta.uuid)
-        except Exception:
-            # CLI preparation deliberately has no dependency on the WebUI server.
-            return
+        if self.publish_preview is not None:
+            self.publish_preview(str(meta.path or ""), meta.uuid)
 
     async def gather_prep(self, meta: Meta, mode: str) -> Meta:
         meta_start_time = time.time()

--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -48,6 +48,30 @@ def compile_ffmpeg_command(command: Any) -> list[str]:
     return [str(argument) for argument in command.compile()]
 
 
+def get_ffmpeg_output_path(command: Any, cmd_list: list[str]) -> str:
+    """Return ffmpeg-python's output filename without relying on argument order."""
+    nodes = [getattr(command, "node", None)]
+    visited: set[int] = set()
+
+    while nodes:
+        node = nodes.pop()
+        if node is None or id(node) in visited:
+            continue
+        visited.add(id(node))
+
+        kwargs = getattr(node, "kwargs", {})
+        filename = kwargs.get("filename") if isinstance(kwargs, dict) else None
+        if filename is not None:
+            return str(filename)
+
+        incoming_edges = getattr(node, "_KwargReprNode__incoming_edge_map", {})
+        if isinstance(incoming_edges, dict):
+            nodes.extend(edge[0] for edge in incoming_edges.values() if edge)
+
+    # Keep compatibility with lightweight command doubles used by callers.
+    return cmd_list[-1] if cmd_list else ""
+
+
 algorithm = "mobius"
 desat = 10.0
 
@@ -89,7 +113,7 @@ async def run_ffmpeg(command: Any) -> tuple[int | None, bytes, bytes]:
     # FFREPORT defaults to a timestamped file in the current working
     # directory.  Keep each report beside its output, with a unique name so
     # concurrent or repeated runs do not overwrite an earlier report.
-    output_path = cmd_list[-1] if cmd_list else ""
+    output_path = get_ffmpeg_output_path(command, cmd_list)
     if output_path and output_path not in {"-", "pipe:"} and not output_path.startswith("pipe:"):
         report_path = Path(output_path).resolve().parent / f"ffmpeg-{uuid.uuid4().hex}.log"
         report_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -64,9 +64,8 @@ def get_ffmpeg_output_path(command: Any, cmd_list: list[str]) -> str:
         if filename is not None:
             return str(filename)
 
-        incoming_edges = getattr(node, "_KwargReprNode__incoming_edge_map", {})
-        if isinstance(incoming_edges, dict):
-            nodes.extend(edge[0] for edge in incoming_edges.values() if edge)
+        incoming_edges = getattr(node, "incoming_edges", ())
+        nodes.extend(edge.upstream_node for edge in incoming_edges if getattr(edge, "upstream_node", None) is not None)
 
     # Keep compatibility with lightweight command doubles used by callers.
     return cmd_list[-1] if cmd_list else ""

--- a/src/trackers/UNIT3D/capybarabr.py
+++ b/src/trackers/UNIT3D/capybarabr.py
@@ -200,7 +200,8 @@ class CapybaraBR(UNIT3D):
             if self.tracker == "CAPYBARABR" and meta.type == "DVDRIP":
                 title = meta.aka.replace("AKA", "").strip() if meta.original_language == "pt" and meta.aka else meta.title
                 episode = f"{meta.season}{meta.episode}" if category == "TV" else ""
-                cbr_name = " ".join(part for part in (title, str(meta.year or ""), episode, meta.resolution, "DVDRip", meta.audio, meta.video_encode) if part)
+                audio = str(meta.audio).replace("DD+ ", "DDP").replace("DD ", "DD").replace("AAC ", "AAC").replace("FLAC ", "FLAC")
+                cbr_name = " ".join(part for part in (title, str(meta.year or ""), episode, meta.resolution, "DVDRip", audio, meta.video_encode) if part)
                 if meta.tag:
                     cbr_name += meta.tag
 

--- a/tests/test_samaritano.py
+++ b/tests/test_samaritano.py
@@ -45,7 +45,7 @@ def test_capybarabr_formats_dvdrips_with_resolution_before_audio_and_codec() -> 
         year=2001,
         type="DVDRIP",
         resolution="480p",
-        audio="DD2.0",
+        audio="DD 2.0",
         video_encode="x264",
         tag="-DDOS",
     )

--- a/tests/test_takescreens_ffmpeg.py
+++ b/tests/test_takescreens_ffmpeg.py
@@ -5,6 +5,7 @@ import asyncio
 import sys
 from types import SimpleNamespace
 
+import ffmpeg
 import pytest
 
 from src import takescreens
@@ -36,12 +37,10 @@ async def test_run_ffmpeg_writes_report_next_to_output(tmp_path, monkeypatch):
     monkeypatch.setattr(takescreens.platform, "system", lambda: "Windows")
     monkeypatch.setattr(takescreens.asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
 
-    class Command:
-        def compile(self):
-            return ["ffmpeg", "-i", output.with_name("source.mkv"), output]
+    command = ffmpeg.input(str(output.with_name("source.mkv"))).output(str(output), vframes=1).global_args("-y", "-loglevel", "quiet")
 
-    process = await takescreens.run_ffmpeg(Command())
-    second_process = await takescreens.run_ffmpeg(Command())
+    process = await takescreens.run_ffmpeg(command)
+    second_process = await takescreens.run_ffmpeg(command)
 
     assert process == (0, b"", b"")
     assert second_process == (0, b"", b"")

--- a/upload.py
+++ b/upload.py
@@ -1121,7 +1121,7 @@ async def process_meta(meta: Meta, base_dir: str) -> bool:
         if str(ua).lower() == "true":
             meta.unattended = True
             logger.info("[yellow]Running in Auto Mode")
-    prep = Prep(screens=meta.screens, img_host=meta.imghost, config=config)
+    prep = Prep(screens=meta.screens, img_host=meta.imghost, config=config, publish_preview=_publish_webui_preview_target)
     try:
         meta = await prep.gather_prep(meta=meta, mode="cli")
     except Exception as e:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Web UI preview snapshots are now published more reliably during the prep flow.
  * FFmpeg report/output paths are now detected more accurately for screen capture runs.

* **Bug Fixes**
  * Improved handling of preview publishing so it works consistently without relying on fallback behavior.
  * Reduced the chance of incorrect report-file naming when generating FFmpeg output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->