### PR TITLE
fix: use self.tracker for tracker config lookups and prevent description duplicate rendering

### DIFF
--- a/src/get_desc.py
+++ b/src/get_desc.py
@@ -1217,15 +1217,16 @@ class DescriptionBuilder:
         if self.tracker in {"LAJIDUI", "LONGPT", "PTCAFE", "PTFANS", "PTGTK", "RAILGUNPT", "NEXUSPHP"} and meta.nexusphp_description:
             desc_parts.append(meta.nexusphp_description)
 
+        meta_description_value = meta.description
+        if isinstance(meta_description_value, str):
+            meta_description = meta_description_value
+        elif meta_description_value is None:
+            meta_description = ""
+        else:
+            meta_description = str(meta_description_value)
+
         # Description that may come from API requests
         if description:
-            meta_description_value = meta.description
-            if isinstance(meta_description_value, str):
-                meta_description = meta_description_value
-            elif meta_description_value is None:
-                meta_description = ""
-            else:
-                meta_description = str(meta_description_value)
             # Add FraMeSToR NFO to AITHER
             if self.tracker == "AITHER" and "framestor" in meta and meta.framestor:
                 nfo_content = meta.description_nfo_content
@@ -1268,7 +1269,12 @@ class DescriptionBuilder:
 
         # Description from file/pastebin link
         if user_description:
-            desc_parts.append(await self.get_user_description(meta))
+            user_description_content = await self.get_user_description(meta)
+            # ``gen_desc`` promotes a supplied file/link to ``meta.description``
+            # while retaining it as the user-description source.  Trackers that
+            # enable both sections must not render that same content twice.
+            if not description or user_description_content.strip() != meta_description.strip():
+                desc_parts.append(user_description_content)
 
         # Menu Screenshots
         if menu_screenshots:

--- a/src/trackers/UNIT3D/racing4everyone.py
+++ b/src/trackers/UNIT3D/racing4everyone.py
@@ -114,7 +114,7 @@ class Racing4Everyone(UNIT3D):
         dupes: list[dict[str, Any]] = []
         url = self.search_url
         params: dict[str, Any] = {
-            "api_token": str(self.config["TRACKERS"]["RACING4EVERYONE"]["api_key"]).strip(),
+            "api_token": str(self.config["TRACKERS"][self.tracker]["api_key"]).strip(),
             "tmdb": meta.tmdb,
             "categories[]": (await self.get_category_id(meta))["category_id"],
             "types[]": (await self.get_type_id(meta))["type_id"],

--- a/src/trackers/bithdtv.py
+++ b/src/trackers/bithdtv.py
@@ -104,7 +104,7 @@ class BitHDTV:
             parsed_data: dict[str, Any] | None = cast(dict[str, Any] | None, parsed) if isinstance(parsed, dict) else None
             data_block: dict[str, Any] | None = parsed_data.get("data") if parsed_data else None
             if isinstance(data_block, dict) and "view" in data_block:
-                my_announce_url = self.config["TRACKERS"]["BITHDTV"].get("my_announce_url")
+                my_announce_url = self.config["TRACKERS"][self.tracker].get("my_announce_url")
                 if my_announce_url:
                     await common.create_torrent_ready_to_seed(meta, self.tracker, self.source_flag, my_announce_url, str(data_block["view"]))
                     return True

--- a/src/trackers/pterclub.py
+++ b/src/trackers/pterclub.py
@@ -41,11 +41,11 @@ class PTerClub:
 
     def __init__(self, config: Config) -> None:
         self.config: Config = config
-        self.passkey = str(config["TRACKERS"]["PTERCLUB"].get("passkey", "")).strip()
-        self.username = str(config["TRACKERS"]["PTERCLUB"].get("username", "")).strip()
-        self.password = str(config["TRACKERS"]["PTERCLUB"].get("password", "")).strip()
-        self.rehost_images = bool(config["TRACKERS"]["PTERCLUB"].get("img_rehost", False))
-        self.ptgen_api = str(config["TRACKERS"]["PTERCLUB"].get("ptgen_api", "")).strip()
+        self.passkey = str(config["TRACKERS"][self.tracker].get("passkey", "")).strip()
+        self.username = str(config["TRACKERS"][self.tracker].get("username", "")).strip()
+        self.password = str(config["TRACKERS"][self.tracker].get("password", "")).strip()
+        self.rehost_images = bool(config["TRACKERS"][self.tracker].get("img_rehost", False))
+        self.ptgen_api = str(config["TRACKERS"][self.tracker].get("ptgen_api", "")).strip()
         self.cookie_validator = CookieValidator(config)
 
     def _extract_auth_token(self, text: str, pattern: str) -> str:

--- a/src/trackers/torrenthr.py
+++ b/src/trackers/torrenthr.py
@@ -272,7 +272,7 @@ class TorrentHR:
             ordered_images.append(image)
 
         image_list: list[str] = []
-        image_api_key = str(self.config["TRACKERS"]["TORRENTHR"].get("img_api", "")).strip()
+        image_api_key = str(self.config["TRACKERS"][self.tracker].get("img_api", "")).strip()
         if ordered_images and not image_api_key:
             logger.info(f"{self.tracker}: [yellow]image API key is not configured, skipping screenshot rehost")
 
@@ -322,14 +322,14 @@ class TorrentHR:
         if (meta.is_disc) == "BDMV":
             async with aiofiles.open(f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/BD_SUMMARY_00.txt") as bd_file:
                 desc_parts.append(f"[nfo]{await bd_file.read()}[/nfo]")
-        elif self.config["TRACKERS"]["TORRENTHR"].get("pronfo_api_key"):
+        elif self.config["TRACKERS"][self.tracker].get("pronfo_api_key"):
             # ProNFO
-            pronfo_url = f"https://www.pronfo.com/api/v1/access/upload/{self.config['TRACKERS']['TORRENTHR'].get('pronfo_api_key', '')}"
+            pronfo_url = f"https://www.pronfo.com/api/v1/access/upload/{self.config['TRACKERS'][self.tracker].get('pronfo_api_key', '')}"
             async with aiofiles.open(f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/MEDIAINFO.txt") as mi_file:
                 data = {
                     "content": await mi_file.read(),
-                    "theme": self.config["TRACKERS"]["TORRENTHR"].get("pronfo_theme", "gray"),
-                    "rapi": self.config["TRACKERS"]["TORRENTHR"].get("pronfo_rapi_id"),
+                    "theme": self.config["TRACKERS"][self.tracker].get("pronfo_theme", "gray"),
+                    "rapi": self.config["TRACKERS"][self.tracker].get("pronfo_rapi_id"),
                 }
             async with httpx.AsyncClient(timeout=30.0) as client:
                 response = await client.post(pronfo_url, data=data)

--- a/tests/test_description_review.py
+++ b/tests/test_description_review.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 
 from src.description_review import load_review
-from src.get_desc import gen_desc
+from src.get_desc import DescriptionBuilder, gen_desc
 from src.meta import Meta
 from web_ui import server
 
@@ -82,5 +82,39 @@ def test_base_description_is_kept_in_meta_without_creating_description_file(tmp_
 
         assert meta.description == "tracker text"
         assert not (tmp_path / "tmp" / "release" / "DESCRIPTION.txt").exists()
+
+    asyncio.run(run())
+
+
+def test_description_file_is_not_rendered_twice_when_both_sections_are_enabled(tmp_path):
+    async def run():
+        description_file = tmp_path / "description.txt"
+        description_file.write_text("release notes", encoding="utf-8")
+        meta = Meta({"base_dir": str(tmp_path), "uuid": "release", "description_file": str(description_file)})
+        await gen_desc(meta, None, None)
+        builder = DescriptionBuilder("TEST", {"DEFAULT": {}, "TRACKERS": {"TEST": {}}})
+
+        result = await builder.general_description_generator(
+            meta,
+            audio_spectrogram=False,
+            bluray=False,
+            book=False,
+            custom_header=False,
+            custom_signature=False,
+            description=True,
+            game=False,
+            languages=False,
+            logo=False,
+            mediainfo=False,
+            menu_screenshots=False,
+            nfo=False,
+            screenshots=False,
+            tonemapped_header=False,
+            tv_info=False,
+            ua_signature=False,
+            user_description=True,
+        )
+
+        assert result == "release notes"
 
     asyncio.run(run())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate description content when multiple description sections are enabled.
  * Improved description handling for metadata values of different types.
  * Corrected tracker-specific settings and credentials loading across several trackers.
  * Ensured configured announcement URLs and tracker options are applied consistently.

* **Tests**
  * Added coverage to verify description files are rendered only once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->