### PR TITLE
fix(torrentleech): enforce two-column screenshot layout

### DIFF
--- a/src/get_desc.py
+++ b/src/get_desc.py
@@ -1503,11 +1503,13 @@ class DescriptionBuilder:
                             desc_parts.append(f"[spoiler={edition}][code]{summary}[/code][/spoiler]\n\n")
                             logger.debug("[yellow]Using original uploaded images for first disc")
                             desc_parts.append("[center]")
-                            for img in meta[new_images_key]:
+                            for img_index, img in enumerate(meta[new_images_key]):
                                 web_url = img["web_url"]
                                 raw_url = img["raw_url"]
                                 img_url = img.get("img_url", raw_url)
                                 desc_parts.append(self.format_screenshot(web_url, raw_url, img_url, thumb_size))
+                                if screens_per_row and (img_index + 1) % screens_per_row == 0:
+                                    desc_parts.append("\n")
                             desc_parts.append("[/center]\n\n")
                         else:
                             desc_parts.append("[center]\n\n")
@@ -1542,11 +1544,13 @@ class DescriptionBuilder:
                                     )
 
                                 desc_parts.append("[center]")
-                                for img in uploaded_images:
+                                for img_index, img in enumerate(uploaded_images):
                                     web_url = img["web_url"]
                                     raw_url = img["raw_url"]
                                     img_url = img.get("img_url", raw_url) or ""
                                     desc_parts.append(self.format_screenshot(web_url, raw_url, img_url, thumb_size))
+                                    if screens_per_row and (img_index + 1) % screens_per_row == 0:
+                                        desc_parts.append("\n")
                                 desc_parts.append("[/center]\n\n")
 
                             meta_filename = f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/meta.json"
@@ -1627,11 +1631,13 @@ class DescriptionBuilder:
                             desc_parts.append("[/center]\n\n")
                             # Use existing URLs from meta to write to descfile
                             desc_parts.append("[center]")
-                            for img in meta[new_images_key]:
+                            for img_index, img in enumerate(meta[new_images_key]):
                                 web_url = img["web_url"]
                                 raw_url = img["raw_url"]
                                 img_url = img.get("img_url", raw_url)
                                 desc_parts.append(self.format_screenshot(web_url, raw_url, img_url, thumb_size))
+                                if screens_per_row and (img_index + 1) % screens_per_row == 0:
+                                    desc_parts.append("\n")
                             desc_parts.append("[/center]\n\n")
                         else:
                             # Increment retry_count for tracking but use unique disc keys for each disc
@@ -1681,11 +1687,13 @@ class DescriptionBuilder:
 
                                 # Write new URLs to descfile
                                 desc_parts.append("[center]")
-                                for img in uploaded_images:
+                                for img_index, img in enumerate(uploaded_images):
                                     web_url = img["web_url"]
                                     raw_url = img["raw_url"]
                                     img_url = img.get("img_url", raw_url) or ""
                                     desc_parts.append(self.format_screenshot(web_url, raw_url, img_url, thumb_size))
+                                    if screens_per_row and (img_index + 1) % screens_per_row == 0:
+                                        desc_parts.append("\n")
                                 desc_parts.append("[/center]\n\n")
 
                             # Save the updated meta to `meta.json` after upload
@@ -1887,13 +1895,15 @@ class DescriptionBuilder:
                 elif multi_screens != 0 and new_images_key in meta and meta[new_images_key]:
                     desc_parts.append("[center]")
                     char_count += len("[center]")
-                    for img in meta[new_images_key]:
+                    for img_index, img in enumerate(meta[new_images_key]):
                         web_url = img["web_url"]
                         raw_url = img["raw_url"]
                         img_url = img.get("img_url", raw_url)
                         image_str = self.format_screenshot(web_url, raw_url, img_url, thumb_size)
                         desc_parts.append(image_str)
                         char_count += len(image_str)
+                        if screens_per_row and (img_index + 1) % screens_per_row == 0:
+                            desc_parts.append("\n")
                     desc_parts.append("[/center]\n\n")
                     char_count += len("[/center]\n\n")
 

--- a/src/get_desc.py
+++ b/src/get_desc.py
@@ -630,8 +630,7 @@ class DescriptionBuilder:
                     img_url = spec_img.get("img_url", raw_url) or ""
                     if web_url and raw_url:
                         desc_parts.append(self.format_screenshot(web_url, raw_url, img_url))
-                        if screens_per_row and (img_index + 1) % screens_per_row == 0:
-                            desc_parts.append("\n")
+                        self._append_screenshot_row_separator(desc_parts, img_index, screens_per_row)
             desc_parts.append("[/center]\n")
             return "".join(desc_parts)
         except Exception as e:
@@ -1443,8 +1442,7 @@ class DescriptionBuilder:
                 web_url = images[img_index]["web_url"]
                 raw_url = images[img_index]["raw_url"]
                 desc_parts.append(self.format_screenshot(web_url, raw_url))
-                if screens_per_row and (img_index + 1) % screens_per_row == 0:
-                    desc_parts.append("\n")
+                self._append_screenshot_row_separator(desc_parts, img_index, screens_per_row)
             desc_parts.append("[/center]")
             return "".join(desc_parts)
 
@@ -1463,8 +1461,7 @@ class DescriptionBuilder:
                 raw_url = images[img_index]["raw_url"]
                 img_url = images[img_index].get("img_url", raw_url)
                 desc_parts.append(self.format_screenshot(web_url, raw_url, img_url))
-                if screens_per_row and (img_index + 1) % screens_per_row == 0:
-                    desc_parts.append("\n")
+                self._append_screenshot_row_separator(desc_parts, img_index, screens_per_row)
             desc_parts.append("[/center]")
             if each["type"] == "BDMV":
                 bdinfo_keys = [key for key in each if key.startswith("bdinfo")]
@@ -1508,8 +1505,7 @@ class DescriptionBuilder:
                                 raw_url = img["raw_url"]
                                 img_url = img.get("img_url", raw_url)
                                 desc_parts.append(self.format_screenshot(web_url, raw_url, img_url, thumb_size))
-                                if screens_per_row and (img_index + 1) % screens_per_row == 0:
-                                    desc_parts.append("\n")
+                                self._append_screenshot_row_separator(desc_parts, img_index, screens_per_row)
                             desc_parts.append("[/center]\n\n")
                         else:
                             desc_parts.append("[center]\n\n")
@@ -1549,8 +1545,7 @@ class DescriptionBuilder:
                                     raw_url = img["raw_url"]
                                     img_url = img.get("img_url", raw_url) or ""
                                     desc_parts.append(self.format_screenshot(web_url, raw_url, img_url, thumb_size))
-                                    if screens_per_row and (img_index + 1) % screens_per_row == 0:
-                                        desc_parts.append("\n")
+                                    self._append_screenshot_row_separator(desc_parts, img_index, screens_per_row)
                                 desc_parts.append("[/center]\n\n")
 
                             meta_filename = f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/meta.json"
@@ -1592,8 +1587,7 @@ class DescriptionBuilder:
                         raw_url = images[img_index]["raw_url"]
                         img_url = images[img_index].get("img_url", raw_url)
                         desc_parts.append(self.format_screenshot(web_url, raw_url, img_url, thumb_size))
-                        if screens_per_row and (img_index + 1) % screens_per_row == 0:
-                            desc_parts.append("\n")
+                        self._append_screenshot_row_separator(desc_parts, img_index, screens_per_row)
                     desc_parts.append("[/center]\n\n")
                 else:
                     if multi_screens != 0:
@@ -1636,8 +1630,7 @@ class DescriptionBuilder:
                                 raw_url = img["raw_url"]
                                 img_url = img.get("img_url", raw_url)
                                 desc_parts.append(self.format_screenshot(web_url, raw_url, img_url, thumb_size))
-                                if screens_per_row and (img_index + 1) % screens_per_row == 0:
-                                    desc_parts.append("\n")
+                                self._append_screenshot_row_separator(desc_parts, img_index, screens_per_row)
                             desc_parts.append("[/center]\n\n")
                         else:
                             # Increment retry_count for tracking but use unique disc keys for each disc
@@ -1692,8 +1685,7 @@ class DescriptionBuilder:
                                     raw_url = img["raw_url"]
                                     img_url = img.get("img_url", raw_url) or ""
                                     desc_parts.append(self.format_screenshot(web_url, raw_url, img_url, thumb_size))
-                                    if screens_per_row and (img_index + 1) % screens_per_row == 0:
-                                        desc_parts.append("\n")
+                                    self._append_screenshot_row_separator(desc_parts, img_index, screens_per_row)
                                 desc_parts.append("[/center]\n\n")
 
                             # Save the updated meta to `meta.json` after upload
@@ -1742,8 +1734,7 @@ class DescriptionBuilder:
                 raw_url = images[img_index]["raw_url"]
                 img_url = images[img_index].get("img_url", raw_url)
                 desc_parts.append(self.format_screenshot(web_url, raw_url, img_url))
-                if screens_per_row and (img_index + 1) % screens_per_row == 0:
-                    desc_parts.append("\n")
+                self._append_screenshot_row_separator(desc_parts, img_index, screens_per_row)
             desc_parts.append("[/center]")
 
         # Handle multiple files case
@@ -1888,8 +1879,7 @@ class DescriptionBuilder:
                             image_str = self.format_screenshot(web_url, raw_url, img_url, thumb_size)
                             desc_parts.append(image_str)
                             char_count += len(image_str)
-                            if screens_per_row and (img_index + 1) % screens_per_row == 0:
-                                desc_parts.append("\n")
+                            char_count += len(self._append_screenshot_row_separator(desc_parts, img_index, screens_per_row))
                         desc_parts.append("[/center]\n\n")
                         char_count += len("[/center]\n\n")
                 elif multi_screens != 0 and new_images_key in meta and meta[new_images_key]:
@@ -1902,8 +1892,7 @@ class DescriptionBuilder:
                         image_str = self.format_screenshot(web_url, raw_url, img_url, thumb_size)
                         desc_parts.append(image_str)
                         char_count += len(image_str)
-                        if screens_per_row and (img_index + 1) % screens_per_row == 0:
-                            desc_parts.append("\n")
+                        char_count += len(self._append_screenshot_row_separator(desc_parts, img_index, screens_per_row))
                     desc_parts.append("[/center]\n\n")
                     char_count += len("[/center]\n\n")
 
@@ -1934,6 +1923,14 @@ class DescriptionBuilder:
             screens_per_row = 2
         return screens_per_row
 
+    def _append_screenshot_row_separator(self, parts: list[str], image_index: int, screens_per_row: int) -> str:
+        if not screens_per_row or (image_index + 1) % screens_per_row != 0:
+            return ""
+
+        separator = "<br><br>" if self.tracker == "TORRENTLEECH" else "\n"
+        parts.append(separator)
+        return separator
+
     async def menu_section(self, meta: Meta) -> str:
         menu_image_section = ""
         try:
@@ -1953,8 +1950,7 @@ class DescriptionBuilder:
                         if not web_url or not raw_url:
                             continue
                         menu_parts.append(self.format_screenshot(web_url, raw_url, img_url))
-                        if screens_per_row and (img_index + 1) % screens_per_row == 0:
-                            menu_parts.append("\n")
+                        self._append_screenshot_row_separator(menu_parts, img_index, screens_per_row)
                     menu_parts.append("[/center]\n\n")
                     menu_image_section = "".join(menu_parts)
         except Exception as e:

--- a/src/get_desc.py
+++ b/src/get_desc.py
@@ -1910,6 +1910,9 @@ class DescriptionBuilder:
 
     async def get_screens_per_row(self) -> int:
         try:
+            if self.tracker == "TORRENTLEECH":
+                return 2
+
             # If screens_per_row is set, use that to determine how many screenshots should be on each row. Otherwise, use 2 as default
             screens_per_row = self._get_int_config("screens_per_row", 2)
             if self.tracker == "HAWKEUNO":
@@ -1961,7 +1964,7 @@ class DescriptionBuilder:
         if self.tracker == "HDTORRENTS":
             return f"<a href='{raw_url}'><img src='{img_url}' height=137></a> "
         if self.tracker == "TORRENTLEECH":
-            return f'<a href="{web_url}"><img src="{img_url}" style="max-width: {thumb_size}px;"></a>  '
+            return f'<a href="{web_url}"><img src="{img_url}" style="max-width: 350px;"></a>  '
         if self.tracker == "FUNFILE":
             return f'<a href="{web_url}" target="_blank"><img src="{img_url}" width="{thumb_size}"></a> '
         if self.tracker == "GREATPOSTERWALL":

--- a/tests/test_torrentleech_description.py
+++ b/tests/test_torrentleech_description.py
@@ -25,12 +25,15 @@ def test_torrentleech_uses_original_ua_screenshot_layout() -> None:
 
 def test_other_trackers_keep_configured_screenshot_layout() -> None:
     config = {
-        "DEFAULT": {"screens_per_row": 4, "thumbnail_size": 450},
-        "TRACKERS": {"TEST": {}},
+        "DEFAULT": {"screens_per_row": 2, "thumbnail_size": 350},
+        "TRACKERS": {"TEST": {"screens_per_row": 4, "thumbnail_size": 450}},
     }
     builder = DescriptionBuilder("TEST", config)
 
     assert asyncio.run(builder.get_screens_per_row()) == 4
+    assert builder.format_screenshot("https://example.com/page", "https://example.com/raw.png", "https://example.com/thumb.png") == (
+        "[url=https://example.com/page][img=450]https://example.com/raw.png[/img][/url] "
+    )
 
     parts: list[str] = []
     assert builder._append_screenshot_row_separator(parts, 3, 4) == "\n"

--- a/tests/test_torrentleech_description.py
+++ b/tests/test_torrentleech_description.py
@@ -1,0 +1,37 @@
+# ruff: noqa: S101
+import asyncio
+
+from src.get_desc import DescriptionBuilder
+
+
+def test_torrentleech_uses_original_ua_screenshot_layout() -> None:
+    config = {
+        "DEFAULT": {"screens_per_row": 4, "thumbnail_size": 450},
+        "TRACKERS": {"TORRENTLEECH": {"screens_per_row": 3, "thumbnail_size": 450}},
+    }
+    builder = DescriptionBuilder("TORRENTLEECH", config)
+
+    assert asyncio.run(builder.get_screens_per_row()) == 2
+    assert builder.format_screenshot("https://example.com/page", "https://example.com/raw.png", "https://example.com/thumb.png") == (
+        '<a href="https://example.com/page"><img src="https://example.com/thumb.png" style="max-width: 350px;"></a>  '
+    )
+
+    parts: list[str] = []
+    assert builder._append_screenshot_row_separator(parts, 0, 2) == ""
+    assert parts == []
+    assert builder._append_screenshot_row_separator(parts, 1, 2) == "<br><br>"
+    assert parts == ["<br><br>"]
+
+
+def test_other_trackers_keep_configured_screenshot_layout() -> None:
+    config = {
+        "DEFAULT": {"screens_per_row": 4, "thumbnail_size": 450},
+        "TRACKERS": {"TEST": {}},
+    }
+    builder = DescriptionBuilder("TEST", config)
+
+    assert asyncio.run(builder.get_screens_per_row()) == 4
+
+    parts: list[str] = []
+    assert builder._append_screenshot_row_separator(parts, 3, 4) == "\n"
+    assert parts == ["\n"]


### PR DESCRIPTION
Force TorrentLeech screenshots to render in two columns with a 350 px thumbnail cap.

This restores the original Upload Assistant TorrentLeech screenshot behaviour and prevents uneven or wrapped screenshot rows.

- Force TorrentLeech descriptions to use two screenshots per row.
- Cap TorrentLeech screenshot thumbnails at 350 px.
- Ignore `screens_per_row` and `thumbnail_size` overrides for TorrentLeech only, keeping the layout reliable within its narrow description column.

We could raise the maximum thumbnail width to 450 px, but 350 px is the safer choice. At 450 px, two screenshots leave little spare width in TorrentLeech’s description area, so even minor layout changes could cause wrapping issues to return. I’ll leave that decision to your discretion. 🙂

## BEFORE / CURRENT BEHAVIOUR

**Before:** Three configured thumbnails overflow TorrentLeech’s description width, producing uneven `2 + 1` rows.

<img width="1113" height="1102" alt="Before" src="https://github.com/user-attachments/assets/ae13ac8c-5b0e-47de-a506-4866b8f30e55" />

## AFTER / ORIGINAL UA BEHAVIOUR

**After:** TorrentLeech adopts the original UA behaviour, rendering two 350 px thumbnails per row.

<img width="1145" height="860" alt="image" src="https://github.com/user-attachments/assets/34d57439-89ab-4afe-9dca-b54e41b0adef" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screenshot layouts across game, playlist, multi-disc, multi-file, spectrogram, and menu views with consistent row breaks.
  * Updated TorrentLeech layouts to display two screenshots per row with clear spacing between rows.
  * Standardized TorrentLeech screenshot sizing with a 350px maximum width.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->