### PR TITLE
fix(NORDICQUALITY): preserve release group in upload names

### DIFF
--- a/src/trackers/UNIT3D/nordicquality.py
+++ b/src/trackers/UNIT3D/nordicquality.py
@@ -23,6 +23,7 @@ class NordicQuality(UNIT3D):
     torrent_url = f"{base_url}/torrents/"
     supported_categories = ("TV", "MOVIE", "MUSIC", "BOOK", "GAME")
     tracker_urls = (base_url,)
+    KNOWN_MEDIA_EXTENSIONS: ClassVar[frozenset[str]] = frozenset({".avi", ".mkv", ".mp4", ".ts"})
     NORDIC_SUBTITLE_LANGUAGES: ClassVar[list[str]] = [
         "da",
         "dan",
@@ -129,8 +130,25 @@ class NordicQuality(UNIT3D):
 
         return {"type_id": type_id.get(resolved_type, "15" if meta.category in {"MUSIC", "BOOK", "GAME"} else "0")}
 
+    @classmethod
+    def _release_name_source(cls, meta: Meta) -> str:
+        if meta.category not in {"MOVIE", "TV"}:
+            return Path(meta.uuid or meta.name).stem
+
+        source_name = ""
+        if not meta.is_disc and len(meta.filelist) == 1:
+            media_path = meta.filelist[0]
+            if isinstance(media_path, str) and media_path.strip():
+                source_name = Path(media_path).name
+
+        if not source_name:
+            source_name = Path(meta.uuid or meta.name).name
+
+        extension = Path(source_name).suffix
+        return source_name[: -len(extension)] if extension.casefold() in cls.KNOWN_MEDIA_EXTENSIONS else source_name
+
     async def get_name(self, meta: Meta) -> dict[str, str]:
-        name = Path(meta.uuid).stem.replace(" ", ".")
+        name = self._release_name_source(meta).replace(" ", ".")
 
         name = name.translate(
             str.maketrans(

--- a/tests/test_nordicquality.py
+++ b/tests/test_nordicquality.py
@@ -97,3 +97,35 @@ def test_nordicquality_sanitizes_upload_name():
     meta = Meta(uuid="\u00c6r\u00f8sk\u00f8bing \u00c5r 2025 HDR10+ DD+ DTS:X &.mkv")
 
     assert asyncio.run(_tracker().get_name(meta)) == {"name": "AEroskobing.Ar.2025.HDR10P.DDP.DTS-X.and"}  # noqa: S101
+
+
+def test_nordicquality_preserves_release_suffix_in_extensionless_uuid():
+    meta = Meta(category="MOVIE", uuid="Snatched.2017.UHD.BluRay.2160p.DTS-HD.MA.7.1.HEVC.REMUX-FraMeSToR")
+
+    assert asyncio.run(_tracker().get_name(meta)) == {  # noqa: S101
+        "name": "Snatched.2017.UHD.BluRay.2160p.DTS-HD.MA.7.1.HEVC.REMUX-FraMeSToR"
+    }
+
+
+def test_nordicquality_prefers_single_media_filename_over_folder_uuid():
+    meta = Meta(
+        category="MOVIE",
+        uuid="Snatched.2017.UHD.BluRay.2160p.DTS-HD.MA.7.1.HEVC",
+        filelist=["D:/Movies/Snatched/Snatched.2017.UHD.BluRay.2160p.DTS-HD.MA.7.1.HEVC.REMUX-FraMeSToR.mkv"],
+    )
+
+    assert asyncio.run(_tracker().get_name(meta)) == {  # noqa: S101
+        "name": "Snatched.2017.UHD.BluRay.2160p.DTS-HD.MA.7.1.HEVC.REMUX-FraMeSToR"
+    }
+
+
+def test_nordicquality_strips_only_known_media_extensions():
+    meta = Meta(category="MOVIE", uuid="unused-folder-name", filelist=["D:/Movies/Movie.2025.1080p.BluRay.REMUX-GROUP.MKV"])
+
+    assert asyncio.run(_tracker().get_name(meta)) == {"name": "Movie.2025.1080p.BluRay.REMUX-GROUP"}  # noqa: S101
+
+
+def test_nordicquality_falls_back_to_generated_name():
+    meta = Meta(category="MOVIE", name="Movie 2025 1080p BluRay REMUX DTS-HD MA 7.1-GROUP")
+
+    assert asyncio.run(_tracker().get_name(meta)) == {"name": "Movie.2025.1080p.BluRay.REMUX.DTS-HD.MA.7.1-GROUP"}  # noqa: S101


### PR DESCRIPTION
## Summary

Fixes NORDICQUALITY upload titles occasionally losing the release type and release group.

For example:

**Source release:**

`Snatched.2017.UHD.BluRay.2160p.DTS-HD.MA.7.1.HEVC.REMUX-FraMeSToR.mkv`

**Previously generated title:**

`Snatched.2017.UHD.BluRay.2160p.DTS-HD.MA.7.1.HEVC`

**Corrected title:**

`Snatched.2017.UHD.BluRay.2160p.DTS-HD.MA.7.1.HEVC.REMUX-FraMeSToR`

## Cause

NORDICQUALITY generated its upload name using `Path(meta.uuid).stem`.

When `meta.uuid` represented an extensionless release directory such as:

`Snatched.2017...HEVC.REMUX-FraMeSToR`

`Path.stem` treated `.REMUX-FraMeSToR` as though it were a file extension and removed it. This resulted in an incomplete upload title and could also affect duplicate matching.

## Changes

- Prefer the actual media filename for single-file Movie and TV uploads.
- Only remove recognized media extensions such as `.mkv`, `.mp4`, `.avi`,  and `.ts`.
- Preserve extensionless release suffixes such as `.REMUX-FraMeSToR`.
- Fall back to the UUID or generated release name when a source filename is unavailable.

## Testing

Added regression coverage for:

- Extensionless release names containing the release group.
- Selecting the source filename over an incomplete folder UUID.
- Case-insensitive removal of recognized media extensions.
- Falling back to the generated release name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release name detection for single-file movie and TV uploads.
  * Preserves meaningful release suffixes when filenames lack extensions.
  * Removes only recognized media file extensions.
  * Falls back to generated names when no suitable filename is available.

* **Tests**
  * Added coverage for release name selection, extension handling, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->