### PR TITLE
fix: incorrect method call on migration

### DIFF
--- a/config-generator.py
+++ b/config-generator.py
@@ -441,7 +441,7 @@ def autofill_missing_keys(config_data: ConfigDict, example_config: ConfigDict) -
                         # Match by "torrent_client" property
                         client_type = client_settings.get("torrent_client")
                         if client_type:
-                            for _template_name, template_settings in example_section.values():
+                            for _template_name, template_settings in example_section.items():
                                 if isinstance(template_settings, dict) and template_settings.get("torrent_client") == client_type:
                                     example_client = template_settings
                                     break


### PR DESCRIPTION
Fixes following bug:

```python
Traceback (most recent call last):
  File "/Upload-Assistant/config-generator.py", line 1185, in <module>
    autofill_missing_keys(config_data, example_config)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Upload-Assistant/config-generator.py", line 444, in autofill_missing_keys
    for _template_name, template_settings in example_section.values():
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: too many values to unpack (expected 2, got 21)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed automatic configuration filling for torrent-client templates.
  * Missing settings are now matched and populated correctly from the selected template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->