### PR TITLE
fix(webui): prevent log buffer lock reuse across upload event loops

### DIFF
--- a/src/console.py
+++ b/src/console.py
@@ -159,13 +159,39 @@ class LogBufferHandler(logging.Handler):
         self.buffer.append(record)
 
 
-_log_buffer_lock = asyncio.Lock()
+_log_buffer_lock: asyncio.Lock | None = None
+_log_buffer_loop: asyncio.AbstractEventLoop | None = None
+_log_buffer_state_lock = threading.Lock()
+
+
+def _get_log_buffer_lock() -> asyncio.Lock:
+    """Return a lock owned by the active event loop.
+
+    The Web UI runs each in-process upload with a fresh ``asyncio.run`` call.
+    Asyncio locks cannot be reused after they have been bound to an earlier
+    event loop, so replace the lock once that earlier loop has stopped.
+    """
+    global _log_buffer_lock, _log_buffer_loop
+
+    current_loop = asyncio.get_running_loop()
+    with _log_buffer_state_lock:
+        if _log_buffer_loop is not current_loop:
+            if _log_buffer_loop is not None and _log_buffer_loop.is_running():
+                raise RuntimeError("Console log buffering cannot span concurrent event loops")
+            _log_buffer_loop = current_loop
+            _log_buffer_lock = None
+
+        lock = _log_buffer_lock
+        if lock is None:
+            lock = asyncio.Lock()
+            _log_buffer_lock = lock
+        return lock
 
 
 @contextlib.asynccontextmanager
 async def buffer_console_logs() -> AsyncGenerator[None]:
     """Temporarily hold console log output in memory while user prompts are active."""
-    async with _log_buffer_lock:
+    async with _get_log_buffer_lock():
         root_logger = logger
         original_rich_handlers = [h for h in root_logger.handlers if isinstance(h, RichHandler)]
         buffer_handler = LogBufferHandler()

--- a/tests/test_console_links.py
+++ b/tests/test_console_links.py
@@ -4,7 +4,7 @@ from io import StringIO
 
 from rich.console import Console
 
-from src.console import ansi_to_html, prompt_in_thread
+from src.console import ansi_to_html, buffer_console_logs, prompt_in_thread
 
 
 def test_ansi_to_html_preserves_osc8_hyperlinks() -> None:
@@ -21,3 +21,36 @@ def test_prompt_in_thread_returns_prompt_result() -> None:
         return await prompt_in_thread(lambda prefix, value: f"{prefix}{value}", "answer-", 42)
 
     assert asyncio.run(ask()) == "answer-42"
+
+
+def test_buffer_console_logs_can_contend_across_consecutive_event_loops() -> None:
+    async def contend_for_buffer() -> None:
+        first_entered = asyncio.Event()
+        release_first = asyncio.Event()
+        second_started = asyncio.Event()
+        order: list[str] = []
+
+        async def first_user() -> None:
+            async with buffer_console_logs():
+                order.append("first-entered")
+                first_entered.set()
+                await release_first.wait()
+                order.append("first-leaving")
+
+        async def second_user() -> None:
+            await first_entered.wait()
+            second_started.set()
+            async with buffer_console_logs():
+                order.append("second-entered")
+
+        first_task = asyncio.create_task(first_user())
+        second_task = asyncio.create_task(second_user())
+        await second_started.wait()
+        await asyncio.sleep(0)
+        release_first.set()
+        await asyncio.gather(first_task, second_task)
+
+        assert order == ["first-entered", "first-leaving", "second-entered"]
+
+    asyncio.run(contend_for_buffer())
+    asyncio.run(contend_for_buffer())


### PR DESCRIPTION
## Summary

Fixes an issue where the Web UI could complete one upload successfully but fail during a subsequent upload with:

~~~text
RuntimeError: <asyncio.locks.Lock ...> is bound to a different event loop
~~~

## Bug

The first upload would normally complete successfully. When another upload was started without restarting the Web UI, it could fail during duplicate checking or another interactive tracker prompt.

## Root cause

Each in-process Web UI upload is executed using a new `asyncio.run()` call, which creates a fresh event loop.

However, the console log-buffering lock was created once at module level:

~~~python
_log_buffer_lock = asyncio.Lock()
~~~

When concurrent tracker prompts contended for this lock during the first upload, the lock became bound to that upload's event loop.

The lock persisted after the upload completed. A subsequent upload created a different event loop and attempted to reuse the existing lock, causing asyncio to raise the cross-loop error.

## Fix

The console log-buffering lock is now associated with the currently active event loop.

When another upload runs on a new event loop, the lock is recreated after the previous loop has stopped. Concurrent prompts within the same upload continue to share the same lock and remain serialized.

A thread-safe state guard was also added around lock selection.

## Testing

Added a regression test that:

1. Creates contention between two console log-buffer users.
2. Completes the operation on one event loop.
3. Repeats the contended operation using a second `asyncio.run()` event loop.
4. Confirms both runs complete in the expected order without a cross-loop error.

This reproduces the event-loop lifecycle used by consecutive in-process Web UI uploads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved buffered console logging when used across sequential event loops.
  * Prevented conflicting concurrent event loops from sharing the same log buffer.
  * Preserved the correct order of buffered log entries during competing operations.

* **Tests**
  * Added coverage for log ordering across consecutive event loops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->