### PR TITLE
fix: MediaInfo CLI path fallback

### DIFF
--- a/bin/get_mediainfo.py
+++ b/bin/get_mediainfo.py
@@ -70,7 +70,7 @@ class MediaInfoBinaryManager:
         try:
             binary = cls.binary_path(base_dir)
         except RuntimeError:
-            return None
+            return shutil.which("mediainfo")
         if binary.is_file() and (binary.suffix.lower() == ".exe" or os.access(binary, os.X_OK)):
             return str(binary)
         return shutil.which("mediainfo")

--- a/bin/get_mediainfo.py
+++ b/bin/get_mediainfo.py
@@ -73,9 +73,7 @@ class MediaInfoBinaryManager:
             return None
         if binary.is_file() and (binary.suffix.lower() == ".exe" or os.access(binary, os.X_OK)):
             return str(binary)
-        if cls._is_macos():
-            return shutil.which("mediainfo")
-        return None
+        return shutil.which("mediainfo")
 
     @classmethod
     async def ensure_mediainfo_binary(cls, base_dir: str | Path) -> str:

--- a/tests/test_exportmi.py
+++ b/tests/test_exportmi.py
@@ -119,3 +119,15 @@ def test_macos_falls_back_to_path_when_downloaded_binary_is_unavailable(tmp_path
         patch("bin.get_mediainfo.shutil.which", return_value="/opt/homebrew/bin/mediainfo"),
     ):
         assert MediaInfoBinaryManager.find_existing_binary(tmp_path) == "/opt/homebrew/bin/mediainfo"
+
+
+def test_linux_falls_back_to_path_when_downloaded_binary_is_unavailable(tmp_path) -> None:
+    from bin.get_mediainfo import MediaInfoBinaryManager
+
+    with (
+        patch.object(MediaInfoBinaryManager, "_is_android", return_value=False),
+        patch.object(MediaInfoBinaryManager, "_is_macos", return_value=False),
+        patch.object(MediaInfoBinaryManager, "_platform_info", return_value=("linux", "MediaInfo_CLI_26.05_Lambda_x86_64.zip", "mediainfo", "zip")),
+        patch("bin.get_mediainfo.shutil.which", return_value="/usr/bin/mediainfo"),
+    ):
+        assert MediaInfoBinaryManager.find_existing_binary(tmp_path) == "/usr/bin/mediainfo"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MediaInfo executable detection across platforms.
  * The application now falls back to a system-installed `mediainfo` executable when a platform-specific or downloaded binary is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->