### PR TITLE
fix(webui): load config from runtime data directory

### DIFF
--- a/tests/test_webui_config_paths.py
+++ b/tests/test_webui_config_paths.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+import web_ui.server as server
+
+
+def test_load_config_accepts_user_owned_runtime_path(tmp_path: Path, monkeypatch) -> None:
+    state_dir = tmp_path / "state"
+    config_path = state_dir / "data" / "config.py"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text("config = {'DEFAULT': {'screens': 6}}\n", encoding="utf-8")
+    monkeypatch.setattr(server, "STATE_DIR", state_dir)
+
+    assert server._load_config_from_file(config_path) == {"DEFAULT": {"screens": 6}}
+
+
+def test_load_config_accepts_python_files_beneath_both_data_directories(tmp_path: Path, monkeypatch) -> None:
+    code_dir = tmp_path / "checkout"
+    state_dir = tmp_path / "state"
+    repository_path = code_dir / "data" / "nested" / "repository_config.py"
+    runtime_path = state_dir / "data" / "nested" / "runtime_config.py"
+    for path in (repository_path, runtime_path):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("config = {'DEFAULT': {}}\n", encoding="utf-8")
+    monkeypatch.setattr(server, "CODE_DIR", code_dir)
+    monkeypatch.setattr(server, "STATE_DIR", state_dir)
+
+    assert server._load_config_from_file(repository_path) == {"DEFAULT": {}}
+    assert server._load_config_from_file(runtime_path) == {"DEFAULT": {}}
+
+
+def test_load_config_rejects_unrelated_python_file(tmp_path: Path, monkeypatch) -> None:
+    state_dir = tmp_path / "state"
+    unrelated_path = tmp_path / "config.py"
+    unrelated_path.write_text("config = {'DEFAULT': {}}\n", encoding="utf-8")
+    monkeypatch.setattr(server, "STATE_DIR", state_dir)
+
+    assert server._load_config_from_file(unrelated_path) is None

--- a/tests/test_webui_config_paths.py
+++ b/tests/test_webui_config_paths.py
@@ -35,3 +35,13 @@ def test_load_config_rejects_unrelated_python_file(tmp_path: Path, monkeypatch) 
     monkeypatch.setattr(server, "STATE_DIR", state_dir)
 
     assert server._load_config_from_file(unrelated_path) is None
+
+
+def test_load_config_rejects_non_python_file_inside_runtime_data(tmp_path: Path, monkeypatch) -> None:
+    state_dir = tmp_path / "state"
+    config_path = state_dir / "data" / "config.txt"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text("config = {'DEFAULT': {}}\n", encoding="utf-8")
+    monkeypatch.setattr(server, "STATE_DIR", state_dir)
+
+    assert server._load_config_from_file(config_path) is None

--- a/web_ui/server.py
+++ b/web_ui/server.py
@@ -2295,8 +2295,8 @@ def set_runtime_browse_roots(browse_roots: str) -> None:
 def _load_config_from_file(path: Path) -> dict[str, Any] | None:
     """Load and return the ``config`` dict from a Python config file.
 
-    Only files inside the repository ``data/`` directory with a ``.py``
-    extension are accepted.  No ownership or permission checks are
+    Only files inside the repository or runtime ``data/`` directories with a
+    ``.py`` extension are accepted.  No ownership or permission checks are
     performed — the file lives in a user-controlled directory and the app
     already writes to it freely via ``config_update``.
 
@@ -2306,10 +2306,15 @@ def _load_config_from_file(path: Path) -> dict[str, Any] | None:
     if not path.exists():
         return None
 
-    # Restrict to the repository `data` directory and ensure .py extension.
-    repo_data_dir = Path(__file__).resolve().parent.parent / "data"
+    # Preserve support for Python files beneath the repository data directory
+    # while also accepting files beneath the user-owned runtime data directory.
+    allowed_data_dirs = {
+        (CODE_DIR / "data").resolve(),
+        (STATE_DIR / "data").resolve(),
+    }
     try:
-        if not path.resolve().is_relative_to(repo_data_dir.resolve()) or path.suffix != ".py":
+        resolved_path = path.resolve()
+        if path.suffix != ".py" or not any(resolved_path.is_relative_to(directory) for directory in allowed_data_dirs):
             return None
     except Exception:
         return None


### PR DESCRIPTION
## Summary

Fix the WebUI configuration loader so it can read configuration files from the user-owned runtime data directory introduced by the application-path refactor.

## Problem

The application-path refactor moved runtime state out of the source checkout and changed the active configuration path to `STATE_DIR/data/config.py`.

The WebUI routes were updated to use `STATE_DIR`, but `_load_config_from_file()` still only accepted Python files beneath the repository's `data` directory.

As a result, the WebUI found the migrated `config.py` but rejected it before parsing it, causing the interface to display example defaults and report that the configuration could not be loaded. This occurred even when the migrated configuration was syntactically valid.

## Fix

Update `_load_config_from_file()` to accept `.py` files beneath both:

- `CODE_DIR/data`
- `STATE_DIR/data`

This completes the runtime-path refactor while preserving the loader's previous support for all Python files beneath the repository data directory.

Paths outside those two data directories and files without a `.py` extension remain rejected.

## Testing

Added regression tests confirming that the loader:

- accepts configuration files beneath the runtime data directory
- preserves support for Python files beneath the repository data directory
- continues to reject unrelated Python files

Additional targeted checks confirmed custom runtime locations, malformed configuration handling, the legacy-path override, and Python syntax compilation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Configuration files can now be loaded from both repository and runtime `data` directories.
  - Nested Python configuration files within these supported locations are recognized.
  - Configuration loading continues to reject unsupported file types and files outside approved directories.

- **Tests**
  - Added coverage validating supported configuration paths and rejection of unrelated Python files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->