### PR TITLE
fix(mediainfo): handle invalid output bytes

### DIFF
--- a/src/mediainfo.py
+++ b/src/mediainfo.py
@@ -32,7 +32,15 @@ def run_mediainfo(path: str | Path, *, output: str | None = None, full: bool = T
         command.append(f"--Output={output}")
     command.append(str(path))
     try:
-        result = subprocess.run(command, capture_output=True, text=True, check=False, timeout=900)  # noqa: S603
+        result = subprocess.run(  # noqa: S603
+            command,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+            timeout=900,
+        )
     except subprocess.TimeoutExpired as exc:
         raise RuntimeError("MediaInfo timed out after 15 minutes") from exc
     if result.returncode != 0:

--- a/tests/test_exportmi.py
+++ b/tests/test_exportmi.py
@@ -39,6 +39,17 @@ def test_text_reports_always_request_mediainfo_version() -> None:
     assert run.call_args.args[0] == ["mediainfo", "--inform_version=1", "video.mkv"]
 
 
+def test_mediainfo_uses_tolerant_utf8_output_decoding() -> None:
+    completed = Mock(returncode=0, stdout="General", stderr="")
+    with patch("src.mediainfo._binary", return_value="mediainfo"), patch("src.mediainfo.subprocess.run", return_value=completed) as run:
+        from src.mediainfo import run_mediainfo
+
+        run_mediainfo("audio.m4b")
+
+    assert run.call_args.kwargs["encoding"] == "utf-8"
+    assert run.call_args.kwargs["errors"] == "replace"
+
+
 def test_mediainfo_timeout_becomes_runtime_error() -> None:
     with patch("src.mediainfo._binary", return_value="mediainfo"), patch("src.mediainfo.subprocess.run", side_effect=subprocess.TimeoutExpired("mediainfo", 900)):
         from src.mediainfo import run_mediainfo


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of MediaInfo output containing invalid or non-standard characters.
  * Media information processing now continues reliably when output includes malformed text.

* **Tests**
  * Added coverage to verify robust UTF-8 output handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->