### PR TITLE
script: add UNIT3D userscript metadata extractor

### DIFF
--- a/scripts/UNIT3D ID Report/README.md
+++ b/scripts/UNIT3D ID Report/README.md
@@ -1,0 +1,16 @@
+# UNIT3D ID Report
+
+Userscript that adds a button to UNIT3D torrent pages to export **Category**, **Type**, and **Resolution** IDs to a Markdown file.
+
+## Installation
+
+1. Install [Tampermonkey](https://www.tampermonkey.net/) or [Violentmonkey](https://violentmonkey.github.io/).
+2. Open [`UNIT3D-id-report.user.js`](./UNIT3D-id-report.user.js).
+3. Copy its contents into a new userscript in your chosen manager.
+4. Save it and open a UNIT3D-compatible torrent page.
+
+The script runs on URLs matching the `*/torrents*` pattern.
+
+## Usage
+
+When compatible fields are found, the **Export IDs (.md)** button appears in the lower-right corner of the page.

--- a/scripts/UNIT3D ID Report/UNIT3D-id-report.user.js
+++ b/scripts/UNIT3D ID Report/UNIT3D-id-report.user.js
@@ -1,0 +1,132 @@
+// ==UserScript==
+// @name         UNIT3D ID Report
+// @namespace    upload-assistant
+// @version      1.0.0
+// @description  Export UNIT3D category, type, and resolution IDs as Markdown.
+// @match        *://*/torrents*
+// @grant        none
+// ==/UserScript==
+
+(function () {
+    'use strict';
+
+    const BUTTON_ID = 'unit3d-export-id-report';
+    const GROUPS = [
+        { key: 'categoryIds', title: 'Category' },
+        { key: 'typeIds', title: 'Type' },
+        { key: 'resolutionIds', title: 'Resolution' },
+    ];
+
+    function normalizeText(value) {
+        return value.replace(/\s+/g, ' ').trim();
+    }
+
+    function markdownText(value) {
+        return value.replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/\r?\n/g, ' ');
+    }
+
+    function findFieldset(group) {
+        return [...document.querySelectorAll('fieldset')].find((fieldset) => {
+            const input = [...fieldset.querySelectorAll('input')]
+                .find((candidate) => candidate.getAttribute('wire:model.live') === group.key);
+            return Boolean(input);
+        });
+    }
+
+    function extractGroup(group) {
+        const fieldset = findFieldset(group);
+        if (!fieldset) {
+            return [];
+        }
+
+        return [...fieldset.querySelectorAll('input')]
+            .filter((input) => input.getAttribute('wire:model.live') === group.key)
+            .map((input) => {
+                const label = input.closest('label');
+                const name = label ? normalizeText(label.textContent) : '';
+                return { id: input.value.trim(), name };
+            })
+            .filter((item) => item.id && item.name);
+    }
+
+    function buildMarkdown() {
+        const lines = [
+            '# UNIT3D — Supported IDs',
+            '',
+            `- URL: ${window.location.href}`,
+            `- Generated at: ${new Date().toISOString()}`,
+            '',
+        ];
+
+        for (const group of GROUPS) {
+            const entries = extractGroup(group);
+            lines.push(`## ${group.title}`, '', '| ID | Name |', '|---:|---|');
+
+            if (entries.length === 0) {
+                lines.push('| — | No field found |');
+            } else {
+                for (const entry of entries) {
+                    lines.push(`| ${markdownText(entry.id)} | ${markdownText(entry.name)} |`);
+                }
+            }
+            lines.push('');
+        }
+
+        return lines.join('\n');
+    }
+
+    function downloadReport() {
+        const markdown = buildMarkdown();
+        const blob = new Blob([markdown], { type: 'text/markdown;charset=utf-8' });
+        const link = document.createElement('a');
+        const hostname = window.location.hostname.replace(/[^a-z0-9.-]/gi, '_') || 'unit3d';
+        link.href = URL.createObjectURL(blob);
+        link.download = `${hostname}-ids.md`;
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+        setTimeout(() => URL.revokeObjectURL(link.href), 1000);
+    }
+
+    function installButton() {
+        if (document.getElementById(BUTTON_ID) || !GROUPS.some((group) => findFieldset(group))) {
+            return;
+        }
+
+        const button = document.createElement('button');
+        button.id = BUTTON_ID;
+        button.type = 'button';
+        button.textContent = 'Export IDs (.md)';
+        button.title = 'Download Category, Type, and Resolution as Markdown';
+        Object.assign(button.style, {
+            position: 'fixed',
+            right: '16px',
+            bottom: '16px',
+            zIndex: '2147483647',
+            padding: '10px 14px',
+            border: '1px solid #fff',
+            borderRadius: '6px',
+            background: '#1976d2',
+            color: '#fff',
+            cursor: 'pointer',
+            font: '600 14px sans-serif',
+            boxShadow: '0 2px 8px #0006',
+        });
+        button.addEventListener('click', downloadReport);
+        document.body.appendChild(button);
+    }
+
+    function start() {
+        installButton();
+        new MutationObserver(installButton).observe(document.documentElement, {
+            childList: true,
+            subtree: true,
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', start, { once: true });
+    } else {
+        start();
+    }
+})();

--- a/scripts/UNIT3D ID Report/UNIT3D-id-report.user.js
+++ b/scripts/UNIT3D ID Report/UNIT3D-id-report.user.js
@@ -42,7 +42,7 @@
         return [...fieldset.querySelectorAll('input')]
             .filter((input) => input.getAttribute('wire:model.live') === group.key)
             .map((input) => {
-                const label = input.closest('label');
+                const label = input.labels?.[0];
                 const name = label ? normalizeText(label.textContent) : '';
                 return { id: input.value.trim(), name };
             })

--- a/src/trackers/UNIT3D/UNIT3D_TEMPLATE.py
+++ b/src/trackers/UNIT3D/UNIT3D_TEMPLATE.py
@@ -9,6 +9,7 @@ Config = dict[str, Any]
 
 
 class Unit3dTemplate(UNIT3D):  # EDIT 'Unit3dTemplate' AS ABBREVIATED TRACKER NAME
+    # Use scripts/UNIT3D ID Report/UNIT3D-id-report.user.js to discover tracker IDs before implementing mappings.
     tracker = "Abbreviated Tracker Name"
     base_url = "https://domain.tld"
     banned_groups = ("",)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a UNIT3D userscript that exports Category, Type, and Resolution fields as a Markdown report.
  * Reports include page metadata and download automatically using a hostname-based filename.
  * Added an export button that works with dynamically loaded fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->