### PR TITLE
fix(ant-nbl): strip ReportBy from MediaInfo uploads

### DIFF
--- a/src/mediainfo.py
+++ b/src/mediainfo.py
@@ -9,6 +9,14 @@ from typing import Any
 from bin.get_mediainfo import MediaInfoBinaryManager
 
 
+_REPORT_BY_LINE = re.compile(r"^[ \t]*ReportBy[ \t]*:[^\r\n]*(?:\r?\n|\r)?", re.IGNORECASE | re.MULTILINE)
+
+
+def strip_report_by_line(report: str) -> str:
+    """Remove MediaInfo's optional ReportBy version line from a text report."""
+    return _REPORT_BY_LINE.sub("", report)
+
+
 def _base_dir() -> Path:
     return Path(__file__).resolve().parent.parent
 

--- a/src/mediainfo.py
+++ b/src/mediainfo.py
@@ -9,7 +9,7 @@ from typing import Any
 from bin.get_mediainfo import MediaInfoBinaryManager
 
 
-_REPORT_BY_LINE = re.compile(r"^[ \t]*ReportBy[ \t]*:[^\r\n]*(?:\r?\n|\r)?", re.IGNORECASE | re.MULTILINE)
+_REPORT_BY_LINE = re.compile(r"(?<![^\r\n])[ \t]*ReportBy[ \t]*:[^\r\n]*(?:\r\n?|\n)?", re.IGNORECASE)
 
 
 def strip_report_by_line(report: str) -> str:

--- a/src/trackers/anthelion.py
+++ b/src/trackers/anthelion.py
@@ -13,6 +13,7 @@ from rich.markup import escape
 from src.cogs.redaction import Redaction
 from src.console import logger, prompt_in_thread
 from src.get_desc import DescriptionBuilder
+from src.mediainfo import strip_report_by_line
 from src.meta import Meta
 from src.torrentcreate import TorrentCreator
 from src.trackers.common import Common
@@ -295,7 +296,7 @@ class Anthelion:
         else:
             mi_path = f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/MEDIAINFO_CLEANPATH.txt"
             async with aiofiles.open(mi_path, encoding="utf-8") as f:
-                mediainfo_output = await f.read()
+                mediainfo_output = strip_report_by_line(await f.read())
             data.update({"mediainfo": mediainfo_output})
         if meta.scene:
             # ID of "Scene?" checkbox on upload form is actually "censored"
@@ -357,6 +358,11 @@ class Anthelion:
                     meta.tracker_status[self.tracker]["status_message"] = f"data error - {response_data}"
                     return False
             else:
+                if "mediainfo" in data:
+                    debug_mediainfo_path = Path(meta.base_dir) / "tmp" / str(meta.uuid) / f"{self.tracker}_MEDIAINFO.txt"
+                    async with aiofiles.open(debug_mediainfo_path, "w", newline="", encoding="utf-8") as f:
+                        await f.write(str(data["mediainfo"]))
+                    logger.info(f"{self.tracker}: [green]Final MediaInfo payload written to {debug_mediainfo_path}[/green]")
                 logger.info(f"{self.tracker}: Request Data:")
                 logger.info(Redaction.redact_private_info(data))
                 meta.tracker_status[self.tracker]["status_message"] = "Debug mode enabled, not uploading."

--- a/src/trackers/nebulance.py
+++ b/src/trackers/nebulance.py
@@ -10,6 +10,7 @@ import httpx
 
 from src.cogs.redaction import Redaction
 from src.console import logger
+from src.mediainfo import strip_report_by_line
 from src.meta import Meta
 from src.trackers.common import Common
 
@@ -122,7 +123,7 @@ class Nebulance:
                 mi_dump = await f.read()
         else:
             async with aiofiles.open(f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/MEDIAINFO.txt", encoding="utf-8") as f:
-                mi_dump = await f.read()
+                mi_dump = strip_report_by_line(await f.read())
         torrent_file_path = f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/[{self.tracker}].torrent"
         async with aiofiles.open(torrent_file_path, "rb") as f:
             torrent_bytes = await f.read()
@@ -157,6 +158,10 @@ class Nebulance:
                         meta.tracker_status[self.tracker]["status_message"] = response_data
                     return False
             else:
+                debug_mediainfo_path = f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/{self.tracker}_MEDIAINFO.txt"
+                async with aiofiles.open(debug_mediainfo_path, "w", newline="", encoding="utf-8") as f:
+                    await f.write(mi_dump)
+                logger.info(f"{self.tracker}: [green]Final MediaInfo payload written to {debug_mediainfo_path}[/green]")
                 logger.info(f"{self.tracker}: Request Data:")
                 logger.info(Redaction.redact_private_info(data))
                 meta.tracker_status[self.tracker]["status_message"] = "Debug mode enabled, not uploading."

--- a/tests/test_exportmi.py
+++ b/tests/test_exportmi.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from bin.download_integrity import SHA256_BY_ASSET
-from src.mediainfo import MediaInfo
+from src.mediainfo import MediaInfo, strip_report_by_line
 
 
 def test_cli_backed_mediainfo_preserves_track_access() -> None:
@@ -27,6 +27,20 @@ def test_cli_backed_mediainfo_returns_requested_text() -> None:
 
     assert report == "General\nComplete name"
     run.assert_called_once_with("video.mkv", output="STRING", full=False, inform=None)
+
+
+@pytest.mark.parametrize(
+    "report_by_line",
+    [
+        "ReportBy: MediaInfoLib - v26.05\n",
+        "ReportBy                                 : MediaInfoLib - v26.05\r\n",
+        "  reportby : MediaInfoLib - v27.01\n",
+    ],
+)
+def test_strip_report_by_line_handles_mediainfo_formatting(report_by_line: str) -> None:
+    report = f"General\nComplete name : example.mkv\n\n{report_by_line}Video\nFormat : AVC\n"
+
+    assert strip_report_by_line(report) == "General\nComplete name : example.mkv\n\nVideo\nFormat : AVC\n"
 
 
 def test_text_reports_always_request_mediainfo_version() -> None:

--- a/tests/test_exportmi.py
+++ b/tests/test_exportmi.py
@@ -43,6 +43,12 @@ def test_strip_report_by_line_handles_mediainfo_formatting(report_by_line: str) 
     assert strip_report_by_line(report) == "General\nComplete name : example.mkv\n\nVideo\nFormat : AVC\n"
 
 
+def test_strip_report_by_line_handles_bare_carriage_return_boundaries() -> None:
+    report = "General\rComplete name : example.mkv\rReportBy : MediaInfoLib - v26.05\rVideo\rFormat : AVC\r"
+
+    assert strip_report_by_line(report) == "General\rComplete name : example.mkv\rVideo\rFormat : AVC\r"
+
+
 def test_text_reports_always_request_mediainfo_version() -> None:
     completed = Mock(returncode=0, stdout="General", stderr="")
     with patch("src.mediainfo._binary", return_value="mediainfo"), patch("src.mediainfo.subprocess.run", return_value=completed) as run:


### PR DESCRIPTION
## Why this change is needed

NEBULANCE staff marked one of my uploads for deletion because its MediaInfo contained the following unnecessary line:

```text
ReportBy: MediaInfoLib - v26.05
```

UA currently adds this line by invoking MediaInfo with `--inform_version=1`. Because NEBULANCE and its sister tracker ANTHELION receive UA’s generated MediaInfo directly, the line is included in their upload payloads.

This change prevents the issue from recurring on NEBULANCE and applies the same handling to ANTHELION.

## What's changed

The `ReportBy` line is removed from the MediaInfo upload payload before it is submitted to NEBULANCE or ANTHELION.

The change:

- Only affects NEBULANCE and ANTHELION payloads.
- Leaves `MEDIAINFO.txt` and `MEDIAINFO_CLEANPATH.txt` unchanged.
- Does not alter MediaInfo submitted to other trackers.
- Handles different spacing, casing, line endings, and future MediaInfo versions.
- Does not affect ANTHELION BDInfo submissions.

Debug mode now also writes the exact post-sanitisation payload to:

```text
tmp/<uuid>/NEBULANCE_MEDIAINFO.txt
tmp/<uuid>/ANTHELION_MEDIAINFO.txt
```

This provides a readable way to verify what UA would submit without having to inspect the escaped MediaInfo inside the command-line debug output.

## Testing

Regression coverage was added for:

- Compact `ReportBy:` formatting.
- MediaInfo’s padded field formatting.
- Case variations.
- Different line endings.
- Future MediaInfo version numbers.

The modified modules also pass syntax and direct sanitisation checks.

## Question before merging

@wastaken7: I noticed that [PR #272](https://github.com/wastaken7/Upload-Assistant/pull/272) explicitly enabled `--inform_version=1` as part of the MediaInfo-CLI refactor, with a regression test confirming that text reports include the MediaInfo version.

Was the `ReportBy` footer enabled for compatibility with a particular tracker, or primarily to retain version provenance in generated reports?

This PR keeps the change limited to ANTHELION and NEBULANCE because other trackers may accept or rely on the version information. However, if no tracker specifically requires the footer, removing `--inform_version=1` globally may be the cleaner long-term solution. That would restore the original behaviour, prevent `ReportBy` from appearing in generated MediaInfo reports, and remove the need for tracker-specific filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MediaInfo reports now remove optional `ReportBy` version lines before upload.
  * Filtering works across different formatting and line-ending styles while preserving the remaining report content.

* **Diagnostics**
  * Debug mode now saves the final MediaInfo payload to a tracker-specific temporary file and logs its location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->