### PR TITLE
feat(bitporn): support tracker-hosted description images and artwork fields

### DIFF
--- a/src/trackers/UNIT3D/bitporn.py
+++ b/src/trackers/UNIT3D/bitporn.py
@@ -2,7 +2,9 @@
 import re
 from typing import Any, ClassVar
 
+from src.get_desc import DescriptionBuilder
 from src.meta import Meta
+from src.screenshot_manifest import files as manifest_files
 from src.trackers.UNIT3D import UNIT3D
 
 Config = dict[str, Any]
@@ -175,3 +177,73 @@ class BitPorn(UNIT3D):
 
         resolved_resolution = resolution if resolution else meta.resolution
         return {"resolution_id": self.resolution_ids.get(str(resolved_resolution), self.resolution_ids["OTHER"])}
+
+    async def _description_image_files(self, meta: Meta) -> list[tuple[str, bytes, str]]:
+        """Return local XXX contact sheets for BitPorn to host during upload."""
+        images: list[tuple[str, bytes, str]] = []
+        for path in manifest_files(meta.base_dir, meta.uuid, "main"):
+            image = await self.get_image_file(path, max_size=10 * 1024 * 1024)
+            if image:
+                images.append(image)
+        return images
+
+    async def get_description(self, meta: Meta) -> dict[str, str]:
+        """Use BitPorn placeholders so its API, rather than an external host, serves screenshots."""
+        description = await DescriptionBuilder(self.tracker, self.config).general_description_generator(
+            meta,
+            audio_spectrogram=False,
+            bluray=False,
+            book=True,
+            custom_header=True,
+            custom_signature=True,
+            description=True,
+            game=True,
+            languages=False,
+            logo=False,
+            mediainfo=False,
+            menu_screenshots=False,
+            nfo=False,
+            screenshots=False,
+            tonemapped_header=True,
+            tv_info=True,
+            ua_signature=True,
+            user_description=True,
+            music=True,
+        )
+        images = await self._description_image_files(meta)
+        if images:
+            placeholders = "".join(f"[upimg{index}]" for index in range(1, len(images) + 1))
+            description = f"{description}\n[center]{placeholders}[/center]"
+        return {"description": description}
+
+    async def get_data(self, meta: Meta) -> dict[str, str]:
+        """Build only the documented BitPorn upload fields."""
+        data: dict[str, str] = {}
+        for getter in (
+            self.get_name,
+            self.get_description,
+            self.get_mediainfo,
+            self.get_bdinfo,
+            self.get_category_id,
+            self.get_type_id,
+            self.get_resolution_id,
+            self.get_anonymous,
+            self.get_keywords,
+        ):
+            data.update(await getter(meta))
+
+        for index, _ in enumerate(await self._description_image_files(meta), start=1):
+            data[f"description_image_widths[{index}]"] = "450"
+        return data
+
+    async def get_additional_files(self, meta: Meta) -> dict[str, tuple[str, bytes, str]]:
+        """Use BitPorn's multipart names for tracker-hosted artwork and screenshots."""
+        files = await super().get_additional_files(meta)
+        if cover := files.pop("torrent-cover", None):
+            files["cover"] = cover
+        if banner := files.pop("torrent-banner", None):
+            files["banner"] = banner
+
+        for index, image in enumerate(await self._description_image_files(meta)):
+            files[f"description_images[{index}]"] = image
+        return files

--- a/tests/test_bitporn.py
+++ b/tests/test_bitporn.py
@@ -1,12 +1,14 @@
 import asyncio
+from pathlib import Path
 
 from src.meta import Meta
+from src.screenshot_manifest import register as register_screenshots
 from src.trackers.UNIT3D.bitporn import BitPorn
 from src.trackersetup import tracker_class_map
 
 
 def tracker() -> BitPorn:
-    return BitPorn({"TRACKERS": {"BITPORN": {}}})
+    return BitPorn({"DEFAULT": {}, "TRACKERS": {"BITPORN": {}}})
 
 
 def test_bitporn_is_registered_for_xxx_only() -> None:
@@ -44,3 +46,31 @@ def test_bitporn_resolution_mapping() -> None:
     assert asyncio.run(bitporn.get_resolution_id(meta)) == {"resolution_id": "18"}  # noqa: S101
     assert asyncio.run(bitporn.get_resolution_id(meta, "2048p")) == {"resolution_id": "14"}  # noqa: S101
     assert asyncio.run(bitporn.get_resolution_id(meta, "1080i")) == {"resolution_id": "11"}  # noqa: S101
+
+
+def test_bitporn_uses_its_image_upload_contract(tmp_path: Path) -> None:
+    meta = Meta(category="XXX", base_dir=str(tmp_path), uuid="bitporn-images")
+    screenshot_dir = tmp_path / "tmp" / meta.uuid / "screenshots"
+    screenshot_dir.mkdir(parents=True)
+    source = screenshot_dir / "contact-sheet.png"
+    source.write_bytes(
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89"
+        b"\x00\x00\x00\x0dIDATx\x9cc\xf8\xcf\xc0\xf0\x1f\x00\x05\x00\x01\xff\x89\x99=\x1d\x00\x00\x00\x00IEND\xaeB`\x82"
+    )
+    (tmp_path / "tmp" / meta.uuid / "MEDIAINFO_CLEANPATH.txt").write_text("MediaInfo", encoding="utf-8")
+    registered = register_screenshots(meta.base_dir, meta.uuid, [source], "main")
+    meta.artwork_path = str(registered[0])
+    meta.artwork_banner_path = str(registered[0])
+
+    bitporn = tracker()
+    files = asyncio.run(bitporn.get_additional_files(meta))
+    data = asyncio.run(bitporn.get_data(meta))
+
+    assert "description_images[0]" in files  # noqa: S101
+    assert files["description_images[0]"][2] == "image/png"  # noqa: S101
+    assert "cover" in files  # noqa: S101
+    assert "banner" in files  # noqa: S101
+    assert "torrent-cover" not in files  # noqa: S101
+    assert "torrent-banner" not in files  # noqa: S101
+    assert "[upimg1]" in data["description"]  # noqa: S101
+    assert data["description_image_widths[1]"] == "450"  # noqa: S101


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added BitPorn-specific upload support for descriptions, screenshots, cover art, and banner images.
  * Descriptions now include embedded screenshot placeholders and image widths.
  * Upload data uses BitPorn’s required field names and formats.

* **Bug Fixes**
  * Improved handling of local contact-sheet images during BitPorn uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->