### PR TITLE
fix(unit3d): remove imported Upload-Assistant signatures

### DIFF
--- a/src/bbcode.py
+++ b/src/bbcode.py
@@ -517,6 +517,21 @@ class BBCODE:
         )
         desc = re.sub(r"\[center\].*Created by.*Upload Assistant.*\[\/center\]", "", desc, flags=re.IGNORECASE)
         desc = re.sub(r"\[right\].*Created by.*Upload Assistant.*\[\/right\]", "", desc, flags=re.IGNORECASE)
+        # Remove Upload-Assistant signatures imported from another release.
+        ua_signature_regex = r"""
+            ^[ \t]*
+            \[(?:right|center|align=right)\][ \t]*
+            \[url=https:\/\/github\.com\/[^\]]*\/Upload-Assistant\][ \t]*
+            (?:\[size=\d+\][ \t]*)?
+            (?:Shared\s+with|Compartilhado\s+com)\s+Upload[-\s]+Assistant
+            (?:\s+v?[\w.+-]+)?
+            (?:\s+\(fork\))?
+            [ \t]*
+            (?:\[\/size\][ \t]*)?
+            \[\/url\][ \t]*
+            \[\/(?:right|center|align)\][ \t]*$
+        """
+        desc = re.sub(ua_signature_regex, "", desc, flags=re.IGNORECASE | re.MULTILINE | re.VERBOSE)
 
         # Remove leftover [img] or [URL] tags in the description
         desc = re.sub(r"\[img\][\s\S]*?\[\/img\]", "", desc, flags=re.IGNORECASE)

--- a/src/bbcode.py
+++ b/src/bbcode.py
@@ -520,15 +520,15 @@ class BBCODE:
         # Remove Upload-Assistant signatures imported from another release.
         ua_signature_regex = r"""
             ^[ \t]*
-            \[(?:right|center|align=right)\][ \t]*
-            \[url=https:\/\/github\.com\/[^\]]*\/Upload-Assistant\][ \t]*
-            (?:\[size=\d+\][ \t]*)?
+            \[(?:right|center|align=(?:right|center))\][ \t]*(?:\n[ \t]*)?
+            \[url=https:\/\/github\.com\/[^\]]*\/Upload-Assistant\][ \t]*(?:\n[ \t]*)?
+            (?:\[size=\d+\][ \t]*(?:\n[ \t]*)?)?
             (?:Shared\s+with|Compartilhado\s+com)\s+Upload[-\s]+Assistant
-            (?:\s+v?[\w.+-]+)?
-            (?:\s+\(fork\))?
-            [ \t]*
-            (?:\[\/size\][ \t]*)?
-            \[\/url\][ \t]*
+            (?:[ \t]+v?\d+(?:[.+-]\d+)*)?
+            (?:[ \t]+\(fork\))?
+            [ \t]*(?:\n[ \t]*)?
+            (?:\[\/size\][ \t]*(?:\n[ \t]*)?)?
+            \[\/url\][ \t]*(?:\n[ \t]*)?
             \[\/(?:right|center|align)\][ \t]*$
         """
         desc = re.sub(ua_signature_regex, "", desc, flags=re.IGNORECASE | re.MULTILINE | re.VERBOSE)

--- a/tests/test_bbcode.py
+++ b/tests/test_bbcode.py
@@ -1,0 +1,25 @@
+# ruff: noqa: S101
+from src.bbcode import BBCODE
+
+
+def test_clean_unit3d_description_removes_line_wrapped_align_center_signature() -> None:
+    description = """Release notes
+[align=center]
+[url=https://github.com/wastaken7/Upload-Assistant]
+[size=4]
+Shared with Upload-Assistant v3.3 (fork)
+[/size]
+[/url]
+[/align]"""
+
+    cleaned, _ = BBCODE().clean_unit3d_description(description, "https://example.test")
+
+    assert cleaned == "Release notes"
+
+
+def test_clean_unit3d_description_preserves_non_version_suffix() -> None:
+    description = "[right][url=https://github.com/wastaken7/Upload-Assistant]Shared with Upload Assistant release[/url][/right]"
+
+    cleaned, _ = BBCODE().clean_unit3d_description(description, "https://example.test")
+
+    assert cleaned == description


### PR DESCRIPTION
### Summary

Remove Upload-Assistant attribution footers from imported UNIT3D descriptions.

### Problem

descriptions containing:

```text
[right][url=.../Upload-Assistant][size=4]Shared with Upload-Assistant v3.3 (fork)[/size][/url][/right]
```

were not cleaned because the sanitizer only handled older `Created by ... Upload Assistant` patterns.

### Changes

- Remove English and Portuguese Upload-Assistant signatures.
- Support common `[right]`, `[center]`, and `[align=right]` wrappers.
- Support optional size, version, and fork markers.
- Prevent imported signatures from being duplicated on subsequent uploads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved description cleanup by removing additional Upload Assistant signatures across varied layouts and formatting.
  * Added support for localized wording, version details, fork markers, optional size tags, and GitHub links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->