### PR TITLE
fix: HDBits screenshot rehosting

### DIFF
--- a/src/trackers/hdbits.py
+++ b/src/trackers/hdbits.py
@@ -17,6 +17,7 @@ from src.console import console, logger
 from src.description_review import get_base_description
 from src.exceptions import *  # noqa F403
 from src.meta import Meta
+from src.temp_paths import screenshots_dir
 from src.torrentcreate import TorrentCreator
 from src.trackers.common import Common
 
@@ -667,7 +668,7 @@ class HDBits:
                 logger.debug(f"{self.tracker}: [cyan]{i}: {Path(path).name}")
         else:
             thumb_size = "w300"
-            screenshot_dir = f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}"
+            screenshot_dir = screenshots_dir(meta.base_dir, meta.uuid)
             # similar to uploadscreens.py L546
             image_patterns = ["*.png", ".[!.]*.png"]
             image_glob: list[str] = []

--- a/tests/test_hdbits_images.py
+++ b/tests/test_hdbits_images.py
@@ -1,0 +1,42 @@
+"""Regression coverage for HDBits screenshot rehosting."""
+
+# ruff: noqa: S101
+
+import asyncio
+
+import pytest
+
+from src.meta import Meta
+from src.temp_paths import screenshots_dir
+from src.trackers.hdbits import HDBits
+
+
+class _Response:
+    status_code = 200
+    text = "[img]https://img.hdbits.org/screenshot.png[/img]"
+
+
+class _Client:
+    files: dict[str, tuple[str, bytes, str]]
+
+    async def __aenter__(self) -> _Client:
+        return self
+
+    async def __aexit__(self, *_args: object) -> None:
+        pass
+
+    @classmethod
+    async def post(cls, _url: str, **kwargs: object) -> _Response:
+        cls.files = kwargs["files"]  # type: ignore[assignment,index]
+        return _Response()
+
+
+def test_hdbits_rehosts_screenshots_from_typed_directory(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("src.trackers.hdbits.httpx.AsyncClient", lambda **_kwargs: _Client())
+    screenshot = screenshots_dir(tmp_path, "release") / "screen.png"
+    screenshot.write_bytes(b"png")
+    tracker = HDBits({"TRACKERS": {"HDBITS": {"username": "user", "passkey": "pass"}}})
+    meta = Meta(base_dir=str(tmp_path), uuid="release", name="Example", category="MOVIE")
+
+    assert asyncio.run(tracker.hdbimg_upload(meta)) == _Response.text
+    assert _Client.files == {"images_files[0]": ("screen.png", b"png", "image/png")}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HDBits screenshot rehosting to reliably locate images in the configured screenshot directory.
  * Preserved existing image discovery and upload behavior.

* **Tests**
  * Added coverage verifying screenshot uploads and returned responses when using a typed screenshot directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->