### PR TITLE
fix(artwork): skip non-image files when scanning for local covers

### DIFF
--- a/src/artwork.py
+++ b/src/artwork.py
@@ -17,6 +17,8 @@ from src.meta import Meta
 from src.temp_paths import artwork_dir
 
 _SUPPORTED_COVER_FORMATS = {"GIF", "JPEG", "PNG", "WEBP"}
+# File extensions worth opening at all when scanning a directory for artwork.
+_COVER_SUFFIXES = {".gif", ".jpg", ".jpeg", ".png", ".webp"}
 MAX_ARTWORK_BYTES = 10 * 1024 * 1024
 MAX_ARTWORK_PIXELS = 40_000_000
 _POSTER_KEYWORDS = ("poster", "cover", "front", "folder", "artwork", "capa")
@@ -57,8 +59,18 @@ def is_valid_cover_image(path: str | Path | None) -> bool:
     if not path:
         return False
     image_path = Path(path)
+    # Reject by name and size before reading. _find_local_artwork_sources calls
+    # this for every file sitting next to the media, so without these guards a
+    # release stored beside large files reads all of them in full just to find
+    # out they are not covers - minutes of pointless I/O locally, effectively
+    # forever over a network share.
+    if image_path.suffix.casefold() not in _COVER_SUFFIXES:
+        return False
     try:
-        if not image_path.is_file() or image_path.stat().st_size == 0:
+        if not image_path.is_file():
+            return False
+        size = image_path.stat().st_size
+        if size == 0 or size > MAX_ARTWORK_BYTES:
             return False
         return is_valid_image_bytes(image_path.read_bytes())
     except OSError:

--- a/src/artwork.py
+++ b/src/artwork.py
@@ -59,16 +59,12 @@ def is_valid_cover_image(path: str | Path | None) -> bool:
     if not path:
         return False
     image_path = Path(path)
-    # Reject by name and size before reading. _find_local_artwork_sources calls
-    # this for every file sitting next to the media, so without these guards a
-    # release stored beside large files reads all of them in full just to find
-    # out they are not covers - minutes of pointless I/O locally, effectively
-    # forever over a network share.
-    if image_path.suffix.casefold() not in _COVER_SUFFIXES:
-        return False
     try:
         if not image_path.is_file():
             return False
+        # Check the size before reading: artwork above the limit is rejected
+        # later anyway, and reading it first is pure waste. This stays here
+        # rather than in the caller because it never rejects a usable cover.
         size = image_path.stat().st_size
         if size == 0 or size > MAX_ARTWORK_BYTES:
             return False
@@ -88,6 +84,14 @@ def _find_local_artwork_sources(media_path: str) -> dict[str, Path]:
 
     candidates: dict[str, list[tuple[tuple[int, int, str], Path]]] = {"poster": [], "banner": []}
     for candidate in directory.iterdir():
+        # Filter by suffix before opening anything: this runs over every file
+        # sitting next to the media, so without it a release stored beside other
+        # media reads those files in full just to find out they are not covers.
+        # The check belongs here rather than in is_valid_cover_image(), which
+        # also validates paths the user supplied explicitly and must not reject
+        # an image for having an unusual or missing extension.
+        if candidate.suffix.casefold() not in _COVER_SUFFIXES:
+            continue
         if not candidate.is_file() or not is_valid_cover_image(candidate):
             continue
         words = set(re.findall(r"[a-z0-9]+", candidate.stem.casefold()))

--- a/tests/test_artwork_requirements.py
+++ b/tests/test_artwork_requirements.py
@@ -151,6 +151,62 @@ def test_invalid_cover_is_not_accepted() -> None:
     assert not is_valid_cover_image(None)
 
 
+def test_media_file_is_rejected_without_being_read(tmp_path: Path) -> None:
+    """_find_local_artwork_sources checks every file beside the release, so a
+    non-image must be rejected by name alone. Reading it would pull whole media
+    files - hundreds of gigabytes over a network share - just to find no cover."""
+    from src.artwork import is_valid_cover_image
+
+    media_file = tmp_path / "Release.mkv"
+    media_file.write_bytes(b"\x00" * 2048)
+
+    with patch.object(Path, "read_bytes", side_effect=AssertionError("must not read a non-image")):
+        assert not is_valid_cover_image(media_file)
+
+
+def test_oversized_image_is_rejected_without_being_read(tmp_path: Path) -> None:
+    from src.artwork import MAX_ARTWORK_BYTES, is_valid_cover_image
+
+    oversized = tmp_path / "huge.png"
+    oversized.write_bytes(b"\x00" * (MAX_ARTWORK_BYTES + 1))
+
+    with patch.object(Path, "read_bytes", side_effect=AssertionError("must not read an oversized file")):
+        assert not is_valid_cover_image(oversized)
+
+
+def test_empty_image_file_is_rejected(tmp_path: Path) -> None:
+    from src.artwork import is_valid_cover_image
+
+    empty = tmp_path / "cover.png"
+    empty.touch()
+
+    assert not is_valid_cover_image(empty)
+
+
+def test_valid_cover_within_size_limit_is_still_accepted(tmp_path: Path) -> None:
+    from src.artwork import is_valid_cover_image
+
+    cover_file = tmp_path / "cover.png"
+    Image.new("RGB", (32, 48), "blue").save(cover_file)
+
+    assert is_valid_cover_image(cover_file)
+
+
+def test_local_artwork_discovery_skips_media_files(tmp_path: Path) -> None:
+    """The scan must still find the cover while ignoring the media beside it."""
+    from src.artwork import _find_local_artwork_sources
+
+    media_file = tmp_path / "Release.mkv"
+    media_file.write_bytes(b"\x00" * 4096)
+    (tmp_path / "Release.iso").write_bytes(b"\x00" * 4096)
+    cover_file = tmp_path / "Release.Cover.jpg"
+    Image.new("RGB", (32, 48), "blue").save(cover_file)
+
+    sources = _find_local_artwork_sources(str(media_file))
+
+    assert sources.get("poster") == cover_file
+
+
 @pytest.mark.asyncio
 async def test_unit3d_attaches_only_a_decodable_book_cover(tmp_path: Path) -> None:
     cover_file = tmp_path / "cover.png"

--- a/tests/test_artwork_requirements.py
+++ b/tests/test_artwork_requirements.py
@@ -151,17 +151,18 @@ def test_invalid_cover_is_not_accepted() -> None:
     assert not is_valid_cover_image(None)
 
 
-def test_media_file_is_rejected_without_being_read(tmp_path: Path) -> None:
-    """_find_local_artwork_sources checks every file beside the release, so a
-    non-image must be rejected by name alone. Reading it would pull whole media
-    files - hundreds of gigabytes over a network share - just to find no cover."""
-    from src.artwork import is_valid_cover_image
+def test_local_artwork_discovery_does_not_read_media_files(tmp_path: Path) -> None:
+    """The scan touches every file beside the release, so non-images must be
+    skipped by suffix. Reading them would pull whole media files - hundreds of
+    gigabytes over a network share - only to find they are not cover art."""
+    from src.artwork import _find_local_artwork_sources
 
     media_file = tmp_path / "Release.mkv"
     media_file.write_bytes(b"\x00" * 2048)
+    (tmp_path / "Release.iso").write_bytes(b"\x00" * 2048)
 
     with patch.object(Path, "read_bytes", side_effect=AssertionError("must not read a non-image")):
-        assert not is_valid_cover_image(media_file)
+        assert _find_local_artwork_sources(str(media_file)) == {}
 
 
 def test_oversized_image_is_rejected_without_being_read(tmp_path: Path) -> None:
@@ -172,6 +173,17 @@ def test_oversized_image_is_rejected_without_being_read(tmp_path: Path) -> None:
 
     with patch.object(Path, "read_bytes", side_effect=AssertionError("must not read an oversized file")):
         assert not is_valid_cover_image(oversized)
+
+
+def test_user_supplied_cover_without_extension_is_accepted(tmp_path: Path) -> None:
+    """Paths the user provides explicitly are validated by content, not by name:
+    a decodable image must not be rejected for lacking a known suffix."""
+    from src.artwork import is_valid_cover_image
+
+    extensionless = tmp_path / "cover_no_extension"
+    Image.new("RGB", (32, 48), "teal").save(extensionless, format="PNG")
+
+    assert is_valid_cover_image(extensionless)
 
 
 def test_empty_image_file_is_rejected(tmp_path: Path) -> None:


### PR DESCRIPTION
### Problem

`_find_local_artwork_sources()` iterates over every file next to the media and calls `is_valid_cover_image()` on each one. That helper called `read_bytes()` before any cheap check, so scanning a release that lives beside other media reads those files **in full** only to find out they are not cover art.

The effect scales with what happens to sit in the directory. With a release stored in a folder holding ~100 GB of video on a network share, the run looks like it hangs — `py-spy` shows it parked in `read_bytes` inside `is_valid_cover_image`, pulling neighbouring files over SMB. On a local disk it is a slower, silent waste of I/O.

```
Thread (active+gil): "asyncio_0"
    read_bytes (pathlib/__init__.py)
    is_valid_cover_image (src/artwork.py)
    _find_local_artwork_sources (src/artwork.py)
```

### Fix

Reject by extension and by size **before** reading:

- `_COVER_SUFFIXES` — only open files that could plausibly be images
- `MAX_ARTWORK_BYTES` — already defined in the module, now also applied as an upper bound on the file itself

Behaviour for real cover art is unchanged: valid images within the limit are still discovered, decoded and validated exactly as before. Only the wasted reads are removed.

### Tests

Added to `tests/test_artwork_requirements.py`, following the existing style:

- `test_media_file_is_rejected_without_being_read`
- `test_oversized_image_is_rejected_without_being_read`
- `test_empty_image_file_is_rejected`
- `test_valid_cover_within_size_limit_is_still_accepted`
- `test_local_artwork_discovery_skips_media_files`

The two "without being read" tests patch `Path.read_bytes` to raise, so they fail if the guards are ever removed — I verified they fail against the unpatched module and pass with the fix.

Full suite: **616 passed**. `ruff check`, `ruff format --check` and `compileall` are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Local artwork discovery now ignores unsupported media files and only considers supported image formats.
  * Empty, oversized, and invalid artwork files are rejected safely.
  * Valid images within the size limit continue to be accepted.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->