### PR TITLE
feat(desc): add release group tag overrides for description text fields

### DIFF
--- a/config-generator.py
+++ b/config-generator.py
@@ -70,6 +70,7 @@ class LinkedSetting(TypedDict):
 ConfigDict = dict[str, Any]
 ConfigComments = dict[str, list[str]]
 UnexpectedKey = tuple[str, ConfigDict, str]
+DYNAMIC_CONFIG_MAP_KEYS = frozenset({"tag_overrides"})
 
 
 def tracker_sort_key(name: str) -> tuple[bool, bool, str]:
@@ -320,6 +321,8 @@ def validate_config(existing_config: ConfigDict, example_config: ConfigDict) -> 
         for key in existing_section:
             current_path = f"{path}.{key}" if path else key
 
+            if key in DYNAMIC_CONFIG_MAP_KEYS and isinstance(existing_section[key], dict):
+                continue
             if key not in example_section:
                 unexpected_keys.append((current_path, existing_section, key))
             elif isinstance(existing_section[key], dict) and isinstance(example_section.get(key), dict):
@@ -571,6 +574,10 @@ def configure_default_section(
         if key in ["default_torrent_client"]:
             continue
 
+        if key in DYNAMIC_CONFIG_MAP_KEYS and isinstance(default_value, dict):
+            config_defaults[key] = deepcopy(existing_defaults.get(key, default_value))
+            continue
+
         # Skip if this setting should be skipped based on linked settings
         if key in skip_settings:
             # Copy default value from example config
@@ -784,11 +791,20 @@ def configure_trackers(
         example_tracker: ConfigDict = cast(ConfigDict, example_trackers.get(tracker, {}))
         tracker_config: dict[str, Any] = {}
 
+        for key in DYNAMIC_CONFIG_MAP_KEYS:
+            value = existing_tracker_config.get(key)
+            if isinstance(value, dict):
+                tracker_config[key] = deepcopy(value)
+
         if example_tracker:
             for key, default_value in example_tracker.items():
                 # Skip keys that should not be prompted
                 if tracker == "HDTORRENTS" and key == "announce_url":
                     tracker_config[key] = example_tracker[key]
+                    continue
+
+                if key in DYNAMIC_CONFIG_MAP_KEYS and isinstance(default_value, dict):
+                    tracker_config[key] = deepcopy(existing_tracker_config.get(key, default_value))
                     continue
 
                 comment_key = f"TRACKERS.{tracker}.{key}"

--- a/data/example_config.py
+++ b/data/example_config.py
@@ -350,6 +350,20 @@ config: dict[str, Any] = {
         # Allows adding a custom signature, in BBCode, at the bottom of the description section
         # Can be overridden in a per-tracker setting by adding this same config
         "custom_signature": "",
+        # Override description text fields for specific release groups. Tags are matched
+        # case-insensitively, with or without their leading hyphen.
+        # Per-tracker tag_overrides take precedence over these DEFAULT overrides.
+        "tag_overrides": {
+            "MyAwesomeGroupTag": {
+                "custom_description_header": "[center]MyAwesomeGroupTag release[/center]",
+                "screenshot_header": "[h2]MyAwesomeGroupTag Screenshots[/h2]",
+                "disc_menu_header": "[h2]MyAwesomeGroupTag Disc Menu Screenshots[/h2]",
+                "audio_spectrogram_header": "[h2]MyAwesomeGroupTag Audio Spectrogram[/h2]",
+                "dynamic_hdr_plot_header": "[h2]MyAwesomeGroupTag Dynamic HDR Metadata[/h2]",
+                "tonemapped_header": "[center]MyAwesomeGroupTag SDR reference screenshots[/center]",
+                "custom_signature": "[center]MyAwesomeGroupTag signature[/center]",
+            },
+        },
         # Add bluray.com link to description
         # Requires "get_bluray_info" to be set to True
         "add_bluray_link": True,

--- a/docs/example-config.md
+++ b/docs/example-config.md
@@ -167,7 +167,48 @@ These can be [overridden per-tracker](#tracker-overridable-settings) by adding t
 - `custom_description_header` (str): BBCode header added at top of description section.
 - `screenshot_header` (str): BBCode header added above screenshots.
 - `disc_menu_header` (str): BBCode header added above disc menu screenshots (discs only).
+- `audio_spectrogram_header` (str): BBCode header added above audio spectrograms.
+- `dynamic_hdr_plot_header` (str): BBCode header added above dynamic HDR metadata plots.
+- `tonemapped_header` (str): BBCode header added for tone-mapped releases.
 - `custom_signature` (str): BBCode signature appended at bottom of description.
+- `tag_overrides` (dict): Per-release-group overrides for these text fields. The
+  group key is matched against `meta.tag` case-insensitively and may be written
+  with or without its leading hyphen. A tracker-level `tag_overrides` entry has
+  precedence over a `DEFAULT` entry; unspecified fields use their normal
+  tracker/default value.
+
+  Default overrides apply to every tracker that supports the description field:
+
+  ```python
+  config = {
+      "DEFAULT": {
+          "tag_overrides": {
+              "MyAwesomeGroupTag": {
+                  "custom_signature": "[center]Group signature[/center]",
+                  "screenshot_header": "[h2]Group screenshots[/h2]",
+              },
+          },
+      },
+  }
+  ```
+
+  Tracker overrides apply only to that tracker and take precedence over the
+  `DEFAULT` entry for the same group and field:
+
+  ```python
+  config = {
+      "TRACKERS": {
+          "AITHER": {
+              "tag_overrides": {
+                  "MyAwesomeGroupTag": {
+                      "custom_signature": "[center]AITHER group signature[/center]",
+                      "disc_menu_header": "[h2]AITHER group menus[/h2]",
+                  },
+              },
+          },
+      },
+  }
+  ```
 
 ### Torrent client integration
 

--- a/src/get_desc.py
+++ b/src/get_desc.py
@@ -257,8 +257,36 @@ class DescriptionBuilder:
             except ValueError, TypeError:
                 return 0
 
-    def _get_str_config(self, key: str, default: str = "") -> str:
-        """Helper to get a string config value safely. Empty string is returned if it is a valid override."""
+    def _get_tag_override(self, key: str, meta: Meta | None) -> str | None:
+        """Return a tag-specific string override, if configured."""
+        if not meta or not meta.tag:
+            return None
+
+        tag = str(meta.tag).strip().lstrip("-").casefold()
+        if not tag:
+            return None
+
+        default_config = self.config.get("DEFAULT", {})
+        config_sources = (self.tracker_config, default_config)
+        for config_source in config_sources:
+            if not isinstance(config_source, dict):
+                continue
+            tag_overrides = config_source.get("tag_overrides", {})
+            if not isinstance(tag_overrides, dict):
+                continue
+            for configured_tag, overrides in tag_overrides.items():
+                if str(configured_tag).strip().lstrip("-").casefold() != tag or not isinstance(overrides, dict):
+                    continue
+                if key in overrides and overrides[key] is not None:
+                    return str(overrides[key])
+
+        return None
+
+    def _get_str_config(self, key: str, default: str = "", meta: Meta | None = None) -> str:
+        """Get a string config value, optionally overridden by the release group tag."""
+        tag_override = self._get_tag_override(key, meta)
+        if tag_override is not None:
+            return tag_override
         if key in self.tracker_config:
             val = self.tracker_config[key]
             if val is not None:
@@ -266,10 +294,10 @@ class DescriptionBuilder:
         val = self.config["DEFAULT"].get(key, default)
         return str(val) if val is not None else default
 
-    async def get_custom_header(self) -> str:
+    async def get_custom_header(self, meta: Meta) -> str:
         """Returns a custom header if configured."""
         try:
-            custom_description_header = self._get_str_config("custom_description_header", "")
+            custom_description_header = self._get_str_config("custom_description_header", "", meta)
             if custom_description_header:
                 return custom_description_header
         except Exception as e:
@@ -279,7 +307,7 @@ class DescriptionBuilder:
 
     async def get_tonemapped_header(self, meta: Meta) -> str:
         try:
-            tonemapped_description_header = self._get_str_config("tonemapped_header", "")
+            tonemapped_description_header = self._get_str_config("tonemapped_header", "", meta)
             if tonemapped_description_header and meta.tonemapped:
                 return tonemapped_description_header
         except Exception as e:
@@ -516,10 +544,10 @@ class DescriptionBuilder:
 
         return ""
 
-    async def screenshot_header(self) -> str:
+    async def screenshot_header(self, meta: Meta) -> str:
         """Returns the screenshot header if applicable."""
         try:
-            screenheader = self._get_str_config("screenshot_header", "")
+            screenheader = self._get_str_config("screenshot_header", "", meta)
             if screenheader:
                 return screenheader
         except Exception as e:
@@ -532,7 +560,7 @@ class DescriptionBuilder:
         try:
             menu_images = get_tracker_image_collection(meta, self.tracker, "menu_images")
             if meta.is_disc and menu_images:
-                disc_menu_header = self._get_str_config("disc_menu_header", "")
+                disc_menu_header = self._get_str_config("disc_menu_header", "", meta)
                 if disc_menu_header:
                     return disc_menu_header
         except Exception as e:
@@ -558,10 +586,10 @@ class DescriptionBuilder:
 
         return ""
 
-    async def get_custom_signature(self) -> str:
+    async def get_custom_signature(self, meta: Meta) -> str:
         custom_signature: str = ""
         try:
-            custom_signature = self._get_str_config("custom_signature", "")
+            custom_signature = self._get_str_config("custom_signature", "", meta)
         except Exception as e:
             logger.warning(f"[yellow]Warning: Error setting custom signature: {e!s}[/yellow]")
 
@@ -619,7 +647,7 @@ class DescriptionBuilder:
             spectrograms_images = get_tracker_image_collection(meta, self.tracker, "spectrograms_images")
             if not spectrograms_images:
                 return ""
-            audio_spectrogram_header = self._get_str_config("audio_spectrogram_header", "[center][b]Audio Spectrogram[/b][/center]")
+            audio_spectrogram_header = self._get_str_config("audio_spectrogram_header", "[center][b]Audio Spectrogram[/b][/center]", meta)
             desc_parts: list[str] = [audio_spectrogram_header] if audio_spectrogram_header is not None else []
             desc_parts.append("\n[center]")
             screens_per_row = await self.get_screens_per_row()
@@ -644,7 +672,7 @@ class DescriptionBuilder:
         plot_images = get_tracker_image_collection(meta, self.tracker, "dynamic_hdr_plot_images")
         if not plot_images:
             return ""
-        header = self._get_str_config("dynamic_hdr_plot_header", "[center][b]Dynamic HDR Metadata[/b][/center]")
+        header = self._get_str_config("dynamic_hdr_plot_header", "[center][b]Dynamic HDR Metadata[/b][/center]", meta)
         desc_parts: list[str] = [header] if header is not None else []
         desc_parts.append("\n[center]")
         for image in plot_images:
@@ -1122,7 +1150,7 @@ class DescriptionBuilder:
         # Custom Header
         if custom_header:
             if not desc_header:
-                desc_header = await self.get_custom_header()
+                desc_header = await self.get_custom_header(meta)
             if desc_header:
                 desc_parts.append(desc_header + "\n")
 
@@ -1323,7 +1351,7 @@ class DescriptionBuilder:
 
         # Custom Signature
         if custom_signature:
-            desc_parts.append(await self.get_custom_signature())
+            desc_parts.append(await self.get_custom_signature(meta))
 
         # UA Signature
         if ua_signature:
@@ -1414,7 +1442,7 @@ class DescriptionBuilder:
         if not images:
             return ""
         try:
-            screenheader = await self.screenshot_header()
+            screenheader = await self.screenshot_header(meta)
         except Exception:
             screenheader = None
 

--- a/tests/test_config_generator_tag_overrides.py
+++ b/tests/test_config_generator_tag_overrides.py
@@ -1,0 +1,63 @@
+# ruff: noqa: S101
+
+import builtins
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def config_generator_module():
+    path = Path(__file__).parents[1] / "config-generator.py"
+    spec = importlib.util.spec_from_file_location("config_generator", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_validate_config_preserves_tracker_tag_overrides(config_generator_module, monkeypatch):
+    config = {
+        "DEFAULT": {},
+        "TRACKERS": {
+            "AITHER": {
+                "api_key": "key",
+                "tag_overrides": {"MyGroup": {"custom_signature": "signature"}},
+            },
+        },
+    }
+    example = {"DEFAULT": {}, "TRACKERS": {"AITHER": {"api_key": ""}}}
+
+    monkeypatch.setattr(builtins, "input", lambda _prompt: pytest.fail("tag_overrides must not be treated as unexpected"))
+
+    assert config_generator_module.validate_config(config, example) == config
+
+
+def test_configure_default_section_keeps_tag_overrides_as_a_mapping(config_generator_module):
+    existing = {"tag_overrides": {"MyGroup": {"custom_signature": "signature"}}}
+    example = {"tag_overrides": {"MyAwesomeGroupTag": {"custom_signature": "example signature"}}}
+
+    configured = config_generator_module.configure_default_section(existing, example, {})
+
+    assert configured["tag_overrides"] == existing["tag_overrides"]
+    assert configured["tag_overrides"] is not existing["tag_overrides"]
+
+
+def test_configure_trackers_keeps_existing_tag_overrides(config_generator_module, monkeypatch):
+    existing = {
+        "default_trackers": "AITHER",
+        "AITHER": {
+            "api_key": "key",
+            "tag_overrides": {"MyGroup": {"custom_signature": "signature"}},
+        },
+    }
+    example = {"AITHER": {"api_key": ""}}
+
+    monkeypatch.setattr(config_generator_module, "get_user_input", lambda *_args, **_kwargs: "AITHER")
+    monkeypatch.setattr(builtins, "input", lambda _prompt: "y")
+
+    configured = config_generator_module.configure_trackers(existing, example, {})
+
+    assert configured["AITHER"]["tag_overrides"] == existing["AITHER"]["tag_overrides"]
+    assert configured["AITHER"]["tag_overrides"] is not existing["AITHER"]["tag_overrides"]

--- a/tests/test_description_tag_overrides.py
+++ b/tests/test_description_tag_overrides.py
@@ -1,0 +1,58 @@
+# ruff: noqa: S101
+
+import asyncio
+
+from src.get_desc import DescriptionBuilder
+from src.meta import Meta
+
+
+def test_tag_overrides_apply_to_description_text_fields():
+    async def run():
+        builder = DescriptionBuilder(
+            "TEST",
+            {
+                "DEFAULT": {
+                    "custom_signature": "default signature",
+                    "screenshot_header": "default screenshots",
+                    "tag_overrides": {
+                        "MyAwesomeGroupTag": {
+                            "custom_signature": "group signature",
+                            "screenshot_header": "group screenshots",
+                            "disc_menu_header": "",
+                        },
+                    },
+                },
+                "TRACKERS": {"TEST": {}},
+            },
+        )
+        meta = Meta({"tag": "-myawesomegrouptag"})
+
+        assert await builder.get_custom_signature(meta) == "group signature"
+        assert await builder.screenshot_header(meta) == "group screenshots"
+        assert builder._get_str_config("disc_menu_header", "default menu", meta) == ""
+
+    asyncio.run(run())
+
+
+def test_tracker_tag_override_has_precedence_and_untagged_releases_keep_existing_config():
+    async def run():
+        builder = DescriptionBuilder(
+            "TEST",
+            {
+                "DEFAULT": {
+                    "custom_signature": "default signature",
+                    "tag_overrides": {"MyAwesomeGroupTag": {"custom_signature": "default group signature"}},
+                },
+                "TRACKERS": {
+                    "TEST": {
+                        "custom_signature": "tracker signature",
+                        "tag_overrides": {"-myawesomegrouptag": {"custom_signature": "tracker group signature"}},
+                    },
+                },
+            },
+        )
+
+        assert await builder.get_custom_signature(Meta({"tag": "MyAwesomeGroupTag"})) == "tracker group signature"
+        assert await builder.get_custom_signature(Meta({"tag": "-OTHER"})) == "tracker signature"
+
+    asyncio.run(run())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release-tag-specific overrides for description headers, screenshots, spectrograms, HDR plots, tone-mapped text, and signatures.
  * Tag matching is case-insensitive and supports tags with or without a leading hyphen.
  * Tracker-specific overrides take precedence over default overrides.

* **Documentation**
  * Added configuration guidance and examples for tag-based description formatting.

* **Bug Fixes**
  * Existing tag override settings are now preserved during configuration generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->