### PR TITLE
feat(args): replace tracker-specific id flags with generic --tracker-id and unify client comments

### DIFF
--- a/data/example_config.py
+++ b/data/example_config.py
@@ -191,6 +191,8 @@ config: dict[str, Any] = {
         "tracker_description_mode": "text",
         # Maximum number of tracker-ID metadata candidates queried at once.
         "tracker_search_concurrency": 4,
+        # Only query tracker metadata when a torrent ID is known from a client comment or --tracker-id.
+        "tracker_comment_only": True,
         # set true to use argument overrides from data/templates/user-args.json
         "user_overrides": False,
         # Automatically set --personalrelease to True if the detected release group matches any of these tags (case-insensitive)

--- a/docs/cli-args.md
+++ b/docs/cli-args.md
@@ -160,18 +160,7 @@ Note: if a manual TMDb or IMDb id is present in the incoming `meta` before parsi
 These accept either an id or a full URL; when a URL is provided, the parser attempts to extract the id.
 These will parse the torrent descriptions from supported sites, and grab metadata ids to assist with accuracy.
 
-- `-ptp`, `--ptp ID_OR_URL`: PASSTHEPOPCORN torrent id/permalink. (Extracts `torrentid` from query string.)
-- `-blu`, `--blu ID_OR_URL`: BLUTOPIA torrent id/link. (Extracts last path segment.)
-- `-aither`, `--aither ID_OR_URL`: Aither torrent id/link. (Extracts last path segment.)
-- `-lst`, `--lst ID_OR_URL`: LST torrent id/link. (Extracts last path segment.)
-- `-oe`, `--oe ID_OR_URL`: ONLYENCODES torrent id/link. (Extracts last path segment.)
-- `-tik`, `--tik ID_OR_URL`: CINEMATIK torrent id/link. (No URL parsing here; passes through.)
-- `-hdb`, `--hdb ID_OR_URL`: HDBITS torrent id/link. (Extracts `id` from query string.)
-- `-btn`, `--btn ID_OR_URL`: BTN torrent id/link. (Extracts `id` from query string.)
-- `-bhd`, `--bhd ID_OR_URL`: BEYONDHD torrent id/link.
-  - Tries to extract trailing numeric id from URLs like `/download/... .12345`.
-- `-huno`, `--huno ID_OR_URL`: HAWKEUNO torrent id/link. (Extracts last path segment.)
-- `-ulcx`, `--ulcx ID_OR_URL`: ULCX torrent id/link. (Extracts last path segment.)
+- `--tracker-id TRACKER=ID_OR_URL`: Generic tracker torrent ID; repeat for multiple trackers. Also accepts a tracker torrent URL directly, for example `--tracker-id https://aither.cc/torrents/1234`.
 
 Thise will use the specified hash to get tracker ids from qBitTorrent or rTorrent.
 

--- a/docs/example-config.md
+++ b/docs/example-config.md
@@ -228,11 +228,13 @@ Implementation notes:
 - `use_largest_playlist` (bool): Always use the largest Blu-ray playlist without prompting.
 - `tracker_description_mode` (str, required): Import policy for other tracker releases: `ids`, `images`, `text`, or `text_and_images`.
 - `tracker_search_concurrency` (int): Maximum number of tracker IDs queried concurrently; default `4`.
+- `tracker_comment_only` (bool, default `True`): Only query tracker metadata when a torrent ID was obtained from a client comment or supplied with `--tracker-id`; disables filename-based tracker searches. Set `False` to re-enable filename-based tracker searches.
 
 Implementation notes:
 
 - `tracker_pass_checks` is used to determine how many trackers must pass early validation before continuing (see `upload.py`).
 - `tracker_description_mode` is the only configuration that controls imported tracker description text and screenshots. `--onlyID` temporarily forces `ids` for that execution.
+- `tracker_comment_only` does not disable explicit IDs supplied through `--tracker-id`.
 
 ### Sonarr / Radarr integration
 

--- a/src/args.py
+++ b/src/args.py
@@ -1092,7 +1092,7 @@ class Args:
         id_value = candidate
         if "=" in candidate and not candidate.startswith(("http://", "https://")):
             tracker_name, id_value = (part.strip() for part in candidate.split("=", 1))
-            tracker_name = tracker_name.upper()
+            tracker_name = Meta.canonical_tracker_name(tracker_name)
 
         if id_value.startswith(("http://", "https://")):
             parsed = urllib.parse.urlparse(id_value)
@@ -1102,7 +1102,7 @@ class Args:
             ]
             if len(matched_trackers) != 1:
                 raise ValueError(f"--tracker-id URL host is unknown or ambiguous: {host or id_value}")
-            url_tracker = matched_trackers[0]
+            url_tracker = Meta.canonical_tracker_name(matched_trackers[0])
             if tracker_name and tracker_name != url_tracker:
                 raise ValueError(f"--tracker-id tracker {tracker_name} does not match URL host {host}")
             tracker_name = url_tracker

--- a/src/args.py
+++ b/src/args.py
@@ -424,17 +424,12 @@ class Args:
             required=False,
             help="Use the largest video file for processing instead of the first video file found",
         )
-        parser.add_argument("-ptp", "--ptp", nargs=1, required=False, help="PASSTHEPOPCORN torrent id/permalink", type=str)
-        parser.add_argument("-blu", "--blu", nargs=1, required=False, help="BLUTOPIA torrent id/link", type=str)
-        parser.add_argument("-aither", "--aither", nargs=1, required=False, help="AITHER torrent id/link", type=str)
-        parser.add_argument("-lst", "--lst", nargs=1, required=False, help="LST torrent id/link", type=str)
-        parser.add_argument("-oe", "--oe", nargs=1, required=False, help="ONLYENCODES torrent id/link", type=str)
-        parser.add_argument("-hdb", "--hdb", nargs=1, required=False, help="HDBITS torrent id/link", type=str)
-        parser.add_argument("-btn", "--btn", nargs=1, required=False, help="BTN torrent id/link", type=str)
-        parser.add_argument("-bhd", "--bhd", nargs=1, required=False, help="BEYONDHD torrent_id/link", type=str)
-        parser.add_argument("--orpheus", nargs=1, required=False, help="Orpheus torrent id/permalink (MUSIC metadata enrichment)", type=str)
-        parser.add_argument("-huno", "--huno", nargs=1, required=False, help="HAWKEUNO torrent id/link", type=str)
-        parser.add_argument("-ulcx", "--ulcx", nargs=1, required=False, help="ULCX torrent id/link", type=str)
+        parser.add_argument(
+            "--tracker-id",
+            action="append",
+            metavar="TRACKER=ID|URL",
+            help="Tracker torrent ID, as TRACKER=ID, TRACKER=URL, or a tracker torrent URL. May be repeated.",
+        )
         parser.add_argument("-req", "--search_requests", action="store_true", required=False, help="Search for matching requests on supported trackers", default=None)
         parser.add_argument("-sat", "--skip_auto_torrent", action="store_true", required=False, help="Skip automated qbittorrent client torrent searching", default=None)
         parser.add_argument(
@@ -768,57 +763,12 @@ class Args:
                         meta.manual_date = value2
                     elif key == "tmdb_manual":
                         meta.category, meta.tmdb_manual = self.parse_tmdb_id(value2, meta.category)
+                    elif key == "tracker_id":
+                        for tracker_id_value in value_list:
+                            tracker_name, torrent_id = self.parse_tracker_id(tracker_id_value)
+                            meta.set_tracker_ids({tracker_name: torrent_id})
                     elif key == "manual_cast":
                         meta.manual_cast = [name.strip() for name in value2.split(",") if name.strip()]
-                    elif key == "ptp":
-                        if value2.startswith("http"):
-                            parsed = urllib.parse.urlparse(value2)
-                            try:
-                                meta.ptp = urllib.parse.parse_qs(parsed.query)["torrentid"][0]
-                            except Exception:
-                                logger.info("[red]Your terminal ate  part of the url, please surround in quotes next time, or pass only the torrentid")
-                                logger.info("[red]Continuing without -ptp")
-                        else:
-                            meta.ptp = value2
-                    elif key == "blu":
-                        if value2.startswith("http"):
-                            parsed = urllib.parse.urlparse(value2)
-                            try:
-                                blupath = parsed.path
-                                if blupath.endswith("/"):
-                                    blupath = blupath[:-1]
-                                meta.blu = blupath.split("/")[-1]
-                            except Exception:
-                                logger.info("[red]Unable to parse id from url")
-                                logger.info("[red]Continuing without --blu")
-                        else:
-                            meta.blu = value2
-                    elif key == "aither":
-                        if value2.startswith("http"):
-                            parsed = urllib.parse.urlparse(value2)
-                            try:
-                                aitherpath = parsed.path
-                                if aitherpath.endswith("/"):
-                                    aitherpath = aitherpath[:-1]
-                                meta.aither = aitherpath.split("/")[-1]
-                            except Exception:
-                                logger.info("[red]Unable to parse id from url")
-                                logger.info("[red]Continuing without --aither")
-                        else:
-                            meta.aither = value2
-                    elif key == "lst":
-                        if value2.startswith("http"):
-                            parsed = urllib.parse.urlparse(value2)
-                            try:
-                                lstpath = parsed.path
-                                if lstpath.endswith("/"):
-                                    lstpath = lstpath[:-1]
-                                meta.lst = lstpath.split("/")[-1]
-                            except Exception:
-                                logger.info("[red]Unable to parse id from url")
-                                logger.info("[red]Continuing without --lst")
-                        else:
-                            meta.lst = value2
                     elif key == "openlibrary":
                         if value2.startswith("http"):
                             parsed = urllib.parse.urlparse(value2)
@@ -835,105 +785,6 @@ class Args:
                                 logger.info("[red]Continuing without --openlibrary")
                         else:
                             meta.openlibrary = value2
-                    elif key == "oe":
-                        if value2.startswith("http"):
-                            parsed = urllib.parse.urlparse(value2)
-                            try:
-                                oepath = parsed.path
-                                if oepath.endswith("/"):
-                                    oepath = oepath[:-1]
-                                meta.oe = oepath.split("/")[-1]
-                            except Exception:
-                                logger.info("[red]Unable to parse id from url")
-                                logger.info("[red]Continuing without --oe")
-                        else:
-                            meta.oe = value2
-                    elif key == "ulcx":
-                        if value2.startswith("http"):
-                            parsed = urllib.parse.urlparse(value2)
-                            try:
-                                ulcxpath = parsed.path
-                                if ulcxpath.endswith("/"):
-                                    ulcxpath = ulcxpath[:-1]
-                                meta.ulcx = ulcxpath.split("/")[-1]
-                            except Exception:
-                                logger.info("[red]Unable to parse id from url")
-                                logger.info("[red]Continuing without --ulcx")
-                        else:
-                            meta.ulcx = value2
-                    elif key == "hdb":
-                        if value2.startswith("http"):
-                            parsed = urllib.parse.urlparse(value2)
-                            try:
-                                meta.hdb = urllib.parse.parse_qs(parsed.query)["id"][0]
-                            except Exception:
-                                logger.info("[red]Your terminal ate  part of the url, please surround in quotes next time, or pass only the torrentid")
-                                logger.info("[red]Continuing without -hdb")
-                        else:
-                            meta.hdb = value2
-
-                    elif key == "btn":
-                        if value2.startswith("http"):
-                            parsed = urllib.parse.urlparse(value2)
-                            try:
-                                meta.btn = urllib.parse.parse_qs(parsed.query)["id"][0]
-                            except Exception:
-                                logger.info("[red]Your terminal ate  part of the url, please surround in quotes next time, or pass only the torrentid")
-                                logger.info("[red]Continuing without -hdb")
-                        else:
-                            meta.btn = value2
-
-                    elif key == "bhd":
-                        if value2.startswith("http"):
-                            parsed = urllib.parse.urlparse(value2)
-                            try:
-                                bhdpath = parsed.path
-                                if bhdpath.endswith("/"):
-                                    bhdpath = bhdpath[:-1]
-
-                                if "/download/" in bhdpath or "/torrents/" in bhdpath:
-                                    torrent_id_match = re.search(r"\.(\d+)$", bhdpath)
-                                    if torrent_id_match:
-                                        meta.bhd = torrent_id_match.group(1)
-                                    else:
-                                        meta.bhd = bhdpath.split("/")[-1]
-                                else:
-                                    meta.bhd = bhdpath.split("/")[-1]
-
-                                logger.info(f"[green]Parsed BEYONDHD torrent ID: {meta.bhd}")
-                            except Exception as e:
-                                logger.info(f"[red]Unable to parse id from url: {e}")
-                                logger.info("[red]Continuing without --bhd")
-                        else:
-                            meta.bhd = value2
-
-                    elif key == "orpheus":
-                        if value2.startswith("http"):
-                            parsed = urllib.parse.urlparse(value2)
-                            torrent_id = urllib.parse.parse_qs(parsed.query).get("torrentid", [""])[0]
-                            if torrent_id.isdigit():
-                                meta.orpheus = torrent_id
-                            else:
-                                logger.info("[red]Unable to parse torrentid from --orpheus URL; pass a torrent ID or permalink.[/red]")
-                        elif value2.isdigit():
-                            meta.orpheus = value2
-                        else:
-                            logger.info("[red]Invalid --orpheus value; pass a numeric torrent ID or permalink.[/red]")
-
-                    elif key == "huno":
-                        if value2.startswith("http"):
-                            parsed = urllib.parse.urlparse(value2)
-                            try:
-                                hunopath = parsed.path
-                                if hunopath.endswith("/"):
-                                    hunopath = hunopath[:-1]
-                                meta.huno = hunopath.split("/")[-1]
-                            except Exception:
-                                logger.info("[red]Unable to parse id from url")
-                                logger.info("[red]Continuing without --huno")
-                        else:
-                            meta.huno = value2
-
                     elif key == "steam_manual":
                         if value2.startswith("http"):
                             parsed = urllib.parse.urlparse(value2)
@@ -1231,6 +1082,42 @@ class Args:
         except Exception:
             result = "None"
         return result
+
+    def parse_tracker_id(self, value: str) -> tuple[str, str]:
+        """Normalize ``--tracker-id`` values without exposing tracker-specific CLI flags."""
+        from src.trackersetup import get_tracker_comment_hosts, tracker_class_map
+
+        candidate = value.strip()
+        tracker_name = ""
+        id_value = candidate
+        if "=" in candidate and not candidate.startswith(("http://", "https://")):
+            tracker_name, id_value = (part.strip() for part in candidate.split("=", 1))
+            tracker_name = tracker_name.upper()
+
+        if id_value.startswith(("http://", "https://")):
+            parsed = urllib.parse.urlparse(id_value)
+            host = (parsed.hostname or "").lower()
+            matched_trackers = [
+                name for name, domains in get_tracker_comment_hosts(self.config).items() if any(host == domain or host.endswith(f".{domain}") for domain in domains)
+            ]
+            if len(matched_trackers) != 1:
+                raise ValueError(f"--tracker-id URL host is unknown or ambiguous: {host or id_value}")
+            url_tracker = matched_trackers[0]
+            if tracker_name and tracker_name != url_tracker:
+                raise ValueError(f"--tracker-id tracker {tracker_name} does not match URL host {host}")
+            tracker_name = url_tracker
+            query = urllib.parse.parse_qs(parsed.query)
+            id_value = (query.get("torrentid") or query.get("id") or [""])[0]
+            if not id_value:
+                path = parsed.path.rstrip("/")
+                dotted_id = re.search(r"\.(\d+)$", path)
+                id_value = dotted_id.group(1) if dotted_id else path.split("/")[-1]
+
+        if tracker_name not in tracker_class_map:
+            raise ValueError(f"--tracker-id requires a supported tracker name, got: {tracker_name or value}")
+        if not id_value or not id_value.isdigit():
+            raise ValueError(f"--tracker-id requires a numeric torrent ID, got: {value}")
+        return tracker_name, id_value
 
     def parse_tmdb_id(self, id_str: str, category: str | None) -> tuple[str, int]:
         if category is None:

--- a/src/configvalidator.py
+++ b/src/configvalidator.py
@@ -95,6 +95,7 @@ DEFAULT_KEY_TYPES: dict[str, tuple[type, ...]] = {
     "use_largest_playlist": (bool,),
     "tracker_description_mode": (str,),
     "tracker_search_concurrency": (str, int),
+    "tracker_comment_only": (bool,),
     "use_sonarr": (bool,),
     "use_radarr": (bool,),
     "mkbrr": (bool,),

--- a/src/get_tracker_data.py
+++ b/src/get_tracker_data.py
@@ -25,26 +25,6 @@ from src.tracker_descriptions import description_fingerprint
 from src.trackermeta import TrackerMetaManager
 from src.trackersetup import tracker_class_map
 
-_TRACKER_ID_FIELDS = {
-    "AITHER": "aither",
-    "ANTHELION": "ant",
-    "BEYONDHD": "bhd",
-    "BLUTOPIA": "blu",
-    "BTN": "btn",
-    "DARKPEERS": "dp",
-    "HAWKEUNO": "huno",
-    "HDBITS": "hdb",
-    "LASTDIGITALUNDERGROUND": "ldu",
-    "LST": "lst",
-    "OLDTOONSWORLD": "otw",
-    "ONLYENCODES": "oe",
-    "PASSTHEPOPCORN": "ptp",
-    "REELFLIX": "rf",
-    "SEEDPOOL": "sp",
-    "ULCX": "ulcx",
-    "YUSCENE": "yus",
-}
-
 
 class TrackerDataManager:
     def __init__(self, config: dict[str, Any]) -> None:
@@ -74,8 +54,7 @@ class TrackerDataManager:
         use_cache: bool = True,
     ) -> tuple[Meta, bool]:
         """Reuse a cached tracker response only when the user supplied a torrent ID."""
-        tracker_field = _TRACKER_ID_FIELDS.get(tracker_name, tracker_name.lower())
-        tracker_id = str(meta.get(tracker_field, "") or meta.get(tracker_name.lower(), "") or "").strip()
+        tracker_id = (meta.get_tracker_id(tracker_name) or "").strip()
         if not tracker_id:
             return await self.tracker_meta_manager.update_metadata_from_tracker(
                 tracker_name, tracker_instance, meta, search_term, search_file_folder, skip_tracker_descriptions
@@ -155,7 +134,7 @@ class TrackerDataManager:
         await asyncio.to_thread(candidate_dir.mkdir, mode=0o700, parents=True, exist_ok=True)
         try:
             if tracker_name == "BTN":
-                btn_id = str(candidate.btn or "")
+                btn_id = candidate.get_tracker_id("BTN") or ""
                 btn_api = self.default_config.get("btn_api")
                 if not isinstance(btn_api, str) or len(btn_api) <= 25:
                     return None
@@ -328,7 +307,7 @@ class TrackerDataManager:
         search_file_folder_value = search_file_folder or ""
         if search_term:
             # Check if a specific tracker is already set in meta
-            specific_tracker = sorted(tracker_name for tracker_name, tracker_key in _TRACKER_ID_FIELDS.items() if meta.get(tracker_key) is not None)
+            specific_tracker = sorted(meta.tracker_ids)
 
             # Filter out trackers that don't have valid config or api_key/announce_url
             if specific_tracker:

--- a/src/get_tracker_data.py
+++ b/src/get_tracker_data.py
@@ -397,6 +397,10 @@ class TrackerDataManager:
                     logger.debug("[yellow]No matches found on any available specific trackers.[/yellow]")
 
             else:
+                if self.default_config.get("tracker_comment_only", True):
+                    logger.debug("[cyan]Skipping filename-based tracker metadata searches because DEFAULT.tracker_comment_only is enabled.[/cyan]")
+                    return meta
+
                 # Process all trackers with API = true if no specific tracker is set in meta
                 from src.trackersetup import api_trackers
 

--- a/src/meta.py
+++ b/src/meta.py
@@ -4,6 +4,17 @@
 from dataclasses import MISSING, dataclass, field, fields
 from typing import Any
 
+_TRACKER_ID_ALIASES = {
+    "ANT": "ANTHELION",
+    "BHD": "BEYONDHD",
+    "BLU": "BLUTOPIA",
+    "BTN": "BTN",
+    "HDB": "HDBITS",
+    "HUNO": "HAWKEUNO",
+    "OE": "ONLYENCODES",
+    "PTP": "PASSTHEPOPCORN",
+}
+
 
 @dataclass(init=False)
 class Meta:
@@ -14,12 +25,10 @@ class Meta:
 
     adult_media: bool = False
     aither_trumpable: list[Any] | None = field(default_factory=list)
-    aither: str | None = None
     aka: str = ""
     anime: bool = False
     anon: bool = False
     ant_user_tags: bool | None = None
-    ant: int | None = None
     archive_password: str | None = None
     args_line_queue: bool | None = None
     artist: str = ""
@@ -53,10 +62,8 @@ class Meta:
     basename_no_ext: str = ""
     bdinfo: dict[str, Any] = field(default_factory=dict)
     bhd_nfo: bool | None = None
-    bhd: str | int | None = None
     bit_depth: str = ""
     bloated: bool = False
-    blu: str | int | None = None
     bluray_audio_skip: bool = False
     bluray_cover_urls: dict[str, Any] = field(default_factory=dict)
     bluray_score: int = 100
@@ -72,7 +79,6 @@ class Meta:
     book_series: str = ""
     book_title: str | None = None
     book_translator: str | None = None
-    btn: str | int | None = None
     cast: list[str] = field(default_factory=list)
     category_id: str | None = None
     category: str = ""
@@ -175,13 +181,11 @@ class Meta:
     hash_used: str | None = None
     hdb_description: str | None = None
     hdb_name: str | None = None
-    hdb: str | int | None = None
     HDDVD_PLAYLIST: dict[str, Any] | None = None
     hdr: str = ""
     HDR: str = ""
     hfr: bool | None = None
     hosted_artwork: list[dict[str, Any]] | None = None
-    huno: str | int | None = None
     igdb_first_release_date: str = ""
     igdb_id: int = 0
     igdb_manual: str | None = None
@@ -219,7 +223,6 @@ class Meta:
     linking_failed: bool = False
     localized_overviews: dict[str, Any] = field(default_factory=dict)
     logo: str = ""
-    lst: str | int | None = None
     magazine: bool = False
     mal_id: int = 0
     mal_manual: str | int | None = None
@@ -294,7 +297,6 @@ class Meta:
     not_anime: bool = False
     nzb_path: str = ""
     ocr: bool | None = None
-    oe: str | int | None = None
     only_id: bool | None = None
     openlibrary_book_id: int | None = None
     openlibrary_id: int | None = None
@@ -310,7 +312,6 @@ class Meta:
     original_tmdb: int = 0
     original_tvdb: int = 0
     original_tvmaze: int = 0
-    orpheus: str | int | None = None
     overview_meta: str = ""
     overview: str = ""
     part: str = ""
@@ -327,7 +328,6 @@ class Meta:
     production_countries: list[Any] = field(default_factory=list)
     ptgen: dict[str, Any] = field(default_factory=dict)
     ptp_groupid: str | None = None
-    ptp: str | int | None = None
     publisher: str = ""
     qbit_bandwidth_control: bool = False
     qbit_bandwidth_threshold: int = 0
@@ -366,6 +366,7 @@ class Meta:
     description_fingerprint: str = ""
     description_provenance: dict[str, Any] = field(default_factory=dict)
     tracker_description_raw: dict[str, str] = field(default_factory=dict)
+    tracker_ids: dict[str, str] = field(default_factory=dict)
     tracker_description_mode: str = ""
     tracker_search_term: str = ""
     persist_description: bool = True
@@ -473,7 +474,6 @@ class Meta:
     ua_name: str = ""
     ua_signature: str = ""
     uhd: str | bool = False
-    ulcx: str | int | None = None
     unattended_audio_skip: bool = False
     unattended_confirm: bool = False
     unattended_subtitle_skip: bool = False
@@ -600,6 +600,26 @@ class Meta:
         else:
             for k, v in other.items():
                 setattr(self, k, v)
+
+    def get_tracker_id(self, tracker_name: str) -> str | None:
+        """Return the known torrent ID for a tracker."""
+        key = _TRACKER_ID_ALIASES.get(tracker_name.upper(), tracker_name.upper())
+        value = self.tracker_ids.get(key)
+        return str(value) if value is not None else None
+
+    def set_tracker_ids(self, tracker_ids: dict[str, str | int]) -> None:
+        """Persist tracker torrent IDs under their canonical tracker names."""
+        normalized = dict(self.tracker_ids or {})
+        for tracker_name, torrent_id in tracker_ids.items():
+            key = _TRACKER_ID_ALIASES.get(str(tracker_name).upper(), str(tracker_name).upper())
+            value = str(torrent_id)
+            normalized[key] = value
+        self.tracker_ids = normalized
+
+    def clear_tracker_id(self, tracker_name: str) -> None:
+        """Forget a tracker torrent ID."""
+        key = _TRACKER_ID_ALIASES.get(tracker_name.upper(), tracker_name.upper())
+        self.tracker_ids.pop(key, None)
 
     def get(self, key: str, default: Any = None) -> Any:
         """Get attribute value by name, returning default if not set or None."""

--- a/src/meta.py
+++ b/src/meta.py
@@ -531,6 +531,7 @@ class Meta:
                 setattr(self, k, v)
         for k, v in kwargs.items():
             setattr(self, k, v)
+        self.set_tracker_ids(self.tracker_ids)
 
     def copy(self) -> Meta:
         """Ensure copy returns a Meta instance with deep copied attributes."""
@@ -601,24 +602,32 @@ class Meta:
             for k, v in other.items():
                 setattr(self, k, v)
 
+    @staticmethod
+    def canonical_tracker_name(tracker_name: str) -> str:
+        """Return the canonical tracker name for an accepted alias."""
+        normalized_name = tracker_name.upper()
+        return _TRACKER_ID_ALIASES.get(normalized_name, normalized_name)
+
     def get_tracker_id(self, tracker_name: str) -> str | None:
         """Return the known torrent ID for a tracker."""
-        key = _TRACKER_ID_ALIASES.get(tracker_name.upper(), tracker_name.upper())
+        key = self.canonical_tracker_name(tracker_name)
         value = self.tracker_ids.get(key)
         return str(value) if value is not None else None
 
     def set_tracker_ids(self, tracker_ids: dict[str, str | int]) -> None:
         """Persist tracker torrent IDs under their canonical tracker names."""
-        normalized = dict(self.tracker_ids or {})
-        for tracker_name, torrent_id in tracker_ids.items():
-            key = _TRACKER_ID_ALIASES.get(str(tracker_name).upper(), str(tracker_name).upper())
+        normalized: dict[str, str] = {}
+        for tracker_name, torrent_id in (self.tracker_ids or {}).items():
+            normalized[self.canonical_tracker_name(str(tracker_name))] = str(torrent_id)
+        for tracker_name, torrent_id in (tracker_ids or {}).items():
+            key = self.canonical_tracker_name(str(tracker_name))
             value = str(torrent_id)
             normalized[key] = value
         self.tracker_ids = normalized
 
     def clear_tracker_id(self, tracker_name: str) -> None:
         """Forget a tracker torrent ID."""
-        key = _TRACKER_ID_ALIASES.get(tracker_name.upper(), tracker_name.upper())
+        key = self.canonical_tracker_name(tracker_name)
         self.tracker_ids.pop(key, None)
 
     def get(self, key: str, default: Any = None) -> Any:

--- a/src/music/prep.py
+++ b/src/music/prep.py
@@ -369,10 +369,10 @@ def _orpheus_people(group: dict[str, Any], role: str) -> list[str]:
 async def enrich_music_from_orpheus(meta: Meta, config: dict[str, Any]) -> bool:
     """Enrich an analyzed MUSIC release from an explicitly known Orpheus torrent.
 
-    The ID is obtained from a matched client's torrent comment or ``--orpheus``;
+    The ID is obtained from a matched client's torrent comment or ``--tracker-id``;
     this never searches Orpheus by name and never performs a state-changing call.
     """
-    identifier = str(meta.orpheus or "").strip()
+    identifier = meta.get_tracker_id("ORPHEUS") or ""
     if meta.category != "MUSIC" or not identifier.isdigit() or not isinstance(meta.music_release, dict):
         return False
 

--- a/src/prep_helpers.py
+++ b/src/prep_helpers.py
@@ -749,7 +749,7 @@ async def validate_media(_prep_instance: Any, meta: Meta) -> None:
 
 
 async def process_trackers_and_torrent(
-    prep_instance: Any, meta: Meta, client: Clients, hash_ids: list[str], tracker_ids: list[str], _search_term: str, _search_file_folder: str
+    prep_instance: Any, meta: Meta, client: Clients, hash_ids: list[str], _tracker_ids: list[str], _search_term: str, _search_file_folder: str
 ) -> None:
     if "description" not in meta or meta.description is None:
         meta.description = ""
@@ -772,7 +772,7 @@ async def process_trackers_and_torrent(
     # Find one reusable torrent while all local files (including external
     # subtitles) are known. Its path is cached for the upload stage, which
     # prevents a second full client search later in the run.
-    if not any(meta.get(id_type) for id_type in hash_ids + tracker_ids) and not meta.skip_trackers and not meta.edit:
+    if not (any(meta.get(id_type) for id_type in hash_ids) or meta.tracker_ids) and not meta.skip_trackers and not meta.edit:
         reuse_torrent_path = await client.find_existing_torrent(meta)
         if reuse_torrent_path:
             meta.reuse_torrent_path = reuse_torrent_path

--- a/src/torrent_clients/qbittorrent.py
+++ b/src/torrent_clients/qbittorrent.py
@@ -57,6 +57,15 @@ class QbittorrentClientMixin:
     def _extract_tracker_ids_from_comment(self, comment: str) -> dict[str, str]:
         raise NotImplementedError
 
+    @staticmethod
+    def _matches_qbit_content_path(torrent: Any, meta: Meta) -> bool:
+        """Match a qBittorrent content path before falling back to its display name."""
+        expected_path = str(meta.path or "")
+        content_path = str(getattr(torrent, "content_path", "") or "")
+        if expected_path and content_path and os.path.normcase(os.path.normpath(content_path)) == os.path.normcase(os.path.normpath(expected_path)):
+            return True
+        return str(getattr(torrent, "name", "") or "").lower() == str(meta.uuid or "").lower()
+
     async def is_valid_torrent(self, meta: Meta, torrent_path: str, torrenthash: str, torrent_client: str, client: dict[str, Any]) -> tuple[bool, str]:
         raise NotImplementedError
 
@@ -166,7 +175,7 @@ class QbittorrentClientMixin:
                     logger.debug(f"[cyan]Stored comment for torrent: {comment[:100]}...")
 
                     tracker_ids: dict[str, str] = self._extract_tracker_ids_from_comment(comment)
-                    meta.update(tracker_ids)
+                    meta.set_tracker_ids(tracker_ids)
 
                     if meta.torrent_comments and meta.debug:
                         logger.info(f"[green]Stored {len(meta.torrent_comments)} torrent comments for later use")
@@ -508,13 +517,13 @@ class QbittorrentClientMixin:
                 except AttributeError:
                     continue  # Ignore torrents with missing attributes
 
-                if meta.uuid.lower() != torrent_path.lower():
+                if not self._matches_qbit_content_path(torrent, meta):
                     continue
 
                 logger.debug(f"[cyan]Matched Torrent: {torrent.hash}")
                 logger.debug(f"Name: {torrent.name}")
                 logger.debug(f"Save Path: {torrent.save_path}")
-                logger.debug(f"Content Path: {torrent_path}")
+                logger.debug(f"Content Path: {getattr(torrent, 'content_path', torrent_path)}")
 
                 # The early cached-search path must retain the same tracker
                 # discovery side effect as the former get_pathed_torrents flow.
@@ -535,6 +544,33 @@ class QbittorrentClientMixin:
                             tracker_urls.append(str(tracker))
                 if tracker_urls:
                     await match_tracker_url(tracker_urls, meta)
+
+                # The first valid torrent is later reused as BASE.torrent, but
+                # it is not necessarily the torrent whose comment contains
+                # the metadata source. Inspect every matching comment, keeping
+                # any explicitly supplied tracker IDs authoritative.
+                comment = str(getattr(torrent, "comment", "") or "")
+                if not comment:
+                    try:
+                        if proxy_url:
+                            if qbt_session is None:
+                                raise RuntimeError("qBittorrent proxy session is not initialized")
+                            response = await qbt_session.get(f"{proxy_url.rstrip('/')}/api/v2/torrents/properties", params={"hash": torrent.hash})
+                            if response.status_code == 200:
+                                comment = str(response.json().get("comment", "") or "")
+                        elif qbt_client is not None:
+                            properties = await self.retry_qbt_operation(
+                                lambda qbt_client=qbt_client, torrent_hash=torrent.hash: asyncio.to_thread(qbt_client.torrents_properties, torrent_hash=torrent_hash),
+                                f"Get properties for torrent {torrent.name}",
+                            )
+                            comment = str(properties.get("comment", "") or "")
+                    except Exception as error:
+                        logger.debug(f"[yellow]Could not inspect torrent comment for {torrent.hash}: {error}[/yellow]")
+
+                tracker_ids = {key: value for key, value in self._extract_tracker_ids_from_comment(comment).items() if not meta.get_tracker_id(key)}
+                if tracker_ids:
+                    meta.set_tracker_ids(tracker_ids)
+                    logger.debug(f"[bold cyan]Found tracker IDs in matching torrent comment: {', '.join(sorted(tracker_ids))}")
 
                 matching_torrents.append({"hash": torrent.hash, "name": torrent.name})
 
@@ -1216,7 +1252,7 @@ class QbittorrentClientMixin:
                 if match:
                     tracker_id_value = match.group(1)
                     tracker_id_matches.append({"id": tracker_id, "tracker_id": tracker_id_value})
-                    meta[tracker_id] = tracker_id_value
+                    meta.set_tracker_ids({tracker_id: tracker_id_value})
                     tracker_found = True
 
         if torrent.tracker and "hawke.uno" in torrent.tracker and has_working_tracker:
@@ -1233,7 +1269,7 @@ class QbittorrentClientMixin:
                         "tracker_id": huno_id,
                     }
                 )
-                meta.huno = huno_id
+                meta.set_tracker_ids({"HAWKEUNO": huno_id})
                 tracker_found = True
 
         if torrent.tracker and "tracker.anthelion.me" in torrent.tracker:
@@ -1245,7 +1281,7 @@ class QbittorrentClientMixin:
                         "tracker_id": ant_id,
                     }
                 )
-                meta.ant = ant_id
+                meta.set_tracker_ids({"anthelion": ant_id})
                 tracker_found = True
 
         return tracker_id_matches, tracker_found

--- a/src/torrent_clients/qbittorrent.py
+++ b/src/torrent_clients/qbittorrent.py
@@ -11,7 +11,7 @@ import time
 import traceback
 import urllib.parse
 from collections.abc import Awaitable, Callable
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any, TypedDict, cast
 
 import httpx
@@ -1230,9 +1230,9 @@ class QbittorrentClientMixin:
         is_disc = meta.is_disc
         if is_disc in ("", None) and len(meta.filelist) == 1:
             file_path = meta.filelist[0]
-            file_name = Path(file_path).name
-            parent_dir = Path(file_path).parent.name
-            return torrent_name.lower() == file_name.lower() or torrent_name.lower() == meta.uuid.lower() or (parent_dir and torrent_name.lower() == parent_dir.lower())
+            file_name = PureWindowsPath(file_path).name
+            parent_dir = PureWindowsPath(file_path).parent.name
+            return bool(torrent_name.lower() == file_name.lower() or torrent_name.lower() == meta.uuid.lower() or (parent_dir and torrent_name.lower() == parent_dir.lower()))
         return torrent_name.lower() == meta.uuid.lower()
 
     def _extract_tracker_matches(

--- a/src/torrent_clients/qbittorrent.py
+++ b/src/torrent_clients/qbittorrent.py
@@ -57,14 +57,13 @@ class QbittorrentClientMixin:
     def _extract_tracker_ids_from_comment(self, comment: str) -> dict[str, str]:
         raise NotImplementedError
 
-    @staticmethod
-    def _matches_qbit_content_path(torrent: Any, meta: Meta) -> bool:
+    def _matches_qbit_content_path(self, torrent: Any, meta: Meta) -> bool:
         """Match a qBittorrent content path before falling back to its display name."""
         expected_path = str(meta.path or "")
         content_path = str(getattr(torrent, "content_path", "") or "")
         if expected_path and content_path and os.path.normcase(os.path.normpath(content_path)) == os.path.normcase(os.path.normpath(expected_path)):
             return True
-        return str(getattr(torrent, "name", "") or "").lower() == str(meta.uuid or "").lower()
+        return self._torrent_name_matches(str(getattr(torrent, "name", "") or ""), meta)
 
     async def is_valid_torrent(self, meta: Meta, torrent_path: str, torrenthash: str, torrent_client: str, client: dict[str, Any]) -> tuple[bool, str]:
         raise NotImplementedError

--- a/src/torrent_clients/rtorrent.py
+++ b/src/torrent_clients/rtorrent.py
@@ -407,12 +407,11 @@ class RtorrentClientMixin:
 
             # Handle various tracker URL formats in the comment
             tracker_ids = self._extract_tracker_ids_from_comment(comment)
-            meta.update(tracker_ids)
+            meta.set_tracker_ids(tracker_ids)
 
             # If we found a tracker ID, log it
-            for tracker in ["ptp", "bhd", "btn", "blu", "aither", "lst", "oe", "hdb"]:
-                if meta.get(tracker):
-                    logger.info(f"[bold cyan]meta updated with {tracker.upper()} ID: {meta[tracker]}")
+            for tracker_name, torrent_id in tracker_ids.items():
+                logger.info(f"[bold cyan]meta updated with {tracker_name.upper()} ID: {torrent_id}")
 
             if torrent_comments and meta.debug:
                 logger.info(f"[green]Stored {len(torrent_comments)} torrent comments for later use")

--- a/src/trackermeta.py
+++ b/src/trackermeta.py
@@ -289,11 +289,12 @@ async def update_meta_with_unit3d_data(meta: Meta, tracker_data: Sequence[Any], 
         logger.debug(f"set MAL ID: {meta.mal_id}")
     mode = resolve_description_mode(meta.tracker_description_mode)
     if desc:
+        tracker_id = meta.get_tracker_id(tracker_name) or ""
         raw_descriptions = getattr(meta, "tracker_description_raw", {}) or {}
         raw_description = str(raw_descriptions.get(tracker_name, desc))
         candidate = DescriptionCandidate(
             source=tracker_name,
-            release_id=str(meta.get(tracker_name.lower(), "") or ""),
+            release_id=tracker_id,
             release_name=str(filename or ""),
             raw_description=raw_description,
             cleaned_description=str(desc),
@@ -301,7 +302,7 @@ async def update_meta_with_unit3d_data(meta: Meta, tracker_data: Sequence[Any], 
             score=score_release_name(
                 getattr(meta, "tracker_search_term", ""),
                 filename,
-                explicit_id=bool(meta.get(tracker_name.lower())),
+                explicit_id=bool(tracker_id),
             ),
         )
         add_candidate(meta, candidate, selected=mode.imports_text)
@@ -321,7 +322,7 @@ async def update_meta_with_unit3d_data(meta: Meta, tracker_data: Sequence[Any], 
         valid_images = await check_images_concurrently(imagelist_typed, meta)
         if valid_images:
             meta.image_list = valid_images
-            if meta.image_list and (not any(meta.get(t.lower()) for t in api_trackers) or meta.unattended):
+            if meta.image_list and (not meta.tracker_ids or meta.unattended):
                 await handle_image_list(meta, tracker_name, valid_images)
 
     if desc and mode.imports_text:
@@ -344,9 +345,6 @@ async def update_metadata_from_tracker(
     *,
     torrent_id: str = "",
 ) -> tuple[Meta, bool]:
-    # HDBITS stores its torrent ID in ``meta.hdb`` rather than ``meta.hdbits``.
-    # Keep the generic key for every other tracker so all bracket accesses in
-    # the HDBITS branch address the field that was detected upstream.
     tracker_key = "hdb" if tracker_name == "HDBITS" else tracker_name.lower()
     meta.tracker_search_term = search_term
     manual_key = f"{tracker_key}_manual"
@@ -355,7 +353,8 @@ async def update_metadata_from_tracker(
     if tracker_name == "PASSTHEPOPCORN":
         imdb_id: int = 0
         ptp_imagelist: list[ImageDict] = []
-        if meta.ptp is None:
+        ptp_torrent_id = meta.get_tracker_id(tracker_name)
+        if ptp_torrent_id is None:
             ptp_result = await tracker_instance.get_ptp_id_imdb(search_term, search_file_folder, meta)
             imdb_id, ptp_torrent_id, meta.ext_torrenthash = cast(tuple[int, int | None, str | None], ptp_result)
             if ptp_torrent_id:
@@ -366,7 +365,7 @@ async def update_metadata_from_tracker(
                     if await prompt_user_for_confirmation("Do you want to use this ID data from PASSTHEPOPCORN?"):
                         meta.imdb_id = imdb_id
                         found_match = True
-                        meta.ptp = ptp_torrent_id
+                        meta.set_tracker_ids({tracker_name: ptp_torrent_id})
 
                         if not skip_tracker_descriptions or meta.keep_images:
                             ptp_imagelist = cast(
@@ -382,7 +381,7 @@ async def update_metadata_from_tracker(
                     else:
                         found_match = False
                         meta.imdb_id = meta.imdb_id if meta.imdb_id else 0
-                        meta.ptp = None
+                        meta.clear_tracker_id(tracker_name)
                         meta.description = ""
                         meta.image_list = []
 
@@ -403,8 +402,8 @@ async def update_metadata_from_tracker(
                 found_match = False
 
         else:
-            ptp_torrent_id = cast(int, meta.ptp)
-            ptp_imdb_result = await tracker_instance.get_imdb_from_torrent_id(ptp_torrent_id)
+            ptp_torrent_id_int = int(ptp_torrent_id)
+            ptp_imdb_result = await tracker_instance.get_imdb_from_torrent_id(ptp_torrent_id_int)
             imdb_id, meta.ext_torrenthash = cast(tuple[int, str | None], ptp_imdb_result)
             if imdb_id:
                 meta.imdb_id = imdb_id
@@ -414,7 +413,7 @@ async def update_metadata_from_tracker(
                 if not skip_tracker_descriptions or meta.keep_images:
                     ptp_imagelist = cast(
                         list[ImageDict],
-                        await tracker_instance.get_ptp_description(meta.ptp, meta, meta.is_disc),
+                        await tracker_instance.get_ptp_description(ptp_torrent_id_int, meta, meta.is_disc),
                     )
                 if ptp_imagelist:
                     valid_images = await check_images_concurrently(ptp_imagelist, meta)
@@ -422,7 +421,7 @@ async def update_metadata_from_tracker(
                         meta.image_list = valid_images
                         logger.info("[green]PASSTHEPOPCORN images added to metadata.[/green]")
             else:
-                logger.info(f"[yellow]Could not find IMDb ID using PASSTHEPOPCORN ID: {ptp_torrent_id}[/yellow]")
+                logger.info(f"[yellow]Could not find IMDb ID using PASSTHEPOPCORN ID: {ptp_torrent_id_int}[/yellow]")
                 found_match = False
 
     elif tracker_name == "BEYONDHD":
@@ -443,10 +442,11 @@ async def update_metadata_from_tracker(
             return meta, False
         use_foldername = bool(meta.is_disc) or meta.keep_folder is True or meta.isdir is True
 
-        if meta.bhd:
+        bhd_torrent_id = meta.get_tracker_id(tracker_name)
+        if bhd_torrent_id:
             imdb, tmdb = cast(
                 tuple[int | None, int | None],
-                await BtnIdManager.get_bhd_torrents(bhd_api, bhd_rss_key, meta, skip_tracker_descriptions=skip_tracker_descriptions, torrent_id=int(meta.bhd)),
+                await BtnIdManager.get_bhd_torrents(bhd_api, bhd_rss_key, meta, skip_tracker_descriptions=skip_tracker_descriptions, torrent_id=int(bhd_torrent_id)),
             )
         elif use_foldername:
             # Use folder name from path if available, fall back to UUID
@@ -550,7 +550,7 @@ async def update_metadata_from_tracker(
 
                 else:
                     logger.info(f"[yellow]{tracker_name} data discarded.[/yellow]")
-                    meta[tracker_key] = None
+                    meta.clear_tracker_id(tracker_name)
                     meta.imdb_id = meta.imdb_id if meta.imdb_id else 0
                     meta.tmdb_id = meta.tmdb_id if meta.tmdb_id else 0
                     meta.framestor = False
@@ -589,7 +589,7 @@ async def update_metadata_from_tracker(
             found_match = False
 
     elif tracker_name in api_trackers:
-        resolved_torrent_id = torrent_id or meta.get(tracker_key)
+        resolved_torrent_id = torrent_id or meta.get_tracker_id(tracker_name)
         if resolved_torrent_id:
             logger.debug(f"[cyan]{tracker_name} ID found in meta, reusing existing ID: {resolved_torrent_id}[/cyan]")
             tracker_data = cast(
@@ -601,6 +601,7 @@ async def update_metadata_from_tracker(
                     meta,
                     id=resolved_torrent_id,
                     skip_tracker_descriptions=skip_tracker_descriptions,
+                    public_torrent_url=tracker_instance.torrent_url,
                 ),
             )
         else:
@@ -627,12 +628,13 @@ async def update_metadata_from_tracker(
 
     elif tracker_name == "HDBITS":
         bbcode = BBCODE()
-        if meta.hdb is not None:
-            meta[manual_key] = meta[tracker_key]
-            logger.info(f"[cyan]{tracker_name} ID found in meta, reusing existing ID: {meta[tracker_key]}[/cyan]")
+        hdb_torrent_id = meta.get_tracker_id(tracker_name)
+        if hdb_torrent_id is not None:
+            meta[manual_key] = hdb_torrent_id
+            logger.info(f"[cyan]{tracker_name} ID found in meta, reusing existing ID: {hdb_torrent_id}[/cyan]")
 
             # Use get_info_from_torrent_id function if ID is found in meta
-            hdb_info = await tracker_instance.get_info_from_torrent_id(meta[tracker_key])
+            hdb_info = await tracker_instance.get_info_from_torrent_id(hdb_torrent_id)
             imdb, tvdb_id, hdb_name, meta.ext_torrenthash, meta.hdb_description = cast(
                 tuple[int | None, int | None, str | None, str | None, str | None],
                 hdb_info,
@@ -664,7 +666,7 @@ async def update_metadata_from_tracker(
 
                 logger.info(f"[green]{tracker_name} data found: IMDb ID: {imdb}, TVDb ID: {meta.tvdb_id}, HDBITS Name: {meta.hdb_name}[/green]")
             else:
-                logger.info(f"[yellow]{tracker_name} data not found for ID: {meta[tracker_key]}[/yellow]")
+                logger.info(f"[yellow]{tracker_name} data not found for ID: {hdb_torrent_id}[/yellow]")
                 found_match = False
         else:
             logger.debug("[yellow]No ID found in meta for HDBITS, searching by file name[/yellow]")
@@ -677,7 +679,7 @@ async def update_metadata_from_tracker(
             )
             meta.hdb_name = hdb_name
             if tracker_id:
-                meta[tracker_key] = tracker_id
+                meta.set_tracker_ids({tracker_name: tracker_id})
 
             if imdb or tvdb_id or meta.hdb_description:
                 if not meta.unattended:
@@ -723,7 +725,7 @@ async def update_metadata_from_tracker(
                                 await handle_image_list(meta, tracker_name, valid_images)
                     else:
                         logger.info(f"[yellow]{tracker_name} data discarded.[/yellow]")
-                        meta[tracker_key] = None
+                        meta.clear_tracker_id(tracker_name)
                         meta.tvdb_id = meta.tvdb_id if meta.tvdb_id else 0
                         meta.imdb_id = meta.imdb_id if meta.imdb_id else 0
                         meta.hdb_name = None
@@ -751,7 +753,7 @@ async def update_metadata_from_tracker(
             else:
                 meta.hdb_name = None
                 meta.hdb_description = ""
-                meta[tracker_key] = None
+                meta.clear_tracker_id(tracker_name)
                 found_match = False
 
     return meta, found_match

--- a/src/trackers/common.py
+++ b/src/trackers/common.py
@@ -2622,6 +2622,7 @@ class Common:
         id: str | int | None = None,
         file_name: str | list[str] | None = None,
         skip_tracker_descriptions: bool = False,
+        public_torrent_url: str | None = None,
     ) -> tuple[
         int | None,
         int | None,
@@ -2660,7 +2661,10 @@ class Common:
         # Make the GET request with proper encoding handled by 'params'
         try:
             async with httpx.AsyncClient(timeout=5.0) as client:
-                logger.info(f"Searching for information on [bold cyan]{tracker}[/bold cyan]")
+                if id and public_torrent_url:
+                    logger.info(f"Searching for information on [bold cyan]{tracker.title()}[/bold cyan] ({public_torrent_url.rstrip('/')}/{id})")
+                else:
+                    logger.info(f"Searching for information on [bold cyan]{tracker}[/bold cyan]")
                 response = await client.get(url=url, params=params, headers=headers)
                 json_response = response.json()
         except (httpx.RequestError, httpx.TimeoutException) as e:
@@ -2754,9 +2758,11 @@ class Common:
                     logger.info(f"[green]Successfully grabbed description from {tracker}")
                     logger.info(f"Extracted description: \n\n{description}\n\n", extra={"markup": False, "highlighter": None})
 
-                    from src.trackersetup import api_trackers
-
-                    if meta.unattended or any(meta.get(t.lower()) for t in api_trackers):
+                    # A tracker ID only identifies the source of this metadata.  It
+                    # must not suppress the interactive review of the description.
+                    # Candidate collection sets ``unattended`` explicitly and is
+                    # therefore still non-interactive.
+                    if meta.unattended:
                         return tmdb, imdb, tvdb, mal, description, category, infohash, imagelist, file_name
                     logger.info("[cyan]Do you want to edit, discard or keep the description?[/cyan]")
                     edit_choice = cli_ui.ask_string("Enter 'e' to edit, 'd' to discard, or press Enter to keep it as is:")

--- a/tests/test_clients_tracker_comments.py
+++ b/tests/test_clients_tracker_comments.py
@@ -46,6 +46,14 @@ def test_matches_single_file_inside_folder_torrent_content_path():
     assert client._matches_qbit_content_path(torrent, Meta({"path": media, "uuid": "Heat.mkv"}))  # noqa: S101
 
 
+def test_matches_torrent_name_when_content_path_is_unavailable():
+    client = Clients({"TRACKERS": {}})
+    media = r"F:\Filmes\Heat\Heat.mkv"
+    torrent = SimpleNamespace(name="Heat.mkv", content_path="")
+
+    assert client._matches_qbit_content_path(torrent, Meta({"path": media, "filelist": [media], "uuid": "different"}))  # noqa: S101
+
+
 def test_orpheus_uses_its_fixed_base_url():
     tracker = Orpheus({"TRACKERS": {"ORPHEUS": {"base_url": "https://not-orheus.example"}}})
 

--- a/tests/test_clients_tracker_comments.py
+++ b/tests/test_clients_tracker_comments.py
@@ -1,4 +1,7 @@
+from types import SimpleNamespace
+
 from src.clients import Clients
+from src.meta import Meta
 from src.trackers.orpheus import Orpheus
 
 
@@ -25,6 +28,22 @@ def test_uses_orpheus_default_host_without_config_override():
     tracker_ids = client._extract_tracker_ids_from_comment("https://orpheus.network/torrents.php?torrentid=42")
 
     assert tracker_ids == {"orpheus": "42"}  # noqa: S101
+
+
+def test_uses_aither_torrent_comment_id():
+    client = Clients({"TRACKERS": {}})
+
+    tracker_ids = client._extract_tracker_ids_from_comment("This torrent was downloaded from Aither.cc. https://aither.cc/torrents/50049")
+
+    assert tracker_ids == {"aither": "50049"}  # noqa: S101
+
+
+def test_matches_single_file_inside_folder_torrent_content_path():
+    client = Clients({"TRACKERS": {}})
+    media = r"F:\Filmes\Heat\Heat.mkv"
+    torrent = SimpleNamespace(name="Heat", content_path=media)
+
+    assert client._matches_qbit_content_path(torrent, Meta({"path": media, "uuid": "Heat.mkv"}))  # noqa: S101
 
 
 def test_orpheus_uses_its_fixed_base_url():

--- a/tests/test_hdbits_search.py
+++ b/tests/test_hdbits_search.py
@@ -46,19 +46,19 @@ def test_hdbits_explicit_id_uses_hdb_meta_key() -> None:
             assert torrent_id == "12345"
             return 1602620, None, "Amour.2012.1080p.BluRay.x264", None, ""
 
-    meta = Meta({"hdb": "12345", "unattended": True})
+    meta = Meta({"tracker_ids": {"HDBITS": "12345"}, "unattended": True})
 
     updated_meta, matched = asyncio.run(update_metadata_from_tracker("HDBITS", _Tracker(), meta, "Amour", "Amour"))
 
     assert matched
     assert updated_meta.imdb_id == 1602620
-    assert updated_meta.hdb == "12345"
+    assert updated_meta.get_tracker_id("HDBITS") == "12345"
 
 
 def test_hdbits_use_for_search_false_skips_explicit_id(tmp_path) -> None:
     async def run() -> None:
         manager = TrackerDataManager({"TRACKERS": {"HDBITS": {"use_for_search": False}}})
-        meta = Meta({"base_dir": str(tmp_path), "hdb": "12345", "unattended": True})
+        meta = Meta({"base_dir": str(tmp_path), "tracker_ids": {"HDBITS": "12345"}, "unattended": True})
 
         await manager.get_tracker_data(None, meta, "Amour", "Amour")
 

--- a/tests/test_music_architecture.py
+++ b/tests/test_music_architecture.py
@@ -773,7 +773,7 @@ def test_orpheus_enrichment_extracts_discogs_master_from_group_wiki(tmp_path):
     release = MusicRelease(root=str(tmp_path))
     release.set_field("artist", "Kanye West", MetadataSource.FILE_TAG, 1.0)
     release.set_field("album", "808s & Heartbreak", MetadataSource.FILE_TAG, 1.0)
-    meta = Meta(category="MUSIC", orpheus="953914", base_dir=str(tmp_path), uuid="orpheus-master", music_release=release.to_dict())
+    meta = Meta(category="MUSIC", tracker_ids={"ORPHEUS": "953914"}, base_dir=str(tmp_path), uuid="orpheus-master", music_release=release.to_dict())
     response = {
         "group": {"id": 610888, "name": "808s & Heartbreak", "year": 2008, "wikiBBcode": "https://www.discogs.com/master/8489"},
         "torrent": {"media": "CD", "encoding": "Lossless", "remasterYear": 2008, "remasterRecordLabel": "Roc-A-Fella Records", "remasterCatalogueNumber": "B001219802"},

--- a/tests/test_tracker_descriptions.py
+++ b/tests/test_tracker_descriptions.py
@@ -5,11 +5,13 @@ import asyncio
 import pytest
 
 import src.get_tracker_data as tracker_data_module
+import src.trackers.common as common_module
 from src.description_review import draft, load_review, save_review
 from src.get_tracker_data import TrackerDataManager
 from src.meta import Meta
 from src.tracker_descriptions import DescriptionCandidate, TrackerDescriptionMode, add_candidate, description_fingerprint, resolve_description_mode, score_release_name
 from src.trackermeta import update_meta_with_unit3d_data
+from src.trackers.common import Common
 
 
 def test_legacy_options_resolve_to_explicit_description_modes():
@@ -57,11 +59,20 @@ def test_unit3d_import_records_source_and_honors_images_only_mode(tmp_path, monk
     monkeypatch.setattr("src.trackermeta.check_images_concurrently", no_images)
 
     async def run():
-        meta = Meta({"base_dir": str(tmp_path), "uuid": "release", "tracker_description_mode": "images", "tracker_description_raw": {"AITHER": "raw"}})
+        meta = Meta(
+            {
+                "base_dir": str(tmp_path),
+                "uuid": "release",
+                "tracker_ids": {"AITHER": "50049"},
+                "tracker_description_mode": "images",
+                "tracker_description_raw": {"AITHER": "raw"},
+            }
+        )
         result = (1, 2, 3, 0, "clean", "MOVIE", None, [{"raw_url": "https://image"}], "Release.mkv")
         assert await update_meta_with_unit3d_data(meta, result, "AITHER")
         assert meta.description == ""
         assert meta.description_candidates[0]["selected"] is False
+        assert meta.description_candidates[0]["release_id"] == "50049"
 
     asyncio.run(run())
 
@@ -95,6 +106,54 @@ def test_selected_tracker_description_can_be_discarded(monkeypatch):
 
         assert candidate.description == ""
         assert candidate.description_provenance["discarded"] is True
+
+    asyncio.run(run())
+
+
+def test_unit3d_source_id_does_not_skip_interactive_description_review(monkeypatch):
+    class FakeResponse:
+        @staticmethod
+        def json():
+            return {
+                "attributes": {
+                    "description": "tracker text",
+                    "tmdb_id": 949,
+                    "imdb_id": 113277,
+                    "tvdb_id": 0,
+                    "mal_id": 0,
+                    "category": "MOVIE",
+                }
+            }
+
+    class FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        @staticmethod
+        async def get(**_kwargs):
+            return FakeResponse()
+
+    async def run():
+        messages = []
+        monkeypatch.setattr(common_module.httpx, "AsyncClient", lambda **_kwargs: FakeClient())
+        monkeypatch.setattr(common_module.cli_ui, "ask_string", lambda *_args, **_kwargs: "d")
+        monkeypatch.setattr(common_module.logger, "info", lambda message, **_kwargs: messages.append(str(message)))
+        meta = Meta({"tracker_ids": {"AITHER": "123"}, "unattended": False})
+
+        result = await Common({"TRACKERS": {"AITHER": {"api_key": "test"}}}).unit3d_torrent_info(
+            "AITHER",
+            "https://aither.example/api/torrents/",
+            "https://aither.example/api/torrents",
+            meta,
+            id="123",
+            public_torrent_url="https://aither.example/torrents/",
+        )
+
+        assert result[4] is None
+        assert "Searching for information on [bold cyan]Aither[/bold cyan] (https://aither.example/torrents/123)" in messages
 
     asyncio.run(run())
 
@@ -168,8 +227,7 @@ def test_explicit_tracker_ids_are_collected_concurrently_and_best_candidate_is_a
             {
                 "base_dir": str(tmp_path),
                 "uuid": "release",
-                "aither": "11",
-                "blu": "22",
+                "tracker_ids": {"AITHER": "11", "BLUTOPIA": "22"},
                 "unattended": True,
                 "tracker_description_mode": "text",
             }

--- a/tests/test_tracker_descriptions.py
+++ b/tests/test_tracker_descriptions.py
@@ -197,7 +197,7 @@ def test_saved_webui_draft_replaces_the_tracker_description(tmp_path):
 def test_explicit_tracker_ids_are_collected_concurrently_and_best_candidate_is_applied(tmp_path, monkeypatch):
     async def run():
         config = {
-            "DEFAULT": {"tracker_description_mode": "text"},
+            "DEFAULT": {"tracker_comment_only": True, "tracker_description_mode": "text"},
             "TRACKERS": {
                 "AITHER": {"use_for_search": True},
                 "BLUTOPIA": {"use_for_search": True},
@@ -238,5 +238,23 @@ def test_explicit_tracker_ids_are_collected_concurrently_and_best_candidate_is_a
         assert meta.matched_tracker == "BLUTOPIA"
         assert meta.imdb_id == 2
         assert meta.description == "BLUTOPIA"
+
+    asyncio.run(run())
+
+
+def test_tracker_comment_only_defaults_to_skipping_filename_searches(tmp_path, monkeypatch):
+    async def run():
+        manager = TrackerDataManager({"DEFAULT": {}, "TRACKERS": {"AITHER": {"use_for_search": True}}})
+        meta = Meta({"base_dir": str(tmp_path), "uuid": "release"})
+
+        async def unexpected_search(*_args, **_kwargs):
+            raise AssertionError("filename-based tracker search must not run")
+
+        monkeypatch.setattr(manager, "update_metadata_from_explicit_tracker", unexpected_search)
+
+        result = await manager.get_tracker_data(None, meta, "Release", "Release")
+
+        assert result is meta
+        assert meta.no_tracker_match is False
 
     asyncio.run(run())

--- a/tests/test_tracker_id_args.py
+++ b/tests/test_tracker_id_args.py
@@ -24,6 +24,12 @@ def test_tracker_id_accepts_beyondhd_dotted_torrent_url():
     assert args.parse_tracker_id("https://beyond-hd.me/download/release.12345") == ("BEYONDHD", "12345")
 
 
+def test_tracker_id_accepts_beyondhd_alias():
+    args = Args({"TRACKERS": {}})
+
+    assert args.parse_tracker_id("BHD=123") == ("BEYONDHD", "123")
+
+
 def test_tracker_id_rejects_mismatched_tracker_url():
     args = Args({"TRACKERS": {}})
 
@@ -59,3 +65,9 @@ def test_tracker_id_aliases_are_stored_under_canonical_tracker_names(alias, trac
     assert meta.tracker_ids == {tracker_name: "123"}
     assert meta.get_tracker_id(alias) == "123"
     assert meta.get_tracker_id(tracker_name) == "123"
+
+
+def test_restored_tracker_ids_are_canonicalized():
+    meta = Meta({"tracker_ids": {"bhd": "123"}})
+
+    assert meta.tracker_ids == {"BEYONDHD": "123"}

--- a/tests/test_tracker_id_args.py
+++ b/tests/test_tracker_id_args.py
@@ -1,0 +1,61 @@
+# ruff: noqa: S101
+
+import pytest
+
+from src.args import Args
+from src.meta import Meta
+
+
+def test_tracker_id_accepts_explicit_tracker_and_id():
+    args = Args({"TRACKERS": {}})
+
+    assert args.parse_tracker_id("AITHER=50049") == ("AITHER", "50049")
+
+
+def test_tracker_id_accepts_aither_torrent_url():
+    args = Args({"TRACKERS": {}})
+
+    assert args.parse_tracker_id("https://aither.cc/torrents/415499") == ("AITHER", "415499")
+
+
+def test_tracker_id_accepts_beyondhd_dotted_torrent_url():
+    args = Args({"TRACKERS": {}})
+
+    assert args.parse_tracker_id("https://beyond-hd.me/download/release.12345") == ("BEYONDHD", "12345")
+
+
+def test_tracker_id_rejects_mismatched_tracker_url():
+    args = Args({"TRACKERS": {}})
+
+    with pytest.raises(ValueError, match="does not match"):
+        args.parse_tracker_id("BLUTOPIA=https://aither.cc/torrents/415499")
+
+
+def test_tracker_ids_persist_and_expose_tracker_field():
+    meta = Meta()
+
+    meta.set_tracker_ids({"AITHER": "50049"})
+
+    assert meta.tracker_ids == {"AITHER": "50049"}
+    assert meta.get_tracker_id("AITHER") == "50049"
+
+
+@pytest.mark.parametrize(
+    ("alias", "tracker_name"),
+    [
+        ("ptp", "PASSTHEPOPCORN"),
+        ("hdb", "HDBITS"),
+        ("bhd", "BEYONDHD"),
+        ("blu", "BLUTOPIA"),
+        ("oe", "ONLYENCODES"),
+        ("huno", "HAWKEUNO"),
+    ],
+)
+def test_tracker_id_aliases_are_stored_under_canonical_tracker_names(alias, tracker_name):
+    meta = Meta()
+
+    meta.set_tracker_ids({alias: "123"})
+
+    assert meta.tracker_ids == {tracker_name: "123"}
+    assert meta.get_tracker_id(alias) == "123"
+    assert meta.get_tracker_id(tracker_name) == "123"

--- a/tests/test_tracker_metadata_cache.py
+++ b/tests/test_tracker_metadata_cache.py
@@ -41,13 +41,13 @@ def test_explicit_tracker_id_reuses_cached_metadata(tmp_path):
         first_manager = TrackerDataManager(config)
         first_fake = _FakeTrackerMetadataManager()
         first_manager.tracker_meta_manager = first_fake
-        first_meta = Meta({"base_dir": str(tmp_path), "ptp": "12345"})
+        first_meta = Meta({"base_dir": str(tmp_path), "tracker_ids": {"PASSTHEPOPCORN": "12345"}})
         _, first_match = await first_manager.update_metadata_from_explicit_tracker("PASSTHEPOPCORN", object(), first_meta, "Amour", "Amour", False)
 
         second_manager = TrackerDataManager(config)
         second_fake = _FakeTrackerMetadataManager()
         second_manager.tracker_meta_manager = second_fake
-        second_meta = Meta({"base_dir": str(tmp_path), "ptp": "12345"})
+        second_meta = Meta({"base_dir": str(tmp_path), "tracker_ids": {"PASSTHEPOPCORN": "12345"}})
         _, second_match = await second_manager.update_metadata_from_explicit_tracker("PASSTHEPOPCORN", object(), second_meta, "Amour", "Amour", False)
 
         assert first_match and second_match

--- a/upload.py
+++ b/upload.py
@@ -412,7 +412,6 @@ async def merge_meta(meta: Meta, saved_meta: dict[str, Any]) -> dict[str, Any]:
         "tmdb_manual",
         "torrent_creation",
         "trackers",
-        "tracker_ids",
         "tvmaze_manual",
         "type",
         "unattended",
@@ -422,7 +421,10 @@ async def merge_meta(meta: Meta, saved_meta: dict[str, Any]) -> dict[str, Any]:
     sanitized_saved_meta: dict[str, Any] = {}
     for key, value in saved_meta.items():
         clean_key = key.strip().strip("'").strip('"')
-        if clean_key in overwrite_list:
+        if clean_key == "tracker_ids":
+            current_tracker_ids = meta.tracker_ids
+            sanitized_saved_meta[clean_key] = current_tracker_ids if current_tracker_ids else value
+        elif clean_key in overwrite_list:
             if clean_key in meta and getattr(meta, clean_key, None) is not None:
                 sanitized_saved_meta[clean_key] = meta[clean_key]
                 logger.debug(f"Overriding {clean_key} with meta value: {meta[clean_key]}")

--- a/upload.py
+++ b/upload.py
@@ -350,7 +350,6 @@ async def merge_meta(meta: Meta, saved_meta: dict[str, Any]) -> dict[str, Any]:
         "audiobook_duration_formatted",
         "audiobook_duration",
         "author",
-        "blu",
         "book_asin",
         "book_author",
         "book_isbn",
@@ -374,7 +373,6 @@ async def merge_meta(meta: Meta, saved_meta: dict[str, Any]) -> dict[str, Any]:
         "game_system",
         "game_version",
         "hardcoded_subs",
-        "hdb",
         "igdb_manual",
         "imdb",
         "imghost",
@@ -404,7 +402,6 @@ async def merge_meta(meta: Meta, saved_meta: dict[str, Any]) -> dict[str, Any]:
         "openlibrary",
         "personalrelease",
         "platform",
-        "ptp",
         "qbit_cat",
         "qbit_tag",
         "region",
@@ -415,6 +412,7 @@ async def merge_meta(meta: Meta, saved_meta: dict[str, Any]) -> dict[str, Any]:
         "tmdb_manual",
         "torrent_creation",
         "trackers",
+        "tracker_ids",
         "tvmaze_manual",
         "type",
         "unattended",
@@ -2532,15 +2530,12 @@ async def do_the_thing(base_dir: str) -> None:
 
                 keep_meta = config["DEFAULT"].get("keep_meta", False)
 
-                if not keep_meta or meta.delete_meta:
-                    if Path(meta_file).exists():
-                        try:
-                            meta_file.unlink()
-                            logger.debug(f"[bold yellow]Found and deleted existing metadata file: {meta_file}")
-                        except Exception as e:
-                            logger.info(f"[bold red]Failed to delete metadata file {meta_file}: {e!s}")
-                    else:
-                        logger.debug(f"[yellow]No metadata file found at {meta_file}")
+                if (not keep_meta or meta.delete_meta) and Path(meta_file).exists():
+                    try:
+                        meta_file.unlink()
+                        logger.debug(f"[bold yellow]Found and deleted existing metadata file: {meta_file}")
+                    except Exception as e:
+                        logger.info(f"[bold red]Failed to delete metadata file {meta_file}: {e!s}")
 
                 if keep_meta and Path(meta_file).exists():
                     async with aiofiles.open(meta_file, encoding="utf-8") as f:

--- a/upload.py
+++ b/upload.py
@@ -432,7 +432,11 @@ async def merge_meta(meta: Meta, saved_meta: dict[str, Any]) -> dict[str, Any]:
                 sanitized_saved_meta[clean_key] = value
         else:
             sanitized_saved_meta[clean_key] = value
+    tracker_ids = sanitized_saved_meta.pop("tracker_ids", None)
     meta.update(sanitized_saved_meta)
+    if isinstance(tracker_ids, dict):
+        meta.set_tracker_ids(tracker_ids)
+        sanitized_saved_meta["tracker_ids"] = dict(meta.tracker_ids)
     sanitize_book_language(meta)
     sanitize_book_author(meta)
     return sanitized_saved_meta


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added repeatable `--tracker-id TRACKER=ID_OR_URL` support for torrent IDs and supported tracker URLs.
  * Added configurable comment-only tracker searches, enabled by default.
  * Improved torrent matching using normalized content paths, with name and identifier fallbacks.

* **Bug Fixes**
  * Improved extraction and reuse of tracker IDs from torrent comments.
  * Fixed matching for single-file torrents located within folders.
  * Interactive description review now behaves correctly when tracker information is available.

* **Documentation**
  * Documented tracker ID input and comment-only search configuration.

* **Tests**
  * Added coverage for parsing, persistence, comment extraction, matching, and search behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->