### PR TITLE
feat(capybarabr): add BiOMA image host support and automatic rehosting

### DIFF
--- a/data/example_config.py
+++ b/data/example_config.py
@@ -858,6 +858,8 @@ config: dict[str, Any] = {
             "use_for_search": False,
             "api_key": "",
             "anon": True,
+            # BiOMA Zipline API key/token for rehosting screenshots when uploading releases with tag 'BiOMA' (Host: https://img.thebioma.space/)
+            "bioma_api_key": "",
             # Send uploads to CAPYBARABR modq for staff approval
             "modq": False,
             # Set this to True if you want to allow external subtitles to be included in the upload

--- a/src/artwork.py
+++ b/src/artwork.py
@@ -33,7 +33,7 @@ def is_public_http_url(value: str | None) -> bool:
     try:
         addresses = {result[4][0] for result in socket.getaddrinfo(parsed.hostname, None, type=socket.SOCK_STREAM)}
         return bool(addresses) and all(ipaddress.ip_address(address).is_global for address in addresses)
-    except OSError, ValueError:
+    except (OSError, ValueError):
         return False
 
 
@@ -50,7 +50,7 @@ def is_valid_image_bytes(image_bytes: bytes) -> bool:
                     return False
                 image.verify()
         return True
-    except OSError, SyntaxError, ValueError, Image.DecompressionBombError, Image.DecompressionBombWarning:
+    except (OSError, SyntaxError, ValueError, Image.DecompressionBombError, Image.DecompressionBombWarning):
         return False
 
 
@@ -157,7 +157,7 @@ def _write_png(source: Path | bytes, destination: Path) -> bool:
             image.save(temporary, "PNG")
         temporary.replace(destination)
         return True
-    except OSError, SyntaxError, ValueError:
+    except (OSError, SyntaxError, ValueError):
         temporary.unlink(missing_ok=True)
         return False
 

--- a/src/rehostimages.py
+++ b/src/rehostimages.py
@@ -13,6 +13,7 @@ import aiofiles
 import httpx
 from aiofiles import os as aio_os
 
+from src.artwork import is_public_http_url, is_valid_image_bytes
 from src.console import logger
 from src.meta import Meta
 from src.screenshot_manifest import files as manifest_files
@@ -251,6 +252,11 @@ async def _local_image_path(meta: Meta, collection_name: str, image: Mapping[str
 
 
 async def _download_image_for_rehost(meta: Meta, collection_name: str, raw_url: str) -> Path | None:
+    # Validate the URL up front to prevent SSRF attacks
+    if not is_public_http_url(raw_url):
+        logger.warning(f"[yellow]Cannot download {collection_name} image: {raw_url} is not a public HTTP(S) URL[/yellow]")
+        return None
+
     directory = Path(meta.base_dir) / "tmp" / meta.uuid / "rehosted_images" / collection_name
     directory.mkdir(parents=True, exist_ok=True)
     parsed = urlparse(raw_url)
@@ -259,10 +265,38 @@ async def _download_image_for_rehost(meta: Meta, collection_name: str, raw_url: 
         suffix = ".png"
     filename = await sanitize_filename(Path(parsed.path).stem or "image")
     destination = directory / f"{filename}{suffix}"
+
     try:
-        async with httpx.AsyncClient(follow_redirects=True, timeout=60.0) as client:
-            response = await client.get(raw_url)
-            response.raise_for_status()
+        # Manually follow redirects to validate each hop against SSRF
+        current_url = raw_url
+        async with httpx.AsyncClient(follow_redirects=False, trust_env=False, timeout=60.0) as client:
+            for _ in range(4):
+                if not is_public_http_url(current_url):
+                    logger.warning(f"[yellow]Cannot download {collection_name} image: redirect target {current_url} is not a public HTTP(S) URL[/yellow]")
+                    return None
+
+                response = await client.get(current_url)
+                if response.is_redirect:
+                    location = response.headers.get("Location")
+                    if not location:
+                        logger.warning(f"[yellow]Could not download {collection_name} image for {raw_url}: redirect missing Location header[/yellow]")
+                        return None
+                    # Resolve relative redirects against the current URL
+                    current_url = str(response.url.join(location))
+                    continue
+
+                response.raise_for_status()
+                break
+            else:
+                # Too many redirects
+                logger.warning(f"[yellow]Could not download {collection_name} image for {raw_url}: too many redirects[/yellow]")
+                return None
+
+        # Validate the downloaded content is actually a valid image
+        if not is_valid_image_bytes(response.content):
+            logger.warning(f"[yellow]Could not download {collection_name} image for {raw_url}: not a valid image[/yellow]")
+            return None
+
         await asyncio.to_thread(destination.write_bytes, response.content)
         return destination
     except (httpx.HTTPError, OSError) as error:

--- a/src/rehostimages.py
+++ b/src/rehostimages.py
@@ -222,6 +222,8 @@ def _image_host(raw_url: str, url_host_mapping: Mapping[str, str]) -> str:
 
 
 def _collection_directory(meta: Meta, collection_name: str) -> Path | None:
+    if collection_name == "screenshots":
+        return screenshots_dir(meta.base_dir, meta.uuid)
     if collection_name == "menu_images":
         return menu_screenshots_dir(meta.base_dir, meta.uuid)
     if collection_name == "spectrograms_images":

--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -581,7 +581,19 @@ async def disc_screenshots(
                     else:
                         logger.info(f"[red]Image {image_path} with size {image_size} bytes: does not meet size requirements for {img_host}, retaking.")
                         retake = True
-                elif img_host and img_host in ["lensdump", "ptscreens", "onlyimage", "dalexni", "zipline", "midnightscene", "passtheimage", "seedpool_cdn", "sharex", "utppm"]:
+                elif img_host and img_host in [
+                    "lensdump",
+                    "ptscreens",
+                    "onlyimage",
+                    "dalexni",
+                    "zipline",
+                    "midnightscene",
+                    "bioma",
+                    "passtheimage",
+                    "seedpool_cdn",
+                    "sharex",
+                    "utppm",
+                ]:
                     logger.debug(f"[green]Image {image_path} meets size requirements for {img_host}.[/green]")
                 else:
                     logger.info(f"[red]Unknown image host or image doesn't meet requirements for host: {img_host}, retaking.")
@@ -615,7 +627,8 @@ async def disc_screenshots(
                                 valid_image = True
                         elif (
                             img_host
-                            and img_host in ["lensdump", "ptscreens", "onlyimage", "dalexni", "zipline", "midnightscene", "passtheimage", "seedpool_cdn", "sharex", "utppm"]
+                            and img_host
+                            in ["lensdump", "ptscreens", "onlyimage", "dalexni", "zipline", "midnightscene", "bioma", "passtheimage", "seedpool_cdn", "sharex", "utppm"]
                             and new_size > 75000
                         ):
                             logger.info(f"[green]Successfully retaken screenshot for: {image_path} ({new_size} bytes)[/green]")
@@ -1977,7 +1990,19 @@ async def screenshots(
                     else:
                         logger.info(f"[red]Image {image_path} with size {image_size} bytes: does not meet size requirements for {img_host}, retaking.")
                         retake = True
-                elif img_host and img_host in ["lensdump", "ptscreens", "onlyimage", "dalexni", "zipline", "midnightscene", "passtheimage", "seedpool_cdn", "sharex", "utppm"]:
+                elif img_host and img_host in [
+                    "lensdump",
+                    "ptscreens",
+                    "onlyimage",
+                    "dalexni",
+                    "zipline",
+                    "midnightscene",
+                    "bioma",
+                    "passtheimage",
+                    "seedpool_cdn",
+                    "sharex",
+                    "utppm",
+                ]:
                     logger.debug(f"[green]Image {image_path} meets size requirements for {img_host}.[/green]")
                 else:
                     logger.info(f"[red]Unknown image host or image doesn't meet requirements for host: {img_host}, retaking.")
@@ -2030,7 +2055,8 @@ async def screenshots(
                                     valid_image = True
                             elif (
                                 img_host
-                                and img_host in ["lensdump", "ptscreens", "onlyimage", "dalexni", "zipline", "midnightscene", "passtheimage", "seedpool_cdn", "sharex", "utppm"]
+                                and img_host
+                                in ["lensdump", "ptscreens", "onlyimage", "dalexni", "zipline", "midnightscene", "bioma", "passtheimage", "seedpool_cdn", "sharex", "utppm"]
                                 and new_size > 75000
                             ):
                                 logger.info(f"[green]Successfully retaken screenshot for: {screenshot_path} ({new_size} bytes)[/green]")
@@ -2075,7 +2101,8 @@ async def screenshots(
                             valid_image = True
                     elif (
                         img_host
-                        and img_host in ["lensdump", "ptscreens", "onlyimage", "dalexni", "zipline", "midnightscene", "passtheimage", "seedpool_cdn", "sharex", "utppm"]
+                        and img_host
+                        in ["lensdump", "ptscreens", "onlyimage", "dalexni", "zipline", "midnightscene", "bioma", "passtheimage", "seedpool_cdn", "sharex", "utppm"]
                         and new_size > 75000
                     ):
                         valid_image = True

--- a/src/trackers/UNIT3D/capybarabr.py
+++ b/src/trackers/UNIT3D/capybarabr.py
@@ -1,12 +1,18 @@
-# Upload Assistant © 2025 Audionut & wastaken7 — Licensed under UAPL v1.0
 import re
 from typing import Any
 
 from src.console import logger
 from src.get_desc import DescriptionBuilder
 from src.meta import Meta
+from src.rehostimages import _download_image_for_rehost, _local_image_path
+from src.screenshot_manifest import files as manifest_files
+from src.tracker_images import (
+    ImageCollection,
+    set_tracker_image_collection,
+)
 from src.trackers.common import Common
 from src.trackers.UNIT3D import UNIT3D
+from src.uploadscreens import upload_image_task
 
 
 class CapybaraBR(UNIT3D):
@@ -296,3 +302,82 @@ class CapybaraBR(UNIT3D):
             return await self.common.check_portuguese_video_requirements(meta, self.tracker)
 
         return True
+
+    async def check_image_hosts(self, meta: Meta) -> None:
+        if meta.category == "MUSIC" or meta.skip_imghost_upload:
+            return
+
+        tag = (meta.tag or "").lstrip("-").strip()
+        if tag.lower() != "bioma":
+            return
+
+        api_key = self.tracker_config.get("bioma_api_key")
+        if not api_key:
+            logger.warning(f"[yellow]{self.tracker}: BiOMA image host API key not configured, falling back to default image host.[/yellow]")
+            return
+
+        await self.rehost_bioma_images(meta)
+
+    async def _rehost_collection(self, meta: Meta, collection_name: ImageCollection, items: list[dict[str, Any]]) -> list[dict[str, Any]] | None:
+        if not items:
+            return None
+
+        manifest = manifest_files(meta.base_dir, meta.uuid, "main") if collection_name == "screenshots" and meta.base_dir and meta.uuid else []
+        rehosted_items: list[dict[str, Any]] = []
+
+        for index, item in enumerate(items):
+            if not isinstance(item, dict):
+                continue
+            raw_url = item.get("raw_url", "")
+
+            local_path = await _local_image_path(meta, collection_name, item)
+            if local_path is None and index < len(manifest) and manifest[index].is_file():
+                local_path = manifest[index]
+            if local_path is None and raw_url:
+                local_path = await _download_image_for_rehost(meta, collection_name, raw_url)
+
+            if local_path is None:
+                logger.warning(
+                    f"[yellow]{self.tracker}: cannot locate or download {collection_name} image {index + 1} for BiOMA rehosting; keeping default image host.[/yellow]"
+                )
+                return None
+
+            upload_result = await upload_image_task((str(local_path), "bioma", self.config, meta))
+            if upload_result.get("status") != "success":
+                reason = upload_result.get("reason", "unknown error")
+                logger.warning(f"[yellow]{self.tracker}: failed to rehost {collection_name} image {index + 1} to BiOMA: {reason}. Keeping default image host.[/yellow]")
+                return None
+
+            rehosted_item = dict(item)
+            rehosted_item.update(
+                {
+                    "img_url": upload_result["img_url"],
+                    "raw_url": upload_result["raw_url"],
+                    "web_url": upload_result["web_url"],
+                    "local_file_path": str(local_path),
+                }
+            )
+            rehosted_items.append(rehosted_item)
+
+        return rehosted_items if len(rehosted_items) == len(items) else None
+
+    async def rehost_bioma_images(self, meta: Meta) -> None:
+        """Rehost screenshots and secondary image collections to BiOMA zipline host (https://img.thebioma.space/)."""
+        image_list = meta.image_list
+        if isinstance(image_list, list) and image_list:
+            rehosted = await self._rehost_collection(meta, "screenshots", image_list)
+            if rehosted:
+                set_tracker_image_collection(meta, self.tracker, "screenshots", rehosted)
+                logger.info(f"[green]{self.tracker}: Successfully rehosted {len(rehosted)} screenshots to BiOMA.[/green]")
+
+        secondary_collections: tuple[ImageCollection, ...] = (
+            "menu_images",
+            "spectrograms_images",
+            "dynamic_hdr_plot_images",
+        )
+        for collection_name in secondary_collections:
+            collection = getattr(meta, collection_name, [])
+            if isinstance(collection, list) and collection:
+                rehosted = await self._rehost_collection(meta, collection_name, collection)
+                if rehosted:
+                    set_tracker_image_collection(meta, self.tracker, collection_name, rehosted)

--- a/src/uploadscreens.py
+++ b/src/uploadscreens.py
@@ -333,14 +333,18 @@ async def upload_image_task(args: Sequence[Any]) -> dict[str, Any]:
                 logger.info(f"[red]Request failed with error: {e}")
                 return {"status": "failed", "reason": str(e)}
 
-        elif img_host in ("zipline", "midnightscene"):
+        elif img_host in ("zipline", "midnightscene", "bioma"):
             if img_host == "midnightscene":
                 url = "https://img.midnightscene.cc/api/upload"
-                api_key = config["DEFAULT"].get("midnightscene_api_key")
+                api_key = config.get("DEFAULT", {}).get("midnightscene_api_key")
                 host_name = "MidnightScene"
+            elif img_host == "bioma":
+                url = "https://img.thebioma.space/api/upload"
+                api_key = config.get("TRACKERS", {}).get("CAPYBARABR", {}).get("bioma_api_key")
+                host_name = "BiOMA"
             else:
-                url = config["DEFAULT"].get("zipline_url")
-                api_key = config["DEFAULT"].get("zipline_api_key")
+                url = config.get("DEFAULT", {}).get("zipline_url")
+                api_key = config.get("DEFAULT", {}).get("zipline_api_key")
                 host_name = "Zipline"
 
             if not url or not api_key:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added BiOMA as a supported image host for screenshot uploads and validation.
  - CapybaraBR releases tagged for BiOMA can automatically rehost screenshots and related images using the configured BiOMA API key.
  - Added support for locating or downloading images before uploading them to BiOMA.
- **Bug Fixes**
  - Improved image-host configuration handling to prevent failures when optional settings are missing.
  - Automatically falls back to the default image host if BiOMA processing fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->