### PR TITLE
fix: tracker-specific UNIT3D region mappings

### DIFF
--- a/src/trackermeta.py
+++ b/src/trackermeta.py
@@ -602,6 +602,7 @@ async def update_metadata_from_tracker(
                     id=resolved_torrent_id,
                     skip_tracker_descriptions=skip_tracker_descriptions,
                     public_torrent_url=tracker_instance.torrent_url,
+                    region_resolver=getattr(tracker_instance, "get_region_name", None),
                 ),
             )
         else:
@@ -615,6 +616,7 @@ async def update_metadata_from_tracker(
                     meta,
                     file_name=search_term,
                     skip_tracker_descriptions=skip_tracker_descriptions,
+                    region_resolver=getattr(tracker_instance, "get_region_name", None),
                 ),
             )
 

--- a/src/trackers/UNIT3D/aither.py
+++ b/src/trackers/UNIT3D/aither.py
@@ -28,6 +28,12 @@ class Aither(UNIT3D):
     supported_categories = ("TV", "MOVIE")
     tracker_urls = ("https://aither.cc",)
     allowed_bloated_audio_languages = ("en",)
+    REGION_IDS = {
+        "FIN": "244",
+        "SWE": "246",
+        "CZE": "247",
+        "EST": "248",
+    }
 
     def __init__(self, config: dict[str, Any]):
         super().__init__(config, tracker_name="AITHER")
@@ -63,6 +69,22 @@ class Aither(UNIT3D):
             data["hdr"] = 1
 
         return data
+
+    async def get_region_id(self, meta: Meta) -> dict[str, str]:
+        region_id = self.REGION_IDS.get(str(meta.region or "").upper())
+        if region_id:
+            return {"region_id": region_id}
+        return await super().get_region_id(meta)
+
+    async def get_region_name(self, region_id: int | str | None) -> str:
+        region_name = {value: key for key, value in self.REGION_IDS.items()}.get(str(region_id), "")
+        if region_name:
+            return region_name
+        try:
+            normalized_id = int(region_id) if region_id is not None else 0
+        except (TypeError, ValueError):
+            return ""
+        return await self.common.unit3d_region_ids(reverse=True, region_id=normalized_id)
 
     async def get_name(self, meta: Meta):
         aither_name: str = meta.name

--- a/src/trackers/UNIT3D/blutopia.py
+++ b/src/trackers/UNIT3D/blutopia.py
@@ -113,6 +113,14 @@ class Blutopia(UNIT3D):
     torrent_url = f"{base_url}/torrents/"
     supported_categories = ("TV", "MOVIE")
     tracker_urls = ("https://blutopia.cc",)
+    REGION_IDS = {
+        "CZE": "244",
+        "SVK": "245",
+        "FIN": "246",
+        "SWE": "247",
+        "BGR": "248",
+        "DNK": "249",
+    }
     allowed_bloated_audio_languages = ("en",)
 
     def __init__(self, config: dict[str, Any]) -> None:
@@ -195,6 +203,22 @@ class Blutopia(UNIT3D):
         return {
             "mod_queue_opt_in": await self.get_flag(meta, "modq"),
         }
+
+    async def get_region_id(self, meta: Meta) -> dict[str, str]:
+        region_id = self.REGION_IDS.get(str(meta.region or "").upper())
+        if region_id:
+            return {"region_id": region_id}
+        return await super().get_region_id(meta)
+
+    async def get_region_name(self, region_id: int | str | None) -> str:
+        region_name = {value: key for key, value in self.REGION_IDS.items()}.get(str(region_id), "")
+        if region_name:
+            return region_name
+        try:
+            normalized_id = int(region_id) if region_id is not None else 0
+        except (TypeError, ValueError):
+            return ""
+        return await self.common.unit3d_region_ids(reverse=True, region_id=normalized_id)
 
     async def get_category_id(
         self,

--- a/src/trackers/UNIT3D/lst.py
+++ b/src/trackers/UNIT3D/lst.py
@@ -29,6 +29,11 @@ class LST(UNIT3D):
     trumping_url = f"{base_url}/api/reports/torrents/"
     supported_categories = ("TV", "MOVIE", "BOOK", "MUSIC", "XXX")
     tracker_urls = ("https://lst.gg",)
+    REGION_IDS = {
+        "CZE": "244",
+        "FIN": "245",
+        "SWE": "246",
+    }
 
     def __init__(self, config: Config) -> None:
         super().__init__(config, tracker_name="LST")
@@ -146,6 +151,22 @@ class LST(UNIT3D):
                 data["release_exists_on_discogs"] = "1"
 
         return data
+
+    async def get_region_id(self, meta: Meta) -> dict[str, str]:
+        region_id = self.REGION_IDS.get(str(meta.region or "").upper())
+        if region_id:
+            return {"region_id": region_id}
+        return await super().get_region_id(meta)
+
+    async def get_region_name(self, region_id: int | str | None) -> str:
+        region_name = {value: key for key, value in self.REGION_IDS.items()}.get(str(region_id), "")
+        if region_name:
+            return region_name
+        try:
+            normalized_id = int(region_id) if region_id is not None else 0
+        except (TypeError, ValueError):
+            return ""
+        return await self.common.unit3d_region_ids(reverse=True, region_id=normalized_id)
 
     async def get_edition(self, meta: Meta) -> int | None:
         edition_mapping = {

--- a/src/trackers/common.py
+++ b/src/trackers/common.py
@@ -2623,6 +2623,7 @@ class Common:
         file_name: str | list[str] | None = None,
         skip_tracker_descriptions: bool = False,
         public_torrent_url: str | None = None,
+        region_resolver: Callable[[Any], Any] | None = None,
     ) -> tuple[
         int | None,
         int | None,
@@ -2697,7 +2698,7 @@ class Common:
                 imdb = 0 if imdb == 0 else imdb
                 if not meta.region and meta.is_disc in ("BDMV", "DVD"):
                     region_id = attributes.get("region_id")
-                    region_name = await self.unit3d_region_ids(reverse=True, region_id=region_id)
+                    region_name = await region_resolver(region_id) if region_resolver else await self.unit3d_region_ids(reverse=True, region_id=region_id)
                     if region_name:
                         meta.region = region_name
                 if not meta.distributor and meta.is_disc in ("BDMV", "DVD"):
@@ -2724,7 +2725,7 @@ class Common:
                     imdb = 0 if imdb == 0 else imdb
                     if not meta.region and meta.is_disc in ("BDMV", "DVD"):
                         region_id = attributes.get("region_id")
-                        region_name = await self.unit3d_region_ids(reverse=True, region_id=region_id)
+                        region_name = await region_resolver(region_id) if region_resolver else await self.unit3d_region_ids(reverse=True, region_id=region_id)
                         if region_name:
                             meta.region = region_name
                     if not meta.distributor and meta.is_disc in ("BDMV", "DVD"):


### PR DESCRIPTION
## Summary

- Add tracker-specific region IDs for Aither, LST, and BLUTOPIA.
- Support reverse mapping of tracker API region IDs back to region codes.

## Mappings

- Aither: FIN `244`, SWE `246`, CZE `247`, EST `248`
- LST: CZE `244`, FIN `245`, SWE `246`
- BLUTOPIA: CZE `244`, SVK `245`, FIN `246`, SWE `247`, BGR `248`, DNK `249`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tracker-specific region mapping for Aither, Blutopia, and LST.
  * Improved conversion between region names and tracker region IDs.
  * Added support for resolving regions consistently across torrent lookup results.

* **Bug Fixes**
  * Invalid or unrecognized region IDs are now handled safely.
  * Region information is preserved for both direct and search-based torrent lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->