### PR TITLE
fix(uploadscreens): keep manifest screenshot paths absolute during upload

### DIFF
--- a/src/uploadscreens.py
+++ b/src/uploadscreens.py
@@ -713,7 +713,11 @@ async def _upload_screens(
     else:
         registered_screens = manifest_files(meta.base_dir, meta.uuid, "main")
         if registered_screens:
-            image_glob = [str(path.relative_to(Path.cwd())) for path in registered_screens]
+            # Manifest entries are absolute paths and can live outside the
+            # process working directory on seedboxes.  Keep them absolute:
+            # every image-host adapter accepts a path, and this avoids a
+            # process-global ``cwd`` race between concurrent uploads.
+            image_glob = [str(path) for path in registered_screens]
         else:
             image_patterns = ["*.png", ".[!.]*.png"]
             image_glob = []

--- a/tests/test_prep_early_screenshots.py
+++ b/tests/test_prep_early_screenshots.py
@@ -190,7 +190,7 @@ def test_upload_uses_only_registered_main_screenshots(tmp_path: Path, monkeypatc
         _, uploaded_count = asyncio.run(_upload_screens(config, meta, 1, 1, 0, 1, [], {}))
 
     assert uploaded_count == 1
-    assert calls == [main_screen.name]
+    assert calls == [str(main_screen)]
 
 
 def test_early_bdmv_capture_includes_alternate_playlists() -> None:

--- a/tests/test_uploadscreens.py
+++ b/tests/test_uploadscreens.py
@@ -69,6 +69,43 @@ def test_upload_screens_does_not_reupload_source_on_fallback(tmp_path: Path) -> 
     assert calls == ["image-1.png"]
 
 
+def test_upload_screens_accepts_manifest_paths_outside_working_directory(tmp_path: Path) -> None:
+    uploaded: list[str] = []
+
+    async def fake_upload(args: object) -> dict[str, str]:
+        assert isinstance(args, list)
+        uploaded.append(str(args[0]))
+        return {
+            "status": "success",
+            "img_url": "https://img.example/image.png",
+            "raw_url": "https://img.example/image.png",
+            "web_url": "https://img.example/image.png",
+        }
+
+    async def exercise() -> None:
+        source_screenshots = tmp_path / "source" / "screenshots"
+        state_screenshots = tmp_path / "state" / "tmp" / "release" / "screenshots"
+        source_screenshots.mkdir(parents=True)
+        state_screenshots.mkdir(parents=True)
+        screenshot = state_screenshots / "image.png"
+        screenshot.write_bytes(b"image")
+        meta = Meta({"base_dir": str(tmp_path), "uuid": "release", "imghost": "imgbox"})
+        config = {"DEFAULT": {"img_host_1": "imgbox", "image_upload_delay": 0}, "TRACKERS": {}}
+
+        with (
+            patch("src.uploadscreens.screenshots_dir", return_value=source_screenshots),
+            patch("src.uploadscreens.os.chdir"),
+            patch("src.uploadscreens.Path.cwd", return_value=source_screenshots),
+            patch("src.uploadscreens.manifest_files", return_value=[screenshot]),
+            patch("src.uploadscreens.upload_image_task", new=fake_upload),
+        ):
+            await _upload_screens(config, meta, 1, 1, 0, 1, [], {})
+
+        assert uploaded == [str(screenshot)]
+
+    asyncio.run(exercise())
+
+
 def test_upload_screens_preserves_partial_successes_across_fallback(tmp_path: Path) -> None:
     calls: list[tuple[str, str]] = []
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed screenshot uploads so manifest-registered screenshots are located and uploaded correctly using their full paths, including files outside the configured screenshots directory.

* **Tests**
  * Added regression coverage for uploading screenshots from external locations.
  * Updated upload expectations to reflect full registered screenshot paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->