### PR TITLE
fix(trackers): fix brasiltracker signature generation and add capybarabr bioma naming tag

### DIFF
--- a/src/artwork.py
+++ b/src/artwork.py
@@ -33,7 +33,7 @@ def is_public_http_url(value: str | None) -> bool:
     try:
         addresses = {result[4][0] for result in socket.getaddrinfo(parsed.hostname, None, type=socket.SOCK_STREAM)}
         return bool(addresses) and all(ipaddress.ip_address(address).is_global for address in addresses)
-    except (OSError, ValueError):
+    except OSError, ValueError:
         return False
 
 
@@ -50,7 +50,7 @@ def is_valid_image_bytes(image_bytes: bytes) -> bool:
                     return False
                 image.verify()
         return True
-    except (OSError, SyntaxError, ValueError, Image.DecompressionBombError, Image.DecompressionBombWarning):
+    except OSError, SyntaxError, ValueError, Image.DecompressionBombError, Image.DecompressionBombWarning:
         return False
 
 
@@ -157,7 +157,7 @@ def _write_png(source: Path | bytes, destination: Path) -> bool:
             image.save(temporary, "PNG")
         temporary.replace(destination)
         return True
-    except (OSError, SyntaxError, ValueError):
+    except OSError, SyntaxError, ValueError:
         temporary.unlink(missing_ok=True)
         return False
 

--- a/src/trackers/UNIT3D/aither.py
+++ b/src/trackers/UNIT3D/aither.py
@@ -1,5 +1,5 @@
 # Upload Assistant © 2025 Audionut & wastaken7 — Licensed under UAPL v1.0
-from typing import Any
+from typing import Any, ClassVar
 
 from src.console import logger
 from src.languages import languages_manager
@@ -28,7 +28,7 @@ class Aither(UNIT3D):
     supported_categories = ("TV", "MOVIE")
     tracker_urls = ("https://aither.cc",)
     allowed_bloated_audio_languages = ("en",)
-    REGION_IDS = {
+    REGION_IDS: ClassVar[dict[str, str]] = {
         "FIN": "244",
         "SWE": "246",
         "CZE": "247",
@@ -82,7 +82,7 @@ class Aither(UNIT3D):
             return region_name
         try:
             normalized_id = int(region_id) if region_id is not None else 0
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             return ""
         return await self.common.unit3d_region_ids(reverse=True, region_id=normalized_id)
 

--- a/src/trackers/UNIT3D/blutopia.py
+++ b/src/trackers/UNIT3D/blutopia.py
@@ -1,5 +1,5 @@
 # Upload Assistant © 2025 Audionut & wastaken7 — Licensed under UAPL v1.0
-from typing import Any
+from typing import Any, ClassVar
 
 import cli_ui
 
@@ -113,7 +113,7 @@ class Blutopia(UNIT3D):
     torrent_url = f"{base_url}/torrents/"
     supported_categories = ("TV", "MOVIE")
     tracker_urls = ("https://blutopia.cc",)
-    REGION_IDS = {
+    REGION_IDS: ClassVar[dict[str, str]] = {
         "CZE": "244",
         "SVK": "245",
         "FIN": "246",
@@ -216,7 +216,7 @@ class Blutopia(UNIT3D):
             return region_name
         try:
             normalized_id = int(region_id) if region_id is not None else 0
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             return ""
         return await self.common.unit3d_region_ids(reverse=True, region_id=normalized_id)
 

--- a/src/trackers/UNIT3D/capybarabr.py
+++ b/src/trackers/UNIT3D/capybarabr.py
@@ -158,11 +158,12 @@ class CapybaraBR(UNIT3D):
     async def get_name(self, meta: Meta) -> dict[str, str]:
         category = meta.category
         cbr_name = meta.name
+        bioma_tag = "[BiOMA]" if "bioma" in (meta.tag or "").lower() and self.tracker == "CAPYBARABR" else ""
 
         if category == "BOOK":
             book_title = self.common.portuguese_title_capitalization(meta.title)
             year_str = str(meta.year) if meta.year is not None else ""
-            cbr_name = f"{book_title} - {meta.author} [{year_str}] [AUDIOBOOK]" if meta.audiobook else f"{book_title} - {meta.author} [{year_str}]"
+            cbr_name = f"{book_title} - {meta.author} [{year_str}] [AUDIOBOOK] {bioma_tag}" if meta.audiobook else f"{book_title} - {meta.author} [{year_str}]"
             book_language_iso = meta.book_language_iso
             if book_language_iso and book_language_iso != "por":
                 cbr_name += f" [{book_language_iso.upper()}]"
@@ -189,7 +190,7 @@ class CapybaraBR(UNIT3D):
                 dlc = f" {dlc}"
 
             year_str = str(meta.year) if meta.year is not None else ""
-            cbr_name = f"{meta.title} {update} {meta.game_version} {year_str} - {tag} {game_lang}{dlc}"
+            cbr_name = f"{meta.title} {update} {meta.game_version} {year_str} - {tag} {game_lang}{dlc} {bioma_tag}"
 
         elif category in ("MOVIE", "TV"):
             cbr_name = cbr_name.replace("DD+ ", "DDP").replace("DD ", "DD").replace("AAC ", "AAC").replace("FLAC ", "FLAC").replace("Dubbed", "").replace("Dual-Audio", "")

--- a/src/trackers/UNIT3D/lst.py
+++ b/src/trackers/UNIT3D/lst.py
@@ -1,6 +1,6 @@
 # Upload Assistant © 2025 Audionut & wastaken7 — Licensed under UAPL v1.0
 import re
-from typing import Any
+from typing import Any, ClassVar
 
 from src.console import logger
 from src.meta import Meta
@@ -29,7 +29,7 @@ class LST(UNIT3D):
     trumping_url = f"{base_url}/api/reports/torrents/"
     supported_categories = ("TV", "MOVIE", "BOOK", "MUSIC", "XXX")
     tracker_urls = ("https://lst.gg",)
-    REGION_IDS = {
+    REGION_IDS: ClassVar[dict[str, str]] = {
         "CZE": "244",
         "FIN": "245",
         "SWE": "246",
@@ -164,7 +164,7 @@ class LST(UNIT3D):
             return region_name
         try:
             normalized_id = int(region_id) if region_id is not None else 0
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             return ""
         return await self.common.unit3d_region_ids(reverse=True, region_id=normalized_id)
 

--- a/src/trackers/brasiltracker.py
+++ b/src/trackers/brasiltracker.py
@@ -615,9 +615,6 @@ class BrasilTracker:
         return await builder.general_description_generator(
             meta,
             audio_spectrogram=False,
-            bluray=False,
-            custom_signature=False,
-            description=False,
             menu_screenshots=False,
             nfo=False,
             screenshots=False,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audiobook and game names from CapybaraBR now include the `[BiOMA]` tag when applicable.

* **Bug Fixes**
  * Improved handling of region names across supported trackers.
  * Corrected image, URL, and PNG processing error handling.
  * Simplified BrasilTracker description generation for more consistent results.

* **Refactor**
  * Improved internal type clarity and consistency for tracker configuration data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->