### PR TITLE
feat(trackers): add configurable upload retries and retry logic for anthelion

### DIFF
--- a/data/example_config.py
+++ b/data/example_config.py
@@ -121,6 +121,9 @@ config: dict[str, Any] = {
         # Default = 1. If 1 (or more) tracker/s pass banned_group, content and dupe checking, uploading will continue
         # If less than the number of trackers pass the checking, exit immediately.
         "tracker_pass_checks": 1,
+        # Number of upload retry attempts for network/server errors (e.g. 500, timeouts).
+        # Trackers can override this individually in their section.
+        "max_retries": 3,
         # Set true to suppress config warnings on startup
         "suppress_warnings": False,
         # Set true to embed terminal links using hyperlinks (OSC 8)
@@ -585,6 +588,8 @@ config: dict[str, Any] = {
             "api_key": "",
             "announce_url": "",
             "anon": True,
+            # Number of upload retry attempts for network/server errors (e.g. 500, timeouts).
+            "max_retries": 5,
             # The configurations below override the DEFAULT configuration
             "add_logo": True,
             "thumbnail_size": "",

--- a/src/trackers/UNIT3D/__init__.py
+++ b/src/trackers/UNIT3D/__init__.py
@@ -515,7 +515,11 @@ class UNIT3D:
 
         if meta.debug is False:
             response_data = {}
-            max_retries = 2
+            try:
+                default_retries = self.config.get("DEFAULT", {}).get("max_retries", 2)
+                max_retries = max(1, int(self.tracker_config.get("max_retries", default_retries)))
+            except ValueError, TypeError:
+                max_retries = 2
             retry_delay = 5
             timeout = 40.0
             download_url: str | None = None

--- a/src/trackers/anthelion.py
+++ b/src/trackers/anthelion.py
@@ -189,11 +189,6 @@ class Anthelion:
 
             if tags:
                 logger.info(f"{self.tracker}: [green]Using IMDb genres for tagging: {', '.join(tags)}")
-                logger.info(
-                    f"{self.tracker}: [yellow]api will accept this upload, but no tag will be added.\nYou must manually add at least one tag from the approved list when uploaded."
-                )
-                await asyncio.sleep(3)
-                meta.ant_user_tags = True
 
         if not tags:
             if meta.unattended and not meta.unattended_confirm:
@@ -365,7 +360,7 @@ class Anthelion:
                                 meta.tracker_status[self.tracker]["status_message"] = "data error: ANTHELION json decode error, the API is probably down"
                                 return False
 
-                            is_success = ("success" in response_data) or (str(response_data.get("status", "")).lower() == "success")
+                            is_success = bool(response_data["success"]) if "success" in response_data else str(response_data.get("status", "")).lower() == "success"
                             if not is_success:
                                 meta.tracker_status[self.tracker]["status_message"] = f"data error: {response_data}"
                                 return False
@@ -388,21 +383,10 @@ class Anthelion:
                         return False
 
                 except httpx.TimeoutException:
-                    if attempt < max_retries - 1:
-                        timeout = timeout * 1.5
-                        logger.info(
-                            f"{self.tracker}: [yellow]Request timed out, retrying in {retry_delay} seconds with {timeout}s timeout... (attempt {attempt + 1}/{max_retries})[/yellow]"
-                        )
-                        await asyncio.sleep(retry_delay)
-                        continue
-                    meta.tracker_status[self.tracker]["status_message"] = "data error: ANTHELION request timed out after multiple attempts."
+                    meta.tracker_status[self.tracker]["status_message"] = "data error: ANTHELION request timed out; it may have uploaded, check the tracker before retrying."
                     return False
                 except httpx.RequestError as e:
-                    if attempt < max_retries - 1:
-                        logger.info(f"{self.tracker}: [yellow]Request error ({e}), retrying in {retry_delay} seconds... (attempt {attempt + 1}/{max_retries})[/yellow]")
-                        await asyncio.sleep(retry_delay)
-                        continue
-                    meta.tracker_status[self.tracker]["status_message"] = f"data error: An error occurred while making the request: {e}"
+                    meta.tracker_status[self.tracker]["status_message"] = f"data error: ANTHELION request failed and may have uploaded; check the tracker before retrying: {e}"
                     return False
                 except Exception as e:
                     import traceback

--- a/src/trackers/anthelion.py
+++ b/src/trackers/anthelion.py
@@ -201,7 +201,6 @@ class Anthelion:
                 meta.skipping = f"{self.tracker}"
                 return ""
             logger.info(f"{self.tracker}: [yellow]No genres found for tagging. Tag required.")
-            logger.info(f"{self.tracker}: [yellow]Only use a tag in the approved list found in the site search box.")
             logger.info(
                 f"{self.tracker}: [yellow]api will accept this upload, but no tag will be added.\nYou must manually add at least one tag from the approved list when uploaded."
             )
@@ -211,7 +210,7 @@ class Anthelion:
                 tags.append(user_tag.replace(" ", ".").lower())
                 meta.ant_user_tags = True
 
-        return tags if not no_tags else ""
+        return tags
 
     async def get_type(self, meta: Meta) -> int:
         ant_type = None
@@ -314,6 +313,9 @@ class Anthelion:
         else:
             data.update({"noreleasegroup": 1})
 
+        if meta.anon or self.tracker_config.get("anon", False):
+            data.update({"anonymous": 1})
+
         if meta.adult_media:
             if not meta.unattended or (meta.unattended and meta.unattended_confirm):
                 logger.info(f"{self.tracker}: [bold red]Adult content detected[/bold red]")
@@ -336,54 +338,94 @@ class Anthelion:
             "User-Agent": f"{meta.ua_name} {(meta.current_version if meta.current_version is not None else 'github.com/wastaken7/Upload-Assistant')} ({platform.system()} {platform.release()})"
         }
 
-        try:
-            if not meta.debug:
-                async with httpx.AsyncClient(timeout=40) as client:
-                    response = await client.post(url=self.api_url, files=files, data=data, headers=headers)
-                    try:
-                        response_data: dict[str, Any] = response.json()
-                    except json.JSONDecodeError:
-                        meta.tracker_status[self.tracker]["status_message"] = "data error: ANTHELION json decode error, the API is probably down"
+        if not meta.debug:
+            response_data: dict[str, Any] = {}
+            try:
+                default_retries = self.config.get("DEFAULT", {}).get("max_retries", 5)
+                max_retries = max(1, int(self.tracker_config.get("max_retries", default_retries)))
+            except ValueError, TypeError:
+                max_retries = 5
+            retry_delay = 5
+            timeout = 40.0
+
+            for attempt in range(max_retries):
+                try:
+                    async with httpx.AsyncClient(timeout=timeout) as client:
+                        response = await client.post(url=self.api_url, files=files, data=data, headers=headers)
+                        if response.status_code in [200, 201]:
+                            try:
+                                response_data = response.json()
+                            except json.JSONDecodeError:
+                                if attempt < max_retries - 1:
+                                    logger.info(
+                                        f"{self.tracker}: [yellow]JSON decode error (HTTP {response.status_code}), retrying in {retry_delay}s... (attempt {attempt + 1}/{max_retries})[/yellow]"
+                                    )
+                                    await asyncio.sleep(retry_delay)
+                                    continue
+                                meta.tracker_status[self.tracker]["status_message"] = "data error: ANTHELION json decode error, the API is probably down"
+                                return False
+
+                            is_success = ("success" in response_data) or (str(response_data.get("status", "")).lower() == "success")
+                            if not is_success:
+                                meta.tracker_status[self.tracker]["status_message"] = f"data error: {response_data}"
+                                return False
+                            meta.tracker_status[self.tracker]["status_message"] = response_data
+                            return True
+
+                        if response.status_code in [401, 403]:
+                            meta.tracker_status[self.tracker]["status_message"] = f"data error: HTTP {response.status_code} - {response.text}"
+                            return False
+
+                        if attempt < max_retries - 1:
+                            logger.info(
+                                f"{self.tracker}: [yellow]HTTP {response.status_code} error, retrying in {retry_delay} seconds... (attempt {attempt + 1}/{max_retries})[/yellow]"
+                            )
+                            await asyncio.sleep(retry_delay)
+                            continue
+
+                        response_data = {"error": f"ANTHELION returned status code: {response.status_code}", "response_content": response.text}
+                        meta.tracker_status[self.tracker]["status_message"] = f"data error - {response_data}"
                         return False
 
-                    if response.status_code in [200, 201]:
-                        is_success = ("success" in response_data) or (str(response_data.get("status", "")).lower() == "success")
-                        if not is_success:
-                            meta.tracker_status[self.tracker]["status_message"] = f"data error: {response_data}"
-                            return False
-                        meta.tracker_status[self.tracker]["status_message"] = response_data
-                        return True
-
-                    response_data = {"error": f"ANTHELION returned status code: {response.status_code}", "response_content": response.text}
-                    meta.tracker_status[self.tracker]["status_message"] = f"data error - {response_data}"
+                except httpx.TimeoutException:
+                    if attempt < max_retries - 1:
+                        timeout = timeout * 1.5
+                        logger.info(
+                            f"{self.tracker}: [yellow]Request timed out, retrying in {retry_delay} seconds with {timeout}s timeout... (attempt {attempt + 1}/{max_retries})[/yellow]"
+                        )
+                        await asyncio.sleep(retry_delay)
+                        continue
+                    meta.tracker_status[self.tracker]["status_message"] = "data error: ANTHELION request timed out after multiple attempts."
                     return False
-            else:
-                if "mediainfo" in data:
-                    debug_mediainfo_path = Path(meta.base_dir) / "tmp" / str(meta.uuid) / f"{self.tracker}_MEDIAINFO.txt"
-                    async with aiofiles.open(debug_mediainfo_path, "w", newline="", encoding="utf-8") as f:
-                        await f.write(str(data["mediainfo"]))
-                    logger.info(f"{self.tracker}: [green]Final MediaInfo payload written to {debug_mediainfo_path}[/green]")
-                logger.info(f"{self.tracker}: Request Data:")
-                logger.info(Redaction.redact_private_info(data))
-                meta.tracker_status[self.tracker]["status_message"] = "Debug mode enabled, not uploading."
-                await self.common.create_torrent_for_upload(meta, f"{self.tracker}" + "_DEBUG", f"{self.tracker}" + "_DEBUG", announce_url="https://fake.tracker")
-                return True
-        except httpx.TimeoutException:
-            meta.tracker_status[self.tracker]["status_message"] = "data error: ANTHELION request timed out while uploading."
-            return False
-        except httpx.RequestError as e:
-            meta.tracker_status[self.tracker]["status_message"] = f"data error: An error occurred while making the request: {e}"
-            return False
-        except Exception as e:
-            import traceback
+                except httpx.RequestError as e:
+                    if attempt < max_retries - 1:
+                        logger.info(f"{self.tracker}: [yellow]Request error ({e}), retrying in {retry_delay} seconds... (attempt {attempt + 1}/{max_retries})[/yellow]")
+                        await asyncio.sleep(retry_delay)
+                        continue
+                    meta.tracker_status[self.tracker]["status_message"] = f"data error: An error occurred while making the request: {e}"
+                    return False
+                except Exception as e:
+                    import traceback
 
-            error_type = type(e).__name__
-            error_msg = str(e) if str(e) else "No error message"
-            traceback_str = traceback.format_exc()
-            logger.info(f"{self.tracker}: [bold red]upload exception ({error_type}): {escape(error_msg)}[/bold red]")
-            logger.info(f"{self.tracker}: [red]Traceback:\n{escape(traceback_str)}[/red]")
-            meta.tracker_status[self.tracker]["status_message"] = "data error: double check if it uploaded"
+                    error_type = type(e).__name__
+                    error_msg = str(e) if str(e) else "No error message"
+                    traceback_str = traceback.format_exc()
+                    logger.info(f"{self.tracker}: [bold red]upload exception ({error_type}): {escape(error_msg)}[/bold red]")
+                    logger.info(f"{self.tracker}: [red]Traceback:\n{escape(traceback_str)}[/red]")
+                    meta.tracker_status[self.tracker]["status_message"] = "data error: double check if it uploaded"
+                    return False
+
             return False
+        if "mediainfo" in data:
+            debug_mediainfo_path = Path(meta.base_dir) / "tmp" / str(meta.uuid) / f"{self.tracker}_MEDIAINFO.txt"
+            async with aiofiles.open(debug_mediainfo_path, "w", newline="", encoding="utf-8") as f:
+                await f.write(str(data["mediainfo"]))
+            logger.info(f"{self.tracker}: [green]Final MediaInfo payload written to {debug_mediainfo_path}[/green]")
+        logger.info(f"{self.tracker}: Request Data:")
+        logger.info(Redaction.redact_private_info(data))
+        meta.tracker_status[self.tracker]["status_message"] = "Debug mode enabled, not uploading."
+        await self.common.create_torrent_for_upload(meta, f"{self.tracker}" + "_DEBUG", f"{self.tracker}" + "_DEBUG", announce_url="https://fake.tracker")
+        return True
 
     async def get_audio(self, meta: Meta) -> str:
         """

--- a/tests/test_anthelion.py
+++ b/tests/test_anthelion.py
@@ -1,0 +1,114 @@
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+
+from src.trackers.anthelion import Anthelion
+
+
+class _Response:
+    status_code = 200
+
+    def json(self):
+        return {"success": False}
+
+
+class _Client:
+    posts = 0
+    response: _Response | Exception = _Response()
+
+    def __init__(self, **_kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return None
+
+    async def post(self, **_kwargs):
+        type(self).posts += 1
+        if isinstance(type(self).response, Exception):
+            raise type(self).response
+        return type(self).response
+
+
+def _meta(tmp_path: Path) -> SimpleNamespace:
+    release_dir = tmp_path / "tmp" / "release"
+    release_dir.mkdir(parents=True)
+    (release_dir / "BASE.torrent").write_bytes(b"torrent")
+    (release_dir / "[ANTHELION].torrent").write_bytes(b"torrent")
+    (release_dir / "MEDIAINFO_CLEANPATH.txt").write_text("General\n", encoding="utf-8")
+    return SimpleNamespace(
+        base_dir=str(tmp_path),
+        uuid="release",
+        mkbrr=False,
+        max_piece_size=None,
+        path="",
+        tracker_status={"ANTHELION": {}},
+        edition="",
+        audio="AAC",
+        has_commentary=False,
+        manual_commentary=False,
+        three_d="",
+        hdr="",
+        distributor="",
+        type="",
+        is_disc="",
+        scene=False,
+        tmdb="1",
+        tag="",
+        anon=False,
+        adult_media=False,
+        image_list=[],
+        ant_user_tags=False,
+        ua_name="Upload Assistant",
+        current_version=None,
+        debug=False,
+    )
+
+
+def _tracker(monkeypatch) -> Anthelion:
+    tracker = Anthelion({"DEFAULT": {"max_retries": 3}, "TRACKERS": {"ANTHELION": {"api_key": "secret"}}})
+
+    async def no_op(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(tracker.common, "create_torrent_for_upload", no_op)
+    monkeypatch.setattr(tracker, "get_flags", no_op)
+    monkeypatch.setattr(tracker, "get_audio", lambda _meta: asyncio.sleep(0, result="AAC"))
+    monkeypatch.setattr(tracker, "get_type", lambda _meta: asyncio.sleep(0, result=0))
+    monkeypatch.setattr(tracker, "get_tags", lambda _meta: asyncio.sleep(0, result=[]))
+    monkeypatch.setattr(tracker, "get_release_group", lambda _meta: asyncio.sleep(0, result=""))
+    monkeypatch.setattr(tracker, "edit_desc", lambda _meta: asyncio.sleep(0, result="description"))
+    monkeypatch.setattr("src.trackers.anthelion.httpx.AsyncClient", _Client)
+    return tracker
+
+
+def test_anthelion_rejects_false_success(tmp_path: Path, monkeypatch) -> None:
+    _Client.posts = 0
+    _Client.response = _Response()
+    meta = _meta(tmp_path)
+
+    assert asyncio.run(_tracker(monkeypatch).upload(meta)) is False  # noqa: S101
+    assert meta.tracker_status["ANTHELION"]["status_message"] == "data error: {'success': False}"  # noqa: S101
+
+
+def test_anthelion_does_not_retry_timeout_after_submission(tmp_path: Path, monkeypatch) -> None:
+    _Client.posts = 0
+    _Client.response = httpx.ReadTimeout("timed out")
+    meta = _meta(tmp_path)
+
+    assert asyncio.run(_tracker(monkeypatch).upload(meta)) is False  # noqa: S101
+    assert _Client.posts == 1  # noqa: S101
+    assert "may have uploaded" in meta.tracker_status["ANTHELION"]["status_message"]  # noqa: S101
+
+
+def test_anthelion_imdb_tags_are_not_marked_as_manual() -> None:
+    meta = SimpleNamespace(genres=[], imdb_info={"genres": ["Action"]}, ant_user_tags=True)
+    tracker = object.__new__(Anthelion)
+    tracker.tracker = "ANTHELION"
+
+    assert asyncio.run(tracker.get_tags(meta)) == ["action"]  # noqa: S101
+    assert meta.ant_user_tags is False  # noqa: S101


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable upload retry limits, including tracker-specific settings.
  * Uploads can now be submitted anonymously when enabled in configuration.
  * Improved retry handling for network errors, server responses, timeouts, and invalid responses.
  * Retry delays now increase between attempts, with status updates during retries.

* **Bug Fixes**
  * Tag handling now consistently returns an empty list when no tags are available.
  * Invalid retry settings are safely replaced with a valid fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->