### PR TITLE
fix(paths): ensure temp and artwork directories fallback to user state dir

### DIFF
--- a/src/meta.py
+++ b/src/meta.py
@@ -4,6 +4,8 @@
 from dataclasses import MISSING, dataclass, field, fields
 from typing import Any
 
+from src.app_paths import STATE_DIR
+
 _TRACKER_ID_ALIASES = {
     "ANT": "ANTHELION",
     "BHD": "BEYONDHD",
@@ -55,7 +57,7 @@ class Meta:
     auto_nfo: bool = False
     available_platforms: list[Any] = field(default_factory=list)
     backdrop: str = ""
-    base_dir: str = ""
+    base_dir: str = field(default_factory=lambda: str(STATE_DIR))
     base_reuse_torrent_path: str | None = None
     base_torrent_created: bool | None = None
     base_torrent_piece_mb: int = 0
@@ -537,6 +539,8 @@ class Meta:
                 setattr(self, k, v)
         for k, v in kwargs.items():
             setattr(self, k, v)
+        if not self.base_dir:
+            self.base_dir = str(STATE_DIR)
         self.set_tracker_ids(self.tracker_ids)
 
     def copy(self) -> Meta:

--- a/src/screenshot_manifest.py
+++ b/src/screenshot_manifest.py
@@ -11,20 +11,20 @@ import uuid
 from pathlib import Path
 from typing import Any
 
-from src.temp_paths import screenshots_dir
+from src.temp_paths import release_temp_dir, screenshots_dir
 
 _locks: dict[str, threading.RLock] = {}
 _locks_guard = threading.Lock()
 
 
-def _lock(base_dir: str | Path, release_id: str) -> threading.RLock:
+def _lock(base_dir: str | Path | None, release_id: str) -> threading.RLock:
     key = str(_path(base_dir, release_id).resolve()).casefold()
     with _locks_guard:
         return _locks.setdefault(key, threading.RLock())
 
 
-def _path(base_dir: str | Path, release_id: str) -> Path:
-    return Path(base_dir) / "tmp" / release_id / "screenshot_manifest.json"
+def _path(base_dir: str | Path | None, release_id: str) -> Path:
+    return release_temp_dir(base_dir, release_id) / "screenshot_manifest.json"
 
 
 def _load(base_dir: str | Path, release_id: str) -> dict[str, Any]:

--- a/src/temp_paths.py
+++ b/src/temp_paths.py
@@ -12,40 +12,40 @@ from pathlib import Path
 from src.app_paths import STATE_DIR
 
 
-def release_temp_dir(base_dir: str | Path, release_id: str) -> Path:
+def release_temp_dir(base_dir: str | Path | None, release_id: str) -> Path:
     """Return the root temporary directory for one release."""
-    return Path(base_dir) / "tmp" / str(release_id)
+    return Path(base_dir or STATE_DIR) / "tmp" / str(release_id)
 
 
 def music_release_snapshot_path(base_dir: str | Path | None, release_id: str) -> Path:
     """Return the music metadata snapshot path under a user-owned state directory."""
-    return release_temp_dir(base_dir or STATE_DIR, release_id) / "music_release.json"
+    return release_temp_dir(base_dir, release_id) / "music_release.json"
 
 
-def image_dir(base_dir: str | Path, release_id: str, kind: str) -> Path:
+def image_dir(base_dir: str | Path | None, release_id: str, kind: str) -> Path:
     """Return and create a typed image directory below a release's temp root."""
     path = release_temp_dir(base_dir, release_id) / kind
     path.mkdir(parents=True, exist_ok=True)
     return path
 
 
-def screenshots_dir(base_dir: str | Path, release_id: str) -> Path:
+def screenshots_dir(base_dir: str | Path | None, release_id: str) -> Path:
     return image_dir(base_dir, release_id, "screenshots")
 
 
-def artwork_dir(base_dir: str | Path, release_id: str) -> Path:
+def artwork_dir(base_dir: str | Path | None, release_id: str) -> Path:
     """Return the per-release directory for all local artwork assets."""
     return image_dir(base_dir, release_id, "artwork")
 
 
-def menu_screenshots_dir(base_dir: str | Path, release_id: str) -> Path:
+def menu_screenshots_dir(base_dir: str | Path | None, release_id: str) -> Path:
     return image_dir(base_dir, release_id, "menu_screenshots")
 
 
-def spectrograms_dir(base_dir: str | Path, release_id: str) -> Path:
+def spectrograms_dir(base_dir: str | Path | None, release_id: str) -> Path:
     return image_dir(base_dir, release_id, "spectrograms")
 
 
-def dynamic_hdr_plots_dir(base_dir: str | Path, release_id: str) -> Path:
+def dynamic_hdr_plots_dir(base_dir: str | Path | None, release_id: str) -> Path:
     """Return the per-release directory for Dolby Vision/HDR10+ plot images."""
     return image_dir(base_dir, release_id, "dynamic_hdr_plots")

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -25,3 +25,12 @@ def test_populate_cast_normalizes_and_limits_entries() -> None:
     meta.populate_cast()
 
     assert meta.cast == ["One", "Two", "Three", "Four", "Five"]
+
+
+def test_meta_base_dir_defaults_to_state_dir() -> None:
+    from src.app_paths import STATE_DIR
+
+    assert Meta().base_dir == str(STATE_DIR)
+    assert Meta(base_dir="").base_dir == str(STATE_DIR)
+    assert Meta({"base_dir": ""}).base_dir == str(STATE_DIR)
+    assert Meta(base_dir="/custom/dir").base_dir == "/custom/dir"

--- a/tests/test_temp_paths.py
+++ b/tests/test_temp_paths.py
@@ -33,3 +33,18 @@ def test_music_release_snapshot_uses_state_dir_when_base_dir_is_empty(tmp_path: 
     monkeypatch.setattr(temp_paths, "STATE_DIR", state_dir)
 
     assert music_release_snapshot_path("", "release") == state_dir / "tmp" / "release" / "music_release.json"
+    assert music_release_snapshot_path(None, "release") == state_dir / "tmp" / "release" / "music_release.json"
+
+
+def test_temp_and_image_dirs_use_state_dir_when_base_dir_is_empty_or_none(tmp_path: Path, monkeypatch) -> None:
+    state_dir = tmp_path / "state"
+    monkeypatch.setattr(temp_paths, "STATE_DIR", state_dir)
+
+    assert temp_paths.release_temp_dir("", "release") == state_dir / "tmp" / "release"
+    assert temp_paths.release_temp_dir(None, "release") == state_dir / "tmp" / "release"
+    assert artwork_dir("", "release") == state_dir / "tmp" / "release" / "artwork"
+    assert artwork_dir(None, "release") == state_dir / "tmp" / "release" / "artwork"
+    assert screenshots_dir("", "release") == state_dir / "tmp" / "release" / "screenshots"
+    assert screenshots_dir(None, "release") == state_dir / "tmp" / "release" / "screenshots"
+    assert (state_dir / "tmp" / "release" / "artwork").is_dir()
+    assert (state_dir / "tmp" / "release" / "screenshots").is_dir()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of temporary files and release assets when no storage location is specified.
  * Empty or unspecified paths now consistently use the application’s default state directory.
  * Custom storage locations continue to be respected.

* **Tests**
  * Added coverage for default and custom storage paths.
  * Verified expected temporary directories are created correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->