### PR TITLE
fix(screenshots): preserve tonemapping state from early capture and existing screens

### DIFF
--- a/src/prep.py
+++ b/src/prep.py
@@ -191,7 +191,7 @@ class Prep:
         # When description images are enabled, however, tracker metadata may
         # satisfy cutoff_screens. Do not generate local frames that would then
         # be discarded solely because that lookup has not completed yet.
-        early_screenshots_task: asyncio.Task[None] | None = None
+        early_screenshots_task: asyncio.Task[Meta | None] | None = None
         if not meta.keep_images:
             early_screenshots_task = asyncio.create_task(self._capture_early_screenshots(meta.copy(), filename, videopath, bdinfo))
         else:
@@ -226,7 +226,14 @@ class Prep:
         # starts consuming the generated files. Any error is logged by the
         # helper; the existing upload-stage capture remains the fallback.
         if early_screenshots_task is not None:
-            await early_screenshots_task
+            early_meta = await early_screenshots_task
+            if early_meta is not None:
+                if early_meta.tonemapped:
+                    meta.tonemapped = True
+                if early_meta.libplacebo:
+                    meta.libplacebo = True
+                if getattr(early_meta, "frame_info_map", None):
+                    meta.frame_info_map = early_meta.frame_info_map
         if meta.category == "XXX":
             meta.screens = len(manifest_files(meta.base_dir, meta.uuid, "main"))
 
@@ -242,12 +249,12 @@ class Prep:
 
         return meta
 
-    async def _capture_early_screenshots(self, meta: Meta, filename: str, videopath: str, bdinfo: dict[str, Any]) -> None:
+    async def _capture_early_screenshots(self, meta: Meta, filename: str, videopath: str, bdinfo: dict[str, Any]) -> Meta | None:
         """Generate local screenshots while metadata and tracker IDs are fetched."""
         if meta.keep_images:
-            return
+            return None
         if meta.category in ("MUSIC", "GAME", "BOOK") or meta.screens <= 0:
-            return
+            return None
 
         try:
             if meta.is_disc == "BDMV":
@@ -330,10 +337,12 @@ class Prep:
                     capture_group="main",
                 )
             logger.debug("[cyan]Early screenshot generation completed.[/cyan]")
+            return meta
         except asyncio.CancelledError:
             raise
         except Exception as error:
             logger.warning(f"[yellow]Early screenshot generation failed; upload stage will retry: {error}[/yellow]")
+            return None
 
     def check_adult_media(self, meta: Meta) -> bool:
         if meta.category == "XXX":

--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -53,7 +53,7 @@ def is_valid_lostimg_image_size(image_size: int) -> bool:
 def _positive_config_int(key: str, default: int) -> int:
     try:
         return max(1, int(default_config.get(key, default) or default))
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         return default
 
 
@@ -71,7 +71,7 @@ def xxx_contact_sheet_animation_settings() -> tuple[bool, float]:
     animated = _as_bool(default_config.get("xxx_contact_sheet_animated_webp"), default=False)
     try:
         duration = max(0.1, float(default_config.get("xxx_contact_sheet_animation_seconds", 5) or 5))
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         duration = 5.0
     return animated, duration
 
@@ -223,12 +223,12 @@ def _apply_config(config: Mapping[str, Any]) -> None:
 
     try:
         task_limit = int(default_config.get("process_limit", 1) or 1)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         task_limit = 1
 
     try:
         cutoff = int(default_config.get("cutoff_screens", 1) or 1)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         cutoff = 1
 
     ffmpeg_limit = default_config.get("ffmpeg_limit", False)
@@ -239,7 +239,7 @@ def _apply_config(config: Mapping[str, Any]) -> None:
     algorithm = str(default_config.get("algorithm", "mobius")).strip()
     try:
         desat = float(default_config.get("desat", 10.0))
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         desat = 10.0
 
 
@@ -1003,7 +1003,7 @@ async def capture_dvd_screenshot(task: tuple[int, str, str, str, Meta, float, fl
                 try:
                     if track.duration is not None:
                         video_duration = float(track.duration)
-                except TypeError, ValueError:
+                except (TypeError, ValueError):
                     video_duration = None
                 break
 
@@ -1770,6 +1770,8 @@ async def screenshots(
     # MediaInfo so an already-complete early capture is a true no-op.
     if not force_screenshots and not meta.retake and len(registered_screens) >= requested_screens:
         logger.debug(f"[yellow]Reusing {len(registered_screens)} registered screenshots from group '{group}'.[/yellow]")
+        if tone_map and any(marker in meta.hdr for marker in ("HDR", "DV", "HLG")):
+            meta.tonemapped = True
         return [str(screen) for screen in registered_screens[:requested_screens]]
 
     try:

--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -446,6 +446,12 @@ async def disc_screenshots(
     existing_screens = [p.name for p in manifest_files(base_dir, folder_id, capture_group or sanitized_filename)]
     total_existing = len(existing_screens) + len(existing_images)
     num_screens = max(0, screens - total_existing) if not force_screenshots else num_screens
+    is_hdr = any(marker in meta.hdr for marker in ("HDR", "DV", "HLG"))
+    if tone_map and is_hdr:
+        hdr_tonemap = True
+        meta.tonemapped = True
+    else:
+        hdr_tonemap = False
 
     if num_screens == 0 and not force_screenshots:
         logger.info("[bold green]Reusing existing screenshots. No additional screenshots needed.")
@@ -453,12 +459,6 @@ async def disc_screenshots(
 
     if meta.debug and not force_screenshots:
         logger.info(f"[bold yellow]Saving Screens... Total needed: {screens}, Existing: {total_existing}, To capture: {num_screens}")
-
-    if tone_map and "HDR" in meta.hdr:
-        hdr_tonemap = True
-        meta.tonemapped = True
-    else:
-        hdr_tonemap = False
 
     ss_times = await valid_ss_time([], num_screens, length, frame_rate or 24.0, meta, retake=force_screenshots)
 
@@ -1837,6 +1837,8 @@ async def screenshots(
     if not force_screenshots and not meta.retake:
         num_screens = max(0, num_screens - len(registered_screens))
     if num_screens <= 0:
+        if tone_map and any(marker in meta.hdr for marker in ("HDR", "DV", "HLG")):
+            meta.tonemapped = True
         return [str(screen) for screen in registered_screens] or None
 
     sanitized_filename = await sanitize_filename(filename)
@@ -1853,6 +1855,8 @@ async def screenshots(
 
     if existing_images_count == num_screens and not meta.retake:
         logger.debug("[yellow]The correct number of screenshots already exists. Skipping capture process.")
+        if tone_map and any(marker in meta.hdr for marker in ("HDR", "DV", "HLG")):
+            meta.tonemapped = True
         return existing_image_paths
 
     num_capture = num_screens - existing_images_count

--- a/tests/test_prep_early_screenshots.py
+++ b/tests/test_prep_early_screenshots.py
@@ -224,3 +224,48 @@ def test_early_bdmv_capture_includes_extra_discs() -> None:
 
     assert len(screenshot_spy.calls) == 2
     assert screenshot_spy.calls[1][0][-1] == "FILE_1"
+
+
+def test_early_capture_returns_meta_with_tonemapping() -> None:
+    prep = Prep.__new__(Prep)
+
+    class _TonemappingTakeScreens:
+        async def screenshots(self, *_args: object, **kwargs: object) -> None:
+            meta_arg = _args[4] if len(_args) > 4 else kwargs.get("meta")
+            if isinstance(meta_arg, Meta):
+                meta_arg.tonemapped = True
+                meta_arg.libplacebo = True
+
+    prep.takescreens_manager = _TonemappingTakeScreens()
+    prep.config = {"DEFAULT": {"multiScreens": 2}}
+    meta = Meta(category="MOVIE", keep_images=False, screens=6, hdr="HDR")
+
+    result = asyncio.run(prep._capture_early_screenshots(meta, "Release", "C:/media/Release.mkv", {}))
+
+    assert result is not None
+    assert result.tonemapped is True
+    assert result.libplacebo is True
+
+
+def test_screenshots_sets_tonemapped_when_reusing_existing_screenshots(tmp_path: Path) -> None:
+    release_id = "release_tonemap"
+    release_dir = tmp_path / "tmp" / release_id
+    screenshot_dir = release_dir / "screenshots"
+    screenshot_dir.mkdir(parents=True)
+    (release_dir / "MediaInfo.json").write_text(
+        '{"media": {"track": [{"Duration": "100"}, {"Duration": "100", "Width": "1920", "Height": "1080", "PixelAspectRatio": "1", "DisplayAspectRatio": "1.777", "FrameRate": "24"}]}}',
+        encoding="utf-8",
+    )
+    for index in range(2):
+        image = screenshot_dir / f"title-{index}.png"
+        image.write_bytes(b"image")
+    meta = Meta(category="MOVIE", base_dir=str(tmp_path), uuid=release_id, screens=2, hdr="HDR10", imghost="imgbb")
+
+    with (
+        patch("src.takescreens.tone_map", True),
+        patch("src.takescreens.get_image_host", new=AsyncMock(return_value="imgbb")),
+    ):
+        result = asyncio.run(screenshots("unused.mkv", "title", release_id, str(tmp_path), meta, num_screens=2))
+
+    assert len(result or []) == 2
+    assert meta.tonemapped is True


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved tone-mapping and frame information captured during early screenshots.
  * Improved HDR, Dolby Vision, and HLG detection for tone-mapped screenshots.
  * Applied tone-mapping status consistently when reusing existing screenshots.

* **Tests**
  * Added coverage for metadata propagation and tone-mapping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->