### PR TITLE
fix(mediainfo): prevent failures caused by the Windows path-length limit

### DIFF
--- a/src/mediainfo.py
+++ b/src/mediainfo.py
@@ -32,11 +32,14 @@ def _binary() -> str:
 def _input_path(path: str | Path) -> str:
     """Return a Windows extended-length path when MediaInfo needs one."""
     value = str(path)
-    if platform.system() != "Windows" or len(value) < 260 or value.startswith("\\\\?\\") or not ntpath.isabs(value):
+    if platform.system() != "Windows" or value.startswith("\\\\?\\") or not ntpath.isabs(value):
         return value
-    if value.startswith("\\\\"):
-        return f"\\\\?\\UNC\\{value[2:]}"
-    return f"\\\\?\\{value}"
+    normalized = ntpath.normpath(value)
+    if len(normalized) < 260:
+        return value
+    if normalized.startswith("\\\\"):
+        return f"\\\\?\\UNC\\{normalized[2:]}"
+    return f"\\\\?\\{normalized}"
 
 
 def run_mediainfo(path: str | Path, *, output: str | None = None, full: bool = True, inform: str | None = None) -> str:

--- a/src/mediainfo.py
+++ b/src/mediainfo.py
@@ -1,6 +1,8 @@
 """Compatibility layer backed by the official MediaInfo CLI."""
 
 import json
+import ntpath
+import platform
 import re
 import subprocess
 from pathlib import Path
@@ -27,6 +29,16 @@ def _binary() -> str:
     return binary
 
 
+def _input_path(path: str | Path) -> str:
+    """Return a Windows extended-length path when MediaInfo needs one."""
+    value = str(path)
+    if platform.system() != "Windows" or len(value) < 260 or value.startswith("\\\\?\\") or not ntpath.isabs(value):
+        return value
+    if value.startswith("\\\\"):
+        return f"\\\\?\\UNC\\{value[2:]}"
+    return f"\\\\?\\{value}"
+
+
 def run_mediainfo(path: str | Path, *, output: str | None = None, full: bool = True, inform: str | None = None) -> str:
     command = [_binary()]
     if output != "JSON":
@@ -37,7 +49,7 @@ def run_mediainfo(path: str | Path, *, output: str | None = None, full: bool = T
         command.append(f"--Inform={inform}")
     elif output and output != "STRING":
         command.append(f"--Output={output}")
-    command.append(str(path))
+    command.append(_input_path(path))
     try:
         result = subprocess.run(  # noqa: S603
             command,

--- a/tests/test_exportmi.py
+++ b/tests/test_exportmi.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from bin.download_integrity import SHA256_BY_ASSET
-from src.mediainfo import MediaInfo, _binary, strip_report_by_line
+from src.mediainfo import MediaInfo, _binary, _input_path, strip_report_by_line
 
 
 def test_cli_backed_mediainfo_preserves_track_access() -> None:
@@ -57,6 +57,47 @@ def test_text_reports_always_request_mediainfo_version() -> None:
         run_mediainfo("video.mkv", output="STRING", full=False)
 
     assert run.call_args.args[0] == ["mediainfo", "--inform_version=1", "video.mkv"]
+
+
+def test_mediainfo_uses_extended_windows_path_for_long_local_files() -> None:
+    path = "C:\\" + "a" * 257
+
+    with patch("src.mediainfo.platform.system", return_value="Windows"):
+        assert _input_path(path) == f"\\\\?\\{path}"
+
+
+def test_mediainfo_uses_extended_windows_path_for_long_unc_files() -> None:
+    path = "\\\\server\\share\\" + "a" * 250
+
+    with patch("src.mediainfo.platform.system", return_value="Windows"):
+        assert _input_path(path) == f"\\\\?\\UNC\\{path[2:]}"
+
+
+def test_mediainfo_does_not_modify_short_or_non_windows_paths() -> None:
+    short_path = "C:\\short\\file.m4b"
+    long_path = "C:\\" + "a" * 257
+
+    with patch("src.mediainfo.platform.system", return_value="Windows"):
+        assert _input_path(short_path) == short_path
+        assert _input_path(f"\\\\?\\{long_path}") == f"\\\\?\\{long_path}"
+    with patch("src.mediainfo.platform.system", return_value="Linux"):
+        assert _input_path(long_path) == long_path
+
+
+def test_mediainfo_passes_extended_path_to_cli() -> None:
+    path = "C:\\" + "a" * 257
+    completed = Mock(returncode=0, stdout="General", stderr="")
+
+    with (
+        patch("src.mediainfo.platform.system", return_value="Windows"),
+        patch("src.mediainfo._binary", return_value="mediainfo"),
+        patch("src.mediainfo.subprocess.run", return_value=completed) as run,
+    ):
+        from src.mediainfo import run_mediainfo
+
+        run_mediainfo(path, output="STRING", full=False)
+
+    assert run.call_args.args[0][-1] == f"\\\\?\\{path}"
 
 
 def test_mediainfo_prefers_configured_binary(tmp_path) -> None:

--- a/tests/test_exportmi.py
+++ b/tests/test_exportmi.py
@@ -1,5 +1,6 @@
 # ruff: noqa: S101
 import asyncio
+import ntpath
 import subprocess
 from unittest.mock import Mock, patch
 
@@ -71,6 +72,20 @@ def test_mediainfo_uses_extended_windows_path_for_long_unc_files() -> None:
 
     with patch("src.mediainfo.platform.system", return_value="Windows"):
         assert _input_path(path) == f"\\\\?\\UNC\\{path[2:]}"
+
+
+@pytest.mark.parametrize(
+    ("path", "prefix"),
+    [
+        ("C:/" + "segment/" * 90 + "./nested/../file.m4b", "\\\\?\\"),
+        ("//server/share/" + "segment/" * 90 + "./nested/../file.m4b", "\\\\?\\UNC\\"),
+    ],
+)
+def test_mediainfo_normalizes_long_windows_paths_before_prefixing(path: str, prefix: str) -> None:
+    normalized = ntpath.normpath(path)
+
+    with patch("src.mediainfo.platform.system", return_value="Windows"):
+        assert _input_path(path) == f"{prefix}{normalized[2:] if prefix.endswith('UNC\\') else normalized}"
 
 
 def test_mediainfo_does_not_modify_short_or_non_windows_paths() -> None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MediaInfo handling for very long Windows file paths.
  * Added support for long local and network (UNC) paths while preserving existing behavior for shorter and non-Windows paths.
  * Prevented failures caused by the Windows path-length limit when processing media files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->