### PR TITLE
fix: dupe prompt order

### DIFF
--- a/src/uphelper.py
+++ b/src/uphelper.py
@@ -1,6 +1,7 @@
 # Upload Assistant © 2025 Audionut & wastaken7 — Licensed under UAPL v1.0
 import asyncio
 import contextlib
+import contextvars
 import json
 import re
 import sys
@@ -20,6 +21,8 @@ from src.config_helpers import format_terminal_link
 from src.console import logger, prompt_in_thread
 from src.meta import Meta
 from src.trackersetup import tracker_class_map
+
+_dupe_prompt_lock_held = contextvars.ContextVar("dupe_prompt_lock_held", default=False)
 
 DupeEntry = dict[str, Any]
 
@@ -252,10 +255,21 @@ class UploadHelper:
 
     async def prompt_yes_no(self, question: str, *, default: bool = False) -> bool:
         """Ask one interactive question at a time without blocking the event loop."""
+        if _dupe_prompt_lock_held.get():
+            return await prompt_in_thread(cli_ui.ask_yes_no, question, default=default)
         async with self._prompt_lock:
             return await prompt_in_thread(cli_ui.ask_yes_no, question, default=default)
 
     async def dupe_check(self, dupes: list[DupeEntry | str], meta: Meta, tracker_name: str) -> tuple[bool, Meta]:
+        """Show duplicate results and their confirmation as one atomic console interaction."""
+        async with self._prompt_lock:
+            token = _dupe_prompt_lock_held.set(True)
+            try:
+                return await self._dupe_check(dupes, meta, tracker_name)
+            finally:
+                _dupe_prompt_lock_held.reset(token)
+
+    async def _dupe_check(self, dupes: list[DupeEntry | str], meta: Meta, tracker_name: str) -> tuple[bool, Meta]:
         def _format_dupe(entry: DupeEntry | str) -> str:
             if isinstance(entry, dict):
                 name = str(entry.get("name", ""))

--- a/tests/test_uphelper_prompts.py
+++ b/tests/test_uphelper_prompts.py
@@ -39,6 +39,44 @@ async def test_prompt_yes_no_serializes_concurrent_prompts(monkeypatch: pytest.M
 
 
 @pytest.mark.asyncio
+async def test_dupe_check_keeps_each_result_list_with_its_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+    first_started = threading.Event()
+    release_first = threading.Event()
+    messages: list[str] = []
+    prompts: list[str] = []
+
+    class Tracker:
+        async def get_name(self, meta: Meta) -> dict[str, str]:
+            return {"name": meta.name}
+
+    def ask_yes_no(question: str, default: bool = False) -> bool:
+        del default
+        prompts.append(question)
+        if len(prompts) == 1:
+            first_started.set()
+            assert release_first.wait(timeout=1)
+        return True
+
+    helper = UploadHelper({"DEFAULT": {}})
+    helper.tracker_class_map = {"FIRST": lambda **_kwargs: Tracker(), "SECOND": lambda **_kwargs: Tracker()}
+    monkeypatch.setattr("src.uphelper.cli_ui.ask_yes_no", ask_yes_no)
+    monkeypatch.setattr("src.uphelper.logger.info", lambda message, **_kwargs: messages.append(message))
+
+    first = asyncio.create_task(helper.dupe_check(["first dupe"], Meta(category="TV", name="First"), "FIRST"))
+    assert await asyncio.to_thread(first_started.wait, 1)
+
+    second = asyncio.create_task(helper.dupe_check(["second dupe"], Meta(category="TV", name="Second"), "SECOND"))
+    await asyncio.sleep(0)
+    assert messages == ["[bold blue]FIRST[/bold blue]: Check if these are actually dupes:", "", "[bold cyan]first dupe[/bold cyan]"]
+
+    release_first.set()
+    await asyncio.gather(first, second)
+
+    assert prompts == ["Upload to FIRST anyway?", "Upload to SECOND anyway?"]
+    assert messages[-3:] == ["[bold blue]SECOND[/bold blue]: Check if these are actually dupes:", "", "[bold cyan]second dupe[/bold cyan]"]
+
+
+@pytest.mark.asyncio
 async def test_bdinfo_comparison_prompt_uses_rich_markup(monkeypatch: pytest.MonkeyPatch) -> None:
     question: str | None = None
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrent duplicate checks so each check retains its own results and prompt state.
  * Prevented duplicate prompts from interfering with one another during overlapping checks.

* **Tests**
  * Added regression coverage validating independent tracker results, prompt ordering, and delayed output during concurrent duplicate checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->