### PR TITLE
fix: ensure numeric CLI arguments are parsed as expected types

### DIFF
--- a/src/args.py
+++ b/src/args.py
@@ -780,12 +780,30 @@ class Args:
                     elif key == "description_file" or key == "comparison":
                         meta[key] = str(Path(value2).resolve())
                     elif key == "screens":
-                        meta[key] = int(value2)
-                    elif key == "trackers_pass":
                         try:
-                            meta.trackers_pass = int(value2)
+                            meta[key] = int(value2)
                         except ValueError, TypeError:
-                            meta.trackers_pass = None
+                            meta[key] = int(self.config.get("DEFAULT", {}).get("screens", 1))
+                    elif key in ("trackers_pass", "comparison_index"):
+                        try:
+                            meta[key] = int(value2)
+                        except ValueError, TypeError:
+                            meta[key] = None
+                    elif key in (
+                        "limit_queue",
+                        "randomized",
+                        "max_piece_size",
+                        "entropy",
+                        "douban_manual",
+                        "music_release_year",
+                        "music_edition_year",
+                        "qbit_bandwidth_threshold",
+                        "qbit_bandwidth_time",
+                    ):
+                        try:
+                            meta[key] = int(value2)
+                        except ValueError, TypeError:
+                            meta[key] = 0
                     elif key == "imghost":
                         meta.imghost = value2
                         meta.imghost_from_cli = True
@@ -855,11 +873,17 @@ class Args:
                 if isinstance(value, list):
                     value_list = [str(item) for item in value]
                     if len(value_list) == 1 and value_list[0] != "":
-                        meta[key] = int(value_list[0])
+                        try:
+                            meta[key] = int(value_list[0])
+                        except ValueError, TypeError:
+                            meta[key] = 0
                     else:
                         meta[key] = 0
                 elif value not in (None, [], 0, ""):
-                    meta[key] = int(str(value))
+                    try:
+                        meta[key] = int(str(value))
+                    except ValueError, TypeError:
+                        meta[key] = 0
                 else:
                     meta[key] = 0
             if key in ("manual_edition"):
@@ -888,11 +912,17 @@ class Args:
                 if isinstance(value, list):
                     value_list = [str(item) for item in value]
                     if len(value_list) == 1 and value_list[0] != "":
-                        meta[key] = float(value_list[0])
+                        try:
+                            meta[key] = float(value_list[0])
+                        except ValueError, TypeError:
+                            meta[key] = None
                     else:
                         meta[key] = None
                 elif value not in (None, [], ""):
-                    meta[key] = float(str(value))
+                    try:
+                        meta[key] = float(str(value))
+                    except ValueError, TypeError:
+                        meta[key] = None
                 else:
                     meta[key] = None
             if key in ("freeleech", "freeleech_until", "double_upload_until"):

--- a/src/args.py
+++ b/src/args.py
@@ -141,7 +141,7 @@ class Args:
             help="Read one full path per line from standard input (finish an interactive paste with an empty line)",
         )
         parser.add_argument("--queue", nargs=1, required=False, help="(--queue queue_name) Process an entire folder (files/subfolders) in a queue")
-        parser.add_argument("-lq", "--limit-queue", dest="limit_queue", nargs=1, required=False, help="Limit the amount of queue files processed", type=int, default=0)
+        parser.add_argument("-lq", "--limit-queue", dest="limit_queue", nargs=1, required=False, help="Limit the amount of queue files processed", default=0)
         parser.add_argument(
             "-sc",
             "--site-check",
@@ -177,7 +177,6 @@ class Args:
             nargs=1,
             required=False,
             help="Which of your comparison indexes is the main images (required when comps)",
-            type=int,
             default=None,
         )
         parser.add_argument("-mf", "--manual_frames", nargs=1, required=False, help="Comma-separated frame numbers to use as screenshots", type=str, default=None)
@@ -213,9 +212,9 @@ class Args:
             dest="music_release_type",
         )
         parser.add_argument(
-            "--music-release-year", nargs=1, required=False, type=int, help="MUSIC: concrete release/pressing year (not the original group year)", dest="music_release_year"
+            "--music-release-year", nargs=1, required=False, help="MUSIC: concrete release/pressing year (not the original group year)", dest="music_release_year"
         )
-        parser.add_argument("--music-edition-year", nargs=1, required=False, type=int, help="MUSIC: remaster/reissue/edition year", dest="music_edition_year")
+        parser.add_argument("--music-edition-year", nargs=1, required=False, help="MUSIC: remaster/reissue/edition year", dest="music_edition_year")
         parser.add_argument("--music-label", nargs=1, required=False, help="MUSIC: label for this release", dest="music_label")
         parser.add_argument("--music-catalogue-number", nargs=1, required=False, help="MUSIC: catalogue number for this release", dest="music_catalogue_number")
         parser.add_argument("--music-genre", nargs=1, required=False, help="MUSIC: comma-separated genre override", dest="music_genres")
@@ -262,7 +261,7 @@ class Args:
         parser.add_argument("-mal", "--mal", nargs=1, required=False, help="MAL ID", type=str, dest="mal_manual")
         parser.add_argument("-tvmaze", "--tvmaze", nargs=1, required=False, help="TVMAZE ID", type=str, dest="tvmaze_manual")
         parser.add_argument("-tvdb", "--tvdb", nargs=1, required=False, help="TVDB ID", type=str, dest="tvdb_manual")
-        parser.add_argument("-douban", "--douban", nargs=1, required=False, help="Douban ID (Number only)", type=int, dest="douban_manual", default=0)
+        parser.add_argument("-douban", "--douban", nargs=1, required=False, help="Douban ID (Number only)", dest="douban_manual", default=0)
         parser.add_argument("--no-metadata-cache", action="store_true", required=False, help="Do not read or write the persistent metadata cache", dest="no_metadata_cache")
         parser.add_argument("-igdb", "--igdb", nargs=1, required=False, help="IGDB ID", type=str, dest="igdb_manual")
         parser.add_argument("-steam", "--steam", nargs=1, required=False, help="Steam App ID or URL", type=str, dest="steam_manual")
@@ -306,7 +305,7 @@ class Args:
             type=str,
         )
         parser.add_argument("-ns", "--no-seed", action="store_true", required=False, help="Do not add torrent to the client")
-        parser.add_argument("-year", "--year", dest="manual_year", nargs=1, required=False, help="Override the year found", type=int, default=0)
+        parser.add_argument("-year", "--year", dest="manual_year", nargs=1, required=False, help="Override the year found", default=0)
         parser.add_argument("-author", "--author", nargs="*", required=False, help="Book/Audiobook author name (overrides auto-detected value)", type=str, dest="book_author")
         parser.add_argument("-btitle", "--book-title", nargs="*", required=False, help="Book/Audiobook title (overrides auto-detected value)", type=str, dest="book_title")
         parser.add_argument("--comic", "-comic", action="store_true", required=False, help="Identify the book upload as a Comic", dest="comic", default=False)
@@ -568,7 +567,6 @@ class Args:
             nargs=1,
             required=False,
             help="Ignore dupes if their size difference is greater than or equal to this percentage (e.g. 20)",
-            type=float,
         )
         parser.add_argument(
             "-debug", "--debug", action="store_true", required=False, help="Debug Mode, will run through all the motions providing extra info, but will not upload to trackers."
@@ -625,10 +623,10 @@ class Args:
             "-qbcon", "--qbit-bw-control", action="store_true", required=False, help="Enable qBittorrent bandwidth control logic before upload", dest="qbit_bandwidth_control"
         )
         parser.add_argument(
-            "-qbcrl", "--qbit-bw-threshold", nargs=1, required=False, help="qBittorrent bandwidth limit threshold (KB/s)", type=int, dest="qbit_bandwidth_threshold"
+            "-qbcrl", "--qbit-bw-threshold", nargs=1, required=False, help="qBittorrent bandwidth limit threshold (KB/s)", dest="qbit_bandwidth_threshold"
         )
         parser.add_argument(
-            "-qbctime", "--qbit-bw-time", nargs=1, required=False, help="Time to stay under qBittorrent threshold (seconds)", type=int, dest="qbit_bandwidth_time"
+            "-qbctime", "--qbit-bw-time", nargs=1, required=False, help="Time to stay under qBittorrent threshold (seconds)", dest="qbit_bandwidth_time"
         )
         parser.add_argument(
             "-uo",
@@ -656,7 +654,6 @@ class Args:
             nargs=1,
             required=False,
             help="How many trackers need to pass all checks (dupe/banned group/etc) to actually proceed to uploading",
-            type=int,
         )
         parser.add_argument("-rt", "--randomized", nargs=1, required=False, help="Number of extra, torrents with random infohash", default=0)
         parser.add_argument(
@@ -666,7 +663,6 @@ class Args:
             nargs=1,
             required=False,
             help="Use entropy in created torrents. (32 or 64) bits (ie: -entropy 32). Not supported at all sites, you many need to redownload the torrent",
-            type=int,
             default=0,
         )
         parser.add_argument("-ua", "--unattended", action="store_true", required=False, help=argparse.SUPPRESS)
@@ -782,12 +778,12 @@ class Args:
                     elif key == "screens":
                         try:
                             meta[key] = int(value2)
-                        except ValueError, TypeError:
+                        except (ValueError, TypeError):
                             meta[key] = int(self.config.get("DEFAULT", {}).get("screens", 1))
                     elif key in ("trackers_pass", "comparison_index"):
                         try:
                             meta[key] = int(value2)
-                        except ValueError, TypeError:
+                        except (ValueError, TypeError):
                             meta[key] = None
                     elif key in (
                         "limit_queue",
@@ -802,7 +798,7 @@ class Args:
                     ):
                         try:
                             meta[key] = int(value2)
-                        except ValueError, TypeError:
+                        except (ValueError, TypeError):
                             meta[key] = 0
                     elif key == "imghost":
                         meta.imghost = value2
@@ -875,14 +871,14 @@ class Args:
                     if len(value_list) == 1 and value_list[0] != "":
                         try:
                             meta[key] = int(value_list[0])
-                        except ValueError, TypeError:
+                        except (ValueError, TypeError):
                             meta[key] = 0
                     else:
                         meta[key] = 0
                 elif value not in (None, [], 0, ""):
                     try:
                         meta[key] = int(str(value))
-                    except ValueError, TypeError:
+                    except (ValueError, TypeError):
                         meta[key] = 0
                 else:
                     meta[key] = 0
@@ -914,14 +910,14 @@ class Args:
                     if len(value_list) == 1 and value_list[0] != "":
                         try:
                             meta[key] = float(value_list[0])
-                        except ValueError, TypeError:
+                        except (ValueError, TypeError):
                             meta[key] = None
                     else:
                         meta[key] = None
                 elif value not in (None, [], ""):
                     try:
                         meta[key] = float(str(value))
-                    except ValueError, TypeError:
+                    except (ValueError, TypeError):
                         meta[key] = None
                 else:
                     meta[key] = None
@@ -932,7 +928,7 @@ class Args:
                         try:
                             parsed_int = int(value_list[0])
                             meta[key] = parsed_int if parsed_int >= 0 else 0
-                        except ValueError, TypeError:
+                        except (ValueError, TypeError):
                             meta[key] = 0
                     else:
                         meta[key] = 0
@@ -940,7 +936,7 @@ class Args:
                     try:
                         parsed_int = int(str(value))
                         meta[key] = parsed_int if parsed_int >= 0 else 0
-                    except ValueError, TypeError:
+                    except (ValueError, TypeError):
                         meta[key] = 0
                 else:
                     meta[key] = 0

--- a/tests/test_tracker_id_args.py
+++ b/tests/test_tracker_id_args.py
@@ -176,3 +176,113 @@ def test_numeric_cli_arguments_parsed_as_correct_types(tmp_path):
     assert isinstance(meta.double_upload_until, int)
 
 
+def test_invalid_trackers_pass_defaults_to_none(tmp_path):
+    """Test that invalid trackers_pass values are handled by fallback logic (defaults to None)."""
+    config = {"DEFAULT": {"screens": 1}}
+    args = Args(config)
+
+    meta, _, _ = args.parse([str(tmp_path), "--trackers-pass", "invalid"], Meta())
+
+    assert meta.trackers_pass is None
+
+
+def test_invalid_comparison_index_defaults_to_none(tmp_path):
+    """Test that invalid comparison_index values are handled by fallback logic (defaults to None)."""
+    config = {"DEFAULT": {"screens": 1}}
+    args = Args(config)
+
+    meta, _, _ = args.parse([str(tmp_path), "--comparison_index", "not-a-number"], Meta())
+
+    assert meta.comparison_index is None
+
+
+def test_invalid_limit_queue_defaults_to_zero(tmp_path):
+    """Test that invalid limit_queue values are handled by fallback logic (defaults to 0)."""
+    config = {"DEFAULT": {"screens": 1}}
+    args = Args(config)
+
+    meta, _, _ = args.parse([str(tmp_path), "--limit-queue", "invalid"], Meta())
+
+    assert meta.limit_queue == 0
+
+
+def test_invalid_year_defaults_to_zero(tmp_path):
+    """Test that invalid year values are handled by fallback logic (defaults to 0)."""
+    config = {"DEFAULT": {"screens": 1}}
+    args = Args(config)
+
+    meta, _, _ = args.parse([str(tmp_path), "--year", "invalid"], Meta())
+
+    assert meta.manual_year == 0
+
+
+def test_invalid_dupe_size_difference_tolerance_defaults_to_none(tmp_path):
+    """Test that invalid dupe-size-difference-tolerance values are handled by fallback logic (defaults to None)."""
+    config = {"DEFAULT": {"screens": 1}}
+    args = Args(config)
+
+    meta, _, _ = args.parse([str(tmp_path), "--dupe-size-difference-tolerance", "not-a-float"], Meta())
+
+    assert meta.dupe_size_difference_tolerance is None
+
+
+def test_invalid_entropy_defaults_to_zero(tmp_path):
+    """Test that invalid entropy values are handled by fallback logic (defaults to 0)."""
+    config = {"DEFAULT": {"screens": 1}}
+    args = Args(config)
+
+    meta, _, _ = args.parse([str(tmp_path), "--entropy", "invalid"], Meta())
+
+    assert meta.entropy == 0
+
+
+def test_invalid_douban_defaults_to_zero(tmp_path):
+    """Test that invalid douban values are handled by fallback logic (defaults to 0)."""
+    config = {"DEFAULT": {"screens": 1}}
+    args = Args(config)
+
+    meta, _, _ = args.parse([str(tmp_path), "--douban", "invalid"], Meta())
+
+    assert meta.douban_manual == 0
+
+
+def test_invalid_music_release_year_defaults_to_zero(tmp_path):
+    """Test that invalid music-release-year values are handled by fallback logic (defaults to 0)."""
+    config = {"DEFAULT": {"screens": 1}}
+    args = Args(config)
+
+    meta, _, _ = args.parse([str(tmp_path), "--music-release-year", "not-a-year"], Meta())
+
+    assert meta.music_release_year == 0
+
+
+def test_invalid_music_edition_year_defaults_to_zero(tmp_path):
+    """Test that invalid music-edition-year values are handled by fallback logic (defaults to 0)."""
+    config = {"DEFAULT": {"screens": 1}}
+    args = Args(config)
+
+    meta, _, _ = args.parse([str(tmp_path), "--music-edition-year", "not-a-year"], Meta())
+
+    assert meta.music_edition_year == 0
+
+
+def test_invalid_qbit_bandwidth_threshold_defaults_to_zero(tmp_path):
+    """Test that invalid qbit-bw-threshold values are handled by fallback logic (defaults to 0)."""
+    config = {"DEFAULT": {"screens": 1}}
+    args = Args(config)
+
+    meta, _, _ = args.parse([str(tmp_path), "--qbit-bw-threshold", "invalid"], Meta())
+
+    assert meta.qbit_bandwidth_threshold == 0
+
+
+def test_invalid_qbit_bandwidth_time_defaults_to_zero(tmp_path):
+    """Test that invalid qbit-bw-time values are handled by fallback logic (defaults to 0)."""
+    config = {"DEFAULT": {"screens": 1}}
+    args = Args(config)
+
+    meta, _, _ = args.parse([str(tmp_path), "--qbit-bw-time", "invalid"], Meta())
+
+    assert meta.qbit_bandwidth_time == 0
+
+

--- a/tests/test_tracker_id_args.py
+++ b/tests/test_tracker_id_args.py
@@ -79,3 +79,100 @@ def test_trackers_pass_parsed_as_int(tmp_path):
     assert meta.trackers_pass == 2
     assert isinstance(meta.trackers_pass, int)
 
+
+def test_numeric_cli_arguments_parsed_as_correct_types(tmp_path):
+    config = {"DEFAULT": {"screens": 2}}
+    args = Args(config)
+
+    cli_input = [
+        str(tmp_path),
+        "--trackers-pass",
+        "3",
+        "--screens",
+        "5",
+        "--limit-queue",
+        "10",
+        "--comparison_index",
+        "2",
+        "--randomized",
+        "4",
+        "--max-piece-size",
+        "64",
+        "--entropy",
+        "32",
+        "--douban",
+        "123456",
+        "--music-release-year",
+        "2021",
+        "--music-edition-year",
+        "2023",
+        "--qbit-bw-threshold",
+        "500",
+        "--qbit-bw-time",
+        "30",
+        "--year",
+        "1994",
+        "--dupe-size-difference-tolerance",
+        "15.5",
+        "--freeleech",
+        "100",
+        "--freeleech-until",
+        "7",
+        "--double-upload-until",
+        "14",
+    ]
+
+    meta, _, _ = args.parse(cli_input, Meta())
+
+    assert meta.trackers_pass == 3
+    assert isinstance(meta.trackers_pass, int)
+
+    assert meta.screens == 5
+    assert isinstance(meta.screens, int)
+
+    assert meta.limit_queue == 10
+    assert isinstance(meta.limit_queue, int)
+
+    assert meta.comparison_index == 2
+    assert isinstance(meta.comparison_index, int)
+
+    assert meta.randomized == 4
+    assert isinstance(meta.randomized, int)
+
+    assert meta.max_piece_size == 64
+    assert isinstance(meta.max_piece_size, int)
+
+    assert meta.entropy == 32
+    assert isinstance(meta.entropy, int)
+
+    assert meta.douban_manual == 123456
+    assert isinstance(meta.douban_manual, int)
+
+    assert meta.music_release_year == 2021
+    assert isinstance(meta.music_release_year, int)
+
+    assert meta.music_edition_year == 2023
+    assert isinstance(meta.music_edition_year, int)
+
+    assert meta.qbit_bandwidth_threshold == 500
+    assert isinstance(meta.qbit_bandwidth_threshold, int)
+
+    assert meta.qbit_bandwidth_time == 30
+    assert isinstance(meta.qbit_bandwidth_time, int)
+
+    assert meta.manual_year == 1994
+    assert isinstance(meta.manual_year, int)
+
+    assert meta.dupe_size_difference_tolerance == 15.5
+    assert isinstance(meta.dupe_size_difference_tolerance, float)
+
+    assert meta.freeleech == 100
+    assert isinstance(meta.freeleech, int)
+
+    assert meta.freeleech_until == 7
+    assert isinstance(meta.freeleech_until, int)
+
+    assert meta.double_upload_until == 14
+    assert isinstance(meta.double_upload_until, int)
+
+

--- a/upload.py
+++ b/upload.py
@@ -2798,6 +2798,7 @@ async def do_the_thing(base_dir: str) -> None:
                         processed_files_count += 1
                         tracker_statuses = [status for status in meta.tracker_status.values() if isinstance(status, Mapping)]
                         upload_succeeded = any(status.get("upload_success") is True for status in tracker_statuses)
+
                         if not upload_succeeded and not meta.debug:
                             skipped_files_count += 1
                             logger.info(f"[yellow]Processed {processed_files_count}/{total_files} files; no tracker upload succeeded.[/yellow]")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line argument handling for invalid numeric values.
  * Applied safe fallback values instead of displaying conversion errors.
  * Invalid year and duplicate-size tolerance inputs now receive appropriate defaults.

* **Tests**
  * Added coverage for parsing integer and decimal command-line options, including value types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->