### PR TITLE
fix(webui): support XXX cover workflow

### DIFF
--- a/src/media_extensions.py
+++ b/src/media_extensions.py
@@ -1,0 +1,5 @@
+"""Shared media filename-extension sets."""
+
+from __future__ import annotations
+
+VIDEO_EXTENSIONS = frozenset({".avi", ".m2ts", ".m4v", ".mkv", ".mov", ".mp4", ".mpeg", ".mpg", ".ts", ".webm", ".wmv"})

--- a/src/media_extensions.py
+++ b/src/media_extensions.py
@@ -3,3 +3,5 @@
 from __future__ import annotations
 
 VIDEO_EXTENSIONS = frozenset({".avi", ".m2ts", ".m4v", ".mkv", ".mov", ".mp4", ".mpeg", ".mpg", ".ts", ".webm", ".wmv"})
+AUDIO_EXTENSIONS = frozenset({".flac", ".mp3", ".m4a", ".aac", ".ac3", ".dts", ".wav", ".aiff", ".alac", ".ogg", ".opus", ".ape", ".wv"})
+ARTWORK_EXTENSIONS = frozenset({".jpg", ".jpeg", ".png", ".webp"})

--- a/src/music/analyzer.py
+++ b/src/music/analyzer.py
@@ -13,10 +13,9 @@ from typing import Any
 
 import mutagen
 
+from src.media_extensions import ARTWORK_EXTENSIONS, AUDIO_EXTENSIONS
 from src.music.models import AudioTrack, MetadataSource, MusicRelease
 
-AUDIO_EXTENSIONS = {".flac", ".mp3", ".m4a", ".aac", ".ac3", ".dts", ".wav", ".aiff", ".alac", ".ogg", ".opus", ".ape", ".wv"}
-ARTWORK_EXTENSIONS = {".jpg", ".jpeg", ".png", ".webp"}
 LINEAGE_NAMES = ("lineage", "equipment", "transfer", "rip", "source")
 DISC_RE = re.compile(r"(?:^|[ _.-])(?:cd|disc|disk)[ _.-]?(\d{1,2})(?:$|[ _.-])", re.I)
 YEAR_RE = re.compile(r"(?:^|[^0-9])((?:19|20)\d{2})(?:[^0-9]|$)")

--- a/src/prep.py
+++ b/src/prep.py
@@ -220,6 +220,9 @@ class Prep:
 
         await prepare_artwork(meta)
 
+        if meta.category == "XXX":
+            await self.takescreens_manager.xxx_fallback_cover(meta.filelist or [], meta.uuid, meta.base_dir, meta)
+
         await languages_manager.process_desc_language(meta)
 
         # Ensure the background capture is complete before the upload stage

--- a/src/prep_helpers.py
+++ b/src/prep_helpers.py
@@ -26,6 +26,7 @@ from src.exportmi import export_info, get_conformance_error, mi_resolution, vali
 from src.get_source import get_source
 from src.imdb import imdb_manager
 from src.languages import languages_manager
+from src.media_extensions import VIDEO_EXTENSIONS
 from src.meta import Meta
 from src.region import get_distributor, get_region, get_service
 from src.tags import get_tag, tag_override
@@ -40,7 +41,7 @@ _URL_TOKEN_RE = re.compile(r"https?://[^\s<>'\"()]+", re.IGNORECASE)
 
 XXX_RELEASE_MARKERS = XXX_PLATFORM_KEYWORDS | {"xxx"}
 _XXX_RELEASE_MARKER_RE = re.compile(rf"(?<![a-z0-9])(?:{'|'.join(re.escape(marker) for marker in sorted(XXX_RELEASE_MARKERS))})(?![a-z0-9])", re.IGNORECASE)
-_VIDEO_EXTENSIONS = frozenset({".avi", ".m2ts", ".m4v", ".mkv", ".mov", ".mp4", ".mpeg", ".mpg", ".ts", ".webm", ".wmv"})
+_VIDEO_EXTENSIONS = VIDEO_EXTENSIONS
 
 
 def is_xxx_video_release(path: str | Path) -> bool:

--- a/src/screenshot_review.py
+++ b/src/screenshot_review.py
@@ -20,7 +20,7 @@ from src.screenshot_manifest import files as manifest_files
 from src.screenshot_manifest import forget_file, group_for
 from src.takescreens import capture_screenshot, determine_tonemapping, disc_screenshots, get_frame_info, screenshot_par_scale_factors
 
-_SCREENSHOT_FILE = re.compile(r"^(?P<prefix>.+)-(?P<index>\d+)\.png$", re.IGNORECASE)
+_SCREENSHOT_FILE = re.compile(r"^(?P<prefix>.+)-(?P<index>\d+)\.(?:png|jpe?g|webp)$", re.IGNORECASE)
 _EXCLUDED_NAMES = {"poster.png", "cover.png", "music_cover.png"}
 _review_locks: dict[str, threading.Lock] = {}
 _review_locks_guard = threading.Lock()
@@ -81,7 +81,7 @@ def list_screenshots(temp_dir: Path, _meta_data: Mapping[str, object]) -> list[R
     manifest_paths = manifest_files(temp_dir.parent.parent, temp_dir.name)
     manifest_names = {path.name for path in manifest_paths}
     screenshot_dir = temp_dir / "screenshots"
-    local_paths = screenshot_dir.iterdir() if screenshot_dir.is_dir() else ()
+    local_paths = sorted(screenshot_dir.iterdir(), key=lambda path: path.name.casefold()) if screenshot_dir.is_dir() else ()
     paths = [*manifest_paths, *(path for path in local_paths if path.name not in manifest_names)]
     for fallback_index, path in enumerate(paths):
         if not _is_reviewable_file(path):

--- a/src/screenshot_review.py
+++ b/src/screenshot_review.py
@@ -63,7 +63,7 @@ def _save_review(temp_dir: Path, review: Mapping[str, Any]) -> None:
 
 def _is_reviewable_file(path: Path) -> bool:
     name = path.name.casefold()
-    return path.is_file() and path.suffix.casefold() == ".png" and name not in _EXCLUDED_NAMES and "libplacebo-test" not in name
+    return path.is_file() and path.suffix.casefold() in {".png", ".jpg", ".jpeg", ".webp"} and name not in _EXCLUDED_NAMES and "libplacebo-test" not in name
 
 
 def _local_id(temp_dir: Path, path: Path) -> str:
@@ -80,7 +80,9 @@ def list_screenshots(temp_dir: Path, _meta_data: Mapping[str, object]) -> list[R
     candidates: list[ReviewedScreenshot] = []
     manifest_paths = manifest_files(temp_dir.parent.parent, temp_dir.name)
     manifest_names = {path.name for path in manifest_paths}
-    paths = [*manifest_paths, *(path for path in (temp_dir / "screenshots").glob("*.png") if path.name not in manifest_names)]
+    screenshot_dir = temp_dir / "screenshots"
+    local_paths = screenshot_dir.iterdir() if screenshot_dir.is_dir() else ()
+    paths = [*manifest_paths, *(path for path in local_paths if path.name not in manifest_names)]
     for fallback_index, path in enumerate(paths):
         if not _is_reviewable_file(path):
             continue

--- a/src/screenshot_review.py
+++ b/src/screenshot_review.py
@@ -22,6 +22,7 @@ from src.takescreens import capture_screenshot, determine_tonemapping, disc_scre
 
 _SCREENSHOT_FILE = re.compile(r"^(?P<prefix>.+)-(?P<index>\d+)\.(?:png|jpe?g|webp)$", re.IGNORECASE)
 _EXCLUDED_NAMES = {"poster.png", "cover.png", "music_cover.png"}
+_EXCLUDED_STEMS = {Path(name).stem.casefold() for name in _EXCLUDED_NAMES}
 _review_locks: dict[str, threading.Lock] = {}
 _review_locks_guard = threading.Lock()
 
@@ -63,7 +64,7 @@ def _save_review(temp_dir: Path, review: Mapping[str, Any]) -> None:
 
 def _is_reviewable_file(path: Path) -> bool:
     name = path.name.casefold()
-    return path.is_file() and path.suffix.casefold() in {".png", ".jpg", ".jpeg", ".webp"} and name not in _EXCLUDED_NAMES and "libplacebo-test" not in name
+    return path.is_file() and path.suffix.casefold() in {".png", ".jpg", ".jpeg", ".webp"} and path.stem.casefold() not in _EXCLUDED_STEMS and "libplacebo-test" not in name
 
 
 def _local_id(temp_dir: Path, path: Path) -> str:

--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -7,6 +7,7 @@ import os
 import platform
 import random
 import re
+import secrets
 import sys
 import time
 import traceback
@@ -179,6 +180,54 @@ async def xxx_contact_sheets(paths: list[str], folder_id: str, base_dir: str, me
     sheets = [str(path) for path in register_screenshots(base_dir, folder_id, results, capture_group)] if results else []
     meta.screens = len(sheets)
     return sheets
+
+
+async def xxx_fallback_cover(paths: list[str], folder_id: str, base_dir: str, meta: Meta, random_frame: bool = False) -> str | None:
+    """Create a poster from a representative frame when XXX has no artwork."""
+    if meta.category != "XXX" or (is_valid_cover_image(meta.artwork_path) and not random_frame):
+        return meta.artwork_path if is_valid_cover_image(meta.artwork_path) else None
+
+    video_path = next((Path(path) for path in paths if Path(path).is_file()), None)
+    if video_path is None:
+        logger.warning("[yellow]XXX has no valid video available to generate a fallback cover.[/yellow]")
+        return None
+
+    output_path = artwork_dir(base_dir, folder_id) / "POSTER.png"
+    try:
+        probe = await asyncio.to_thread(ffmpeg.probe, str(video_path))
+        duration = float(probe["format"]["duration"])
+        if duration <= 0:
+            raise ValueError("duration must be positive")
+
+        # Avoid the opening frame, which is frequently black or only a logo.
+        lower = min(max(duration * 0.10, 1.0), max(duration - 0.1, 0.0))
+        upper = max(lower, min(duration * 0.85, max(duration - 0.1, 0.0)))
+        timestamp = secrets.SystemRandom().uniform(lower, upper) if random_frame and upper > lower else lower
+        stream = ffmpeg.input(str(video_path), ss=str(timestamp))
+        command = ffmpeg.output(
+            stream,
+            str(output_path),
+            vframes=1,
+            vf="scale=1200:-2:force_original_aspect_ratio=decrease",
+            compression_level=ffmpeg_compression,
+        ).global_args("-y", "-loglevel", "verbose" if meta.ffdebug else "quiet")
+        return_code, _stdout, stderr = await run_ffmpeg(command)
+        if return_code != 0 or not is_valid_cover_image(output_path):
+            raise RuntimeError(stderr.decode(errors="replace").strip() or "FFmpeg did not produce a valid image")
+    except Exception as error:
+        logger.warning(f"[yellow]Unable to generate the XXX fallback cover from {video_path.name}: {error}[/yellow]")
+        return None
+
+    meta.artwork_path = str(output_path)
+    meta.artwork_url = ""
+    logger.warning(
+        "[yellow]No XXX cover was found after checking, in order: explicit --poster, "
+        "a local artwork sidecar, and provider artwork. For the local search, place a valid "
+        "GIF/JPG/JPEG/PNG/WEBP image beside the media (or inside the release folder) with a "
+        "filename containing one of: poster, cover, front, folder, artwork. "
+        f"Generated a fallback cover from a video frame: {output_path.name}.[/yellow]"
+    )
+    return str(output_path)
 
 
 def compile_ffmpeg_command(command: Any) -> list[str]:
@@ -2766,6 +2815,9 @@ class TakeScreensManager:
 
     async def xxx_contact_sheets(self, paths: list[str], folder_id: str, base_dir: str, meta: Meta, capture_group: str = "main") -> list[str]:
         return await xxx_contact_sheets(paths, folder_id, base_dir, meta, capture_group)
+
+    async def xxx_fallback_cover(self, paths: list[str], folder_id: str, base_dir: str, meta: Meta, random_frame: bool = False) -> str | None:
+        return await xxx_fallback_cover(paths, folder_id, base_dir, meta, random_frame)
 
     async def prepare_book_cover(self, path: str, folder_id: str, base_dir: str, meta: Meta) -> str | None:
         return await prepare_book_cover(path, folder_id, base_dir, meta)

--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -187,18 +187,29 @@ async def xxx_fallback_cover(paths: list[str], folder_id: str, base_dir: str, me
     if meta.category != "XXX" or (is_valid_cover_image(meta.artwork_path) and not random_frame):
         return meta.artwork_path if is_valid_cover_image(meta.artwork_path) else None
 
-    video_path = next((Path(path) for path in paths if Path(path).is_file()), None)
+    video_path: Path | None = None
+    duration = 0.0
+    for candidate in paths:
+        candidate_path = Path(candidate)
+        if not candidate_path.is_file():
+            continue
+        try:
+            probe = await asyncio.to_thread(ffmpeg.probe, str(candidate_path))
+            candidate_duration = float(probe["format"]["duration"])
+            if candidate_duration <= 0:
+                continue
+        except OSError, KeyError, TypeError, ValueError, ffmpeg.Error:
+            continue
+        video_path = candidate_path
+        duration = candidate_duration
+        break
+
     if video_path is None:
         logger.warning("[yellow]XXX has no valid video available to generate a fallback cover.[/yellow]")
         return None
 
     output_path = artwork_dir(base_dir, folder_id) / "POSTER.png"
     try:
-        probe = await asyncio.to_thread(ffmpeg.probe, str(video_path))
-        duration = float(probe["format"]["duration"])
-        if duration <= 0:
-            raise ValueError("duration must be positive")
-
         # Avoid the opening frame, which is frequently black or only a logo.
         lower = min(max(duration * 0.10, 1.0), max(duration - 0.1, 0.0))
         upper = max(lower, min(duration * 0.85, max(duration - 0.1, 0.0)))

--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -55,7 +55,7 @@ def is_valid_lostimg_image_size(image_size: int) -> bool:
 def _positive_config_int(key: str, default: int) -> int:
     try:
         return max(1, int(default_config.get(key, default) or default))
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         return default
 
 
@@ -73,7 +73,7 @@ def xxx_contact_sheet_animation_settings() -> tuple[bool, float]:
     animated = _as_bool(default_config.get("xxx_contact_sheet_animated_webp"), default=False)
     try:
         duration = max(0.1, float(default_config.get("xxx_contact_sheet_animation_seconds", 5) or 5))
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         duration = 5.0
     return animated, duration
 
@@ -203,7 +203,7 @@ async def xxx_fallback_cover(paths: list[str], folder_id: str, base_dir: str, me
             has_video_stream = isinstance(streams, list) and any(isinstance(stream, Mapping) and stream.get("codec_type") == "video" for stream in streams)
             if candidate_duration <= 0 or not has_video_stream:
                 continue
-        except OSError, KeyError, TypeError, ValueError, ffmpeg.Error:
+        except (OSError, KeyError, TypeError, ValueError, ffmpeg.Error):
             continue
         video_path = candidate_path
         duration = candidate_duration
@@ -288,12 +288,12 @@ def _apply_config(config: Mapping[str, Any]) -> None:
 
     try:
         task_limit = int(default_config.get("process_limit", 1) or 1)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         task_limit = 1
 
     try:
         cutoff = int(default_config.get("cutoff_screens", 1) or 1)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         cutoff = 1
 
     ffmpeg_limit = default_config.get("ffmpeg_limit", False)
@@ -304,7 +304,7 @@ def _apply_config(config: Mapping[str, Any]) -> None:
     algorithm = str(default_config.get("algorithm", "mobius")).strip()
     try:
         desat = float(default_config.get("desat", 10.0))
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         desat = 10.0
 
 
@@ -1068,7 +1068,7 @@ async def capture_dvd_screenshot(task: tuple[int, str, str, str, Meta, float, fl
                 try:
                     if track.duration is not None:
                         video_duration = float(track.duration)
-                except TypeError, ValueError:
+                except (TypeError, ValueError):
                     video_duration = None
                 break
 

--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -196,7 +196,9 @@ async def xxx_fallback_cover(paths: list[str], folder_id: str, base_dir: str, me
         try:
             probe = await asyncio.to_thread(ffmpeg.probe, str(candidate_path))
             candidate_duration = float(probe["format"]["duration"])
-            if candidate_duration <= 0:
+            streams = probe.get("streams", [])
+            has_video_stream = isinstance(streams, list) and any(isinstance(stream, Mapping) and stream.get("codec_type") == "video" for stream in streams)
+            if candidate_duration <= 0 or not has_video_stream:
                 continue
         except OSError, KeyError, TypeError, ValueError, ffmpeg.Error:
             continue

--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -26,6 +26,7 @@ from src.artwork import is_public_http_url, is_valid_cover_image, is_valid_image
 from src.binaries import configured_binary
 from src.cleanup import cleanup_manager
 from src.console import logger
+from src.media_extensions import VIDEO_EXTENSIONS
 from src.mediainfo import MediaInfo
 from src.meta import Meta
 from src.screenshot_manifest import clear_group as clear_screenshot_group
@@ -192,6 +193,8 @@ async def xxx_fallback_cover(paths: list[str], folder_id: str, base_dir: str, me
     for candidate in paths:
         candidate_path = Path(candidate)
         if not candidate_path.is_file():
+            continue
+        if candidate_path.suffix and candidate_path.suffix.casefold() not in VIDEO_EXTENSIONS:
             continue
         try:
             probe = await asyncio.to_thread(ffmpeg.probe, str(candidate_path))

--- a/tests/test_execution_preview.py
+++ b/tests/test_execution_preview.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+
+from web_ui import server
 from web_ui.server import _extract_execution_preview
 
 
@@ -37,3 +40,22 @@ def test_execution_preview_uses_local_cover_for_active_session(tmp_path, monkeyp
     preview = _extract_execution_preview({"uuid": "release-1", "category": "XXX"}, str(tmp_path), "session-1")
 
     assert preview["poster_url"].startswith("/api/execution_preview_cover?session_id=session-1&v=release-1%3A")  # noqa: S101
+    assert preview["media_id"] == "release-1"  # noqa: S101
+
+
+def test_cover_regeneration_rejects_a_preview_that_has_moved(monkeypatch):
+    monkeypatch.setattr(server, "_webui_auth_ok", lambda: True)
+    monkeypatch.setattr(server, "_verify_csrf_header", lambda: True)
+    monkeypatch.setattr(server, "_verify_same_origin", lambda: True)
+    monkeypatch.setattr(
+        server,
+        "_resolve_execution_preview_meta",
+        lambda _session_id: ("C:/media/second", Path("meta.json"), {"uuid": "second", "category": "XXX"}),
+    )
+
+    response = server.app.test_client().post(
+        "/api/execution_preview_cover/regenerate",
+        json={"session_id": "session-1", "media_id": "first"},
+    )
+
+    assert response.status_code == 409  # noqa: S101

--- a/tests/test_execution_preview.py
+++ b/tests/test_execution_preview.py
@@ -27,3 +27,13 @@ def test_execution_preview_prefers_current_tv_artwork_url():
     )
 
     assert preview["poster_url"] == "https://images.example/show-poster.jpg"  # noqa: S101
+
+
+def test_execution_preview_uses_local_cover_for_active_session(tmp_path, monkeypatch):
+    cover = tmp_path / "POSTER.png"
+    cover.write_bytes(b"png")
+    monkeypatch.setattr("web_ui.server._find_execution_preview_cover_file", lambda session_id: cover if session_id == "session-1" else None)
+
+    preview = _extract_execution_preview({"uuid": "release-1", "category": "XXX"}, str(tmp_path), "session-1")
+
+    assert preview["poster_url"].startswith("/api/execution_preview_cover?session_id=session-1&v=release-1%3A")  # noqa: S101

--- a/tests/test_execution_preview.py
+++ b/tests/test_execution_preview.py
@@ -59,3 +59,31 @@ def test_cover_regeneration_rejects_a_preview_that_has_moved(monkeypatch):
     )
 
     assert response.status_code == 409  # noqa: S101
+
+
+def test_cover_regeneration_uses_execution_path_name_when_uuid_is_missing(monkeypatch):
+    captured = {}
+
+    async def fake_fallback_cover(_paths, folder_id, _base_dir, _meta, random_frame=False):
+        captured["folder_id"] = folder_id
+        captured["random_frame"] = random_frame
+        return "POSTER.png"
+
+    monkeypatch.setattr(server, "_webui_auth_ok", lambda: True)
+    monkeypatch.setattr(server, "_verify_csrf_header", lambda: True)
+    monkeypatch.setattr(server, "_verify_same_origin", lambda: True)
+    monkeypatch.setattr(
+        server,
+        "_resolve_execution_preview_meta",
+        lambda _session_id: ("C:/media/release-folder", Path("meta.json"), {"base_dir": "C:/state", "category": "XXX", "filelist": []}),
+    )
+    monkeypatch.setattr("src.takescreens.xxx_fallback_cover", fake_fallback_cover)
+    monkeypatch.setattr(server, "_execution_preview_cover_cache_key", lambda _session_id, fallback: fallback)
+
+    response = server.app.test_client().post(
+        "/api/execution_preview_cover/regenerate",
+        json={"session_id": "session-1", "media_id": "C:/media/release-folder"},
+    )
+
+    assert response.status_code == 200  # noqa: S101
+    assert captured == {"folder_id": "release-folder", "random_frame": True}  # noqa: S101

--- a/tests/test_screenshot_review.py
+++ b/tests/test_screenshot_review.py
@@ -103,6 +103,15 @@ def test_list_screenshots_orders_numeric_jpeg_and_webp_frames(tmp_path: Path) ->
     assert [item.path for item in items] == [two, ten]
 
 
+def test_list_screenshots_excludes_reserved_artwork_stems_for_all_formats(tmp_path: Path) -> None:
+    screenshots_dir = tmp_path / "screenshots"
+    screenshots_dir.mkdir()
+    for filename in ("poster.jpg", "cover.jpeg", "music_cover.webp"):
+        (screenshots_dir / filename).write_bytes(b"artwork")
+
+    assert list_screenshots(tmp_path, {"category": "XXX"}) == []
+
+
 def test_add_bdmv_screenshot_uses_disc_capture_and_opaque_id(tmp_path: Path, monkeypatch) -> None:
     release_id = "release"
     screenshots_dir = tmp_path / "tmp" / release_id / "screenshots"

--- a/tests/test_screenshot_review.py
+++ b/tests/test_screenshot_review.py
@@ -90,6 +90,19 @@ def test_list_screenshots_includes_webp_contact_sheets(tmp_path: Path) -> None:
     assert [item.path for item in items] == [webp]
 
 
+def test_list_screenshots_orders_numeric_jpeg_and_webp_frames(tmp_path: Path) -> None:
+    screenshots_dir = tmp_path / "screenshots"
+    screenshots_dir.mkdir()
+    ten = screenshots_dir / "Release-10.webp"
+    two = screenshots_dir / "Release-2.jpg"
+    ten.write_bytes(b"webp")
+    two.write_bytes(b"jpg")
+
+    items = list_screenshots(tmp_path, {"category": "XXX"})
+
+    assert [item.path for item in items] == [two, ten]
+
+
 def test_add_bdmv_screenshot_uses_disc_capture_and_opaque_id(tmp_path: Path, monkeypatch) -> None:
     release_id = "release"
     screenshots_dir = tmp_path / "tmp" / release_id / "screenshots"

--- a/tests/test_screenshot_review.py
+++ b/tests/test_screenshot_review.py
@@ -79,6 +79,17 @@ def test_list_screenshots_includes_disc_video_frames_with_stable_opaque_ids(tmp_
     assert regular[0].id.startswith("local-")
 
 
+def test_list_screenshots_includes_webp_contact_sheets(tmp_path: Path) -> None:
+    screenshots_dir = tmp_path / "screenshots"
+    screenshots_dir.mkdir()
+    webp = screenshots_dir / "xxx-contact-sheet-1.webp"
+    webp.write_bytes(b"webp")
+
+    items = list_screenshots(tmp_path, {"category": "XXX"})
+
+    assert [item.path for item in items] == [webp]
+
+
 def test_add_bdmv_screenshot_uses_disc_capture_and_opaque_id(tmp_path: Path, monkeypatch) -> None:
     release_id = "release"
     screenshots_dir = tmp_path / "tmp" / release_id / "screenshots"

--- a/tests/test_xxx_contact_sheets.py
+++ b/tests/test_xxx_contact_sheets.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from PIL import Image
 
 from src import takescreens
 from src.meta import Meta
@@ -100,3 +101,33 @@ async def test_animated_xxx_contact_sheet_is_registered_as_webp(tmp_path, monkey
     assert "libwebp_anim" in commands[0]
     assert "-t 5.0" in commands[0]
     assert "drawtext" in commands[0]
+
+
+@pytest.mark.asyncio
+async def test_xxx_fallback_cover_uses_a_video_frame(tmp_path, monkeypatch):
+    video = tmp_path / "OnlyFans.Creator.mp4"
+    video.write_bytes(b"video")
+    commands = []
+
+    def fake_probe(_path):
+        return {"format": {"duration": "60"}}
+
+    async def fake_run_ffmpeg(command):
+        command_args = takescreens.compile_ffmpeg_command(command)
+        commands.append(" ".join(command_args))
+        output = Path(takescreens.get_ffmpeg_output_path(command, command_args))
+        output.parent.mkdir(parents=True, exist_ok=True)
+        Image.new("RGB", (120, 80), "purple").save(output, format="PNG")
+        return 0, b"", b""
+
+    monkeypatch.setattr(takescreens.ffmpeg, "probe", fake_probe)
+    monkeypatch.setattr(takescreens, "run_ffmpeg", fake_run_ffmpeg)
+    meta = Meta(base_dir=str(tmp_path), uuid="fallback-cover", category="XXX")
+
+    cover = await takescreens.xxx_fallback_cover([str(video)], meta.uuid, meta.base_dir, meta)
+
+    assert cover == str(tmp_path / "tmp" / "fallback-cover" / "artwork" / "POSTER.png")
+    assert meta.artwork_path == cover
+    assert meta.artwork_url == ""
+    assert "scale=1200:-2:force_original_aspect_ratio=decrease" in commands[0]
+    assert "-ss 6.0" in commands[0]

--- a/tests/test_xxx_contact_sheets.py
+++ b/tests/test_xxx_contact_sheets.py
@@ -135,7 +135,7 @@ async def test_xxx_fallback_cover_uses_a_video_frame(tmp_path, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_xxx_fallback_cover_skips_unprobeable_candidates(tmp_path, monkeypatch):
-    invalid = tmp_path / "release.nfo"
+    invalid = tmp_path / "release.mkv"
     video = tmp_path / "OnlyFans.Creator.mp4"
     invalid.write_bytes(b"nfo")
     video.write_bytes(b"video")
@@ -166,7 +166,7 @@ async def test_xxx_fallback_cover_skips_unprobeable_candidates(tmp_path, monkeyp
 
 @pytest.mark.asyncio
 async def test_xxx_fallback_cover_skips_audio_only_candidates(tmp_path, monkeypatch):
-    audio = tmp_path / "release.flac"
+    audio = tmp_path / "release.mkv"
     video = tmp_path / "OnlyFans.Creator.mp4"
     audio.write_bytes(b"audio")
     video.write_bytes(b"video")

--- a/tests/test_xxx_contact_sheets.py
+++ b/tests/test_xxx_contact_sheets.py
@@ -46,7 +46,7 @@ async def test_xxx_contact_sheets_create_one_grid_per_video_up_to_configured_lim
     commands = []
 
     def fake_probe(_path):
-        return {"format": {"duration": "60"}}
+        return {"format": {"duration": "60"}, "streams": [{"codec_type": "video"}]}
 
     async def fake_run_ffmpeg(command):
         commands.append(" ".join(takescreens.compile_ffmpeg_command(command)))
@@ -79,7 +79,7 @@ async def test_animated_xxx_contact_sheet_is_registered_as_webp(tmp_path, monkey
     commands = []
 
     def fake_probe(_path):
-        return {"format": {"duration": "60"}}
+        return {"format": {"duration": "60"}, "streams": [{"codec_type": "video"}]}
 
     async def fake_run_ffmpeg(command):
         command_args = takescreens.compile_ffmpeg_command(command)
@@ -110,7 +110,7 @@ async def test_xxx_fallback_cover_uses_a_video_frame(tmp_path, monkeypatch):
     commands = []
 
     def fake_probe(_path):
-        return {"format": {"duration": "60"}}
+        return {"format": {"duration": "60"}, "streams": [{"codec_type": "video"}]}
 
     async def fake_run_ffmpeg(command):
         command_args = takescreens.compile_ffmpeg_command(command)
@@ -144,8 +144,8 @@ async def test_xxx_fallback_cover_skips_unprobeable_candidates(tmp_path, monkeyp
     def fake_probe(path):
         probed.append(Path(path).name)
         if Path(path) == invalid:
-            return {"format": {"duration": "0"}}
-        return {"format": {"duration": "60"}}
+            return {"format": {"duration": "0"}, "streams": [{"codec_type": "video"}]}
+        return {"format": {"duration": "60"}, "streams": [{"codec_type": "video"}]}
 
     async def fake_run_ffmpeg(command):
         command_args = takescreens.compile_ffmpeg_command(command)
@@ -162,3 +162,34 @@ async def test_xxx_fallback_cover_skips_unprobeable_candidates(tmp_path, monkeyp
 
     assert cover is not None
     assert probed == [invalid.name, video.name]
+
+
+@pytest.mark.asyncio
+async def test_xxx_fallback_cover_skips_audio_only_candidates(tmp_path, monkeypatch):
+    audio = tmp_path / "release.flac"
+    video = tmp_path / "OnlyFans.Creator.mp4"
+    audio.write_bytes(b"audio")
+    video.write_bytes(b"video")
+    probed = []
+
+    def fake_probe(path):
+        probed.append(Path(path).name)
+        if Path(path) == audio:
+            return {"format": {"duration": "42"}, "streams": [{"codec_type": "audio"}]}
+        return {"format": {"duration": "60"}, "streams": [{"codec_type": "video"}]}
+
+    async def fake_run_ffmpeg(command):
+        command_args = takescreens.compile_ffmpeg_command(command)
+        output = Path(takescreens.get_ffmpeg_output_path(command, command_args))
+        output.parent.mkdir(parents=True, exist_ok=True)
+        Image.new("RGB", (120, 80), "purple").save(output, format="PNG")
+        return 0, b"", b""
+
+    monkeypatch.setattr(takescreens.ffmpeg, "probe", fake_probe)
+    monkeypatch.setattr(takescreens, "run_ffmpeg", fake_run_ffmpeg)
+    meta = Meta(base_dir=str(tmp_path), uuid="fallback-audio-only", category="XXX")
+
+    cover = await takescreens.xxx_fallback_cover([str(audio), str(video)], meta.uuid, meta.base_dir, meta)
+
+    assert cover is not None
+    assert probed == [audio.name, video.name]

--- a/tests/test_xxx_contact_sheets.py
+++ b/tests/test_xxx_contact_sheets.py
@@ -131,3 +131,34 @@ async def test_xxx_fallback_cover_uses_a_video_frame(tmp_path, monkeypatch):
     assert meta.artwork_url == ""
     assert "scale=1200:-2:force_original_aspect_ratio=decrease" in commands[0]
     assert "-ss 6.0" in commands[0]
+
+
+@pytest.mark.asyncio
+async def test_xxx_fallback_cover_skips_unprobeable_candidates(tmp_path, monkeypatch):
+    invalid = tmp_path / "release.nfo"
+    video = tmp_path / "OnlyFans.Creator.mp4"
+    invalid.write_bytes(b"nfo")
+    video.write_bytes(b"video")
+    probed = []
+
+    def fake_probe(path):
+        probed.append(Path(path).name)
+        if Path(path) == invalid:
+            return {"format": {"duration": "0"}}
+        return {"format": {"duration": "60"}}
+
+    async def fake_run_ffmpeg(command):
+        command_args = takescreens.compile_ffmpeg_command(command)
+        output = Path(takescreens.get_ffmpeg_output_path(command, command_args))
+        output.parent.mkdir(parents=True, exist_ok=True)
+        Image.new("RGB", (120, 80), "purple").save(output, format="PNG")
+        return 0, b"", b""
+
+    monkeypatch.setattr(takescreens.ffmpeg, "probe", fake_probe)
+    monkeypatch.setattr(takescreens, "run_ffmpeg", fake_run_ffmpeg)
+    meta = Meta(base_dir=str(tmp_path), uuid="fallback-candidate", category="XXX")
+
+    cover = await takescreens.xxx_fallback_cover([str(invalid), str(video)], meta.uuid, meta.base_dir, meta)
+
+    assert cover is not None
+    assert probed == [invalid.name, video.name]

--- a/web_ui/server.py
+++ b/web_ui/server.py
@@ -1899,6 +1899,7 @@ def _extract_execution_preview(meta_data: Mapping[str, object], fallback_path: s
     tv_pack_raw = _stringify_preview_value(meta_data.get("tv_pack")).lower()
 
     return {
+        "media_id": _stringify_preview_value(meta_data.get("uuid")) or fallback_path,
         "path": _stringify_preview_value(meta_data.get("path")) or fallback_path,
         "filename": Path(fallback_path).name,
         "title": title or _stringify_preview_value(music.get("album")),
@@ -2174,6 +2175,7 @@ class ProgressItem(TypedDict, total=False):
 class ExecutionPreview(TypedDict, total=False):
     """Serialized preview data for the media currently being processed."""
 
+    media_id: str
     path: str
     filename: str
     title: str
@@ -4543,9 +4545,13 @@ def regenerate_execution_preview_cover():
 
     payload = _request_json_dict()
     session_id = _stringify_preview_value(payload.get("session_id"))
-    _execution_path, meta_file, meta_data = _resolve_execution_preview_meta(session_id)
+    execution_path, meta_file, meta_data = _resolve_execution_preview_meta(session_id)
     if meta_file is None or meta_data is None:
         return jsonify({"success": False, "error": "Execution metadata is not available yet"}), 404
+    media_id = _stringify_preview_value(payload.get("media_id"))
+    current_media_id = _stringify_preview_value(meta_data.get("uuid")) or execution_path
+    if not media_id or media_id != current_media_id:
+        return jsonify({"success": False, "error": "The execution preview has moved to another item"}), 409
     if _stringify_preview_value(meta_data.get("category")).upper() != "XXX":
         return jsonify({"success": False, "error": "Cover regeneration is only available for XXX"}), 400
 

--- a/web_ui/server.py
+++ b/web_ui/server.py
@@ -34,6 +34,7 @@ import psutil
 import web_ui.auth as auth_mod
 from src.webui_progress import ProgressEvent, clear_progress_callback, reset_progress, set_progress_callback
 from src.app_paths import CODE_DIR, STATE_DIR
+from src.meta import Meta
 
 
 def _module_name(*parts: str) -> str:
@@ -1488,6 +1489,16 @@ def _execution_preview_cover_url(preview_session_id: str, cache_key: str) -> str
     return f"/api/execution_preview_cover?session_id={urllib.parse.quote(preview_session_id, safe='')}&v={version}"
 
 
+def _execution_preview_cover_cache_key(session_id: str, fallback: str) -> str:
+    cover_file = _find_execution_preview_cover_file(session_id)
+    if cover_file is None:
+        return fallback
+    try:
+        return f"{fallback}:{cover_file.stat().st_mtime_ns}"
+    except OSError:
+        return fallback
+
+
 def _music_cover_from_meta(meta_data: Mapping[str, object], preview_session_id: str) -> str:
     """Return a public cover URL or the authenticated local-preview endpoint."""
     for key in ("cover", "poster"):
@@ -1860,7 +1871,7 @@ def _music_preview_from_meta(meta_data: Mapping[str, object]) -> dict[str, objec
     }
 
 
-def _extract_execution_preview(meta_data: Mapping[str, object], fallback_path: str) -> ExecutionPreview:
+def _extract_execution_preview(meta_data: Mapping[str, object], fallback_path: str, preview_session_id: str = "") -> ExecutionPreview:
     title = _stringify_preview_value(meta_data.get("title")) or _stringify_preview_value(meta_data.get("name"))
     original_title = _stringify_preview_value(meta_data.get("original_title"))
     category = _stringify_preview_value(meta_data.get("category")).upper()
@@ -1868,6 +1879,12 @@ def _extract_execution_preview(meta_data: Mapping[str, object], fallback_path: s
     # contract for MOVIE/TV.  Keep the older fields as fallbacks so previews
     # remain available for already-created temp metadata.
     poster_url = _stringify_preview_value(meta_data.get("artwork_url")) or _stringify_preview_value(meta_data.get("poster"))
+    if not poster_url and preview_session_id and _find_execution_preview_cover_file(preview_session_id) is not None:
+        cache_key = _execution_preview_cover_cache_key(
+            preview_session_id,
+            _stringify_preview_value(meta_data.get("uuid")) or fallback_path,
+        )
+        poster_url = _execution_preview_cover_url(preview_session_id, cache_key)
     if category == "MUSIC":
         poster_url = _music_cover_from_meta(meta_data, _stringify_preview_value(meta_data.get("webui_session_id")))
     tmdb_poster = _stringify_preview_value(meta_data.get("tmdb_poster_path")) or _stringify_preview_value(meta_data.get("tmdb_poster"))
@@ -1950,7 +1967,7 @@ def _find_execution_preview(session_id: str) -> ExecutionPreview | None:
                         console.print(f"Execution preview cover enrichment failed for session {session_id}: {err}", markup=False)
             if _stringify_preview_value(meta_data.get("category")).upper() == "MUSIC":
                 meta_data = {**meta_data, "webui_session_id": session_id}
-            preview = _extract_execution_preview(meta_data, execution_path)
+            preview = _extract_execution_preview(meta_data, execution_path, session_id)
             preview["awaiting_input"] = bool(process_info.get("awaiting_input"))
             preview["input_type"] = process_info.get("input_type")
             preview["progress"] = _progress_items_for_process(process_info)
@@ -4516,6 +4533,41 @@ def execution_preview_cover():
 
     mimetype = mimetypes.guess_type(str(cover_file))[0] or "application/octet-stream"
     return send_file(cover_file, mimetype=mimetype, conditional=True, max_age=30)
+
+
+@app.route("/api/execution_preview_cover/regenerate", methods=["POST"])
+def regenerate_execution_preview_cover():
+    """Regenerate the local XXX preview cover from another video frame."""
+    if not _verify_csrf_header() or not _verify_same_origin():
+        return jsonify({"success": False, "error": "CSRF/Origin validation failed"}), 403
+
+    payload = _request_json_dict()
+    session_id = _stringify_preview_value(payload.get("session_id"))
+    _execution_path, meta_file, meta_data = _resolve_execution_preview_meta(session_id)
+    if meta_file is None or meta_data is None:
+        return jsonify({"success": False, "error": "Execution metadata is not available yet"}), 404
+    if _stringify_preview_value(meta_data.get("category")).upper() != "XXX":
+        return jsonify({"success": False, "error": "Cover regeneration is only available for XXX"}), 400
+
+    try:
+        from src.takescreens import xxx_fallback_cover
+
+        meta = Meta(dict(meta_data))
+        cover = asyncio.run(xxx_fallback_cover(list(meta.filelist or []), meta.uuid, meta.base_dir, meta, random_frame=True))
+        if not cover:
+            return jsonify({"success": False, "error": "Could not generate a new cover from the source video"}), 422
+        cache_key = _execution_preview_cover_cache_key(session_id, meta.uuid or str(meta_file))
+        return jsonify(
+            {
+                "success": True,
+                "poster_url": _execution_preview_cover_url(session_id, cache_key),
+            }
+        )
+    except (FileNotFoundError, ValueError) as error:
+        return jsonify({"success": False, "error": str(error)}), 404
+    except Exception as error:
+        console.print(f"XXX cover regeneration failed for {session_id}: {error}", markup=False)
+        return jsonify({"success": False, "error": "Could not regenerate the XXX cover"}), 500
 
 
 @app.route("/api/execution_screenshots")

--- a/web_ui/server.py
+++ b/web_ui/server.py
@@ -4559,10 +4559,11 @@ def regenerate_execution_preview_cover():
         from src.takescreens import xxx_fallback_cover
 
         meta = Meta(dict(meta_data))
-        cover = asyncio.run(xxx_fallback_cover(list(meta.filelist or []), meta.uuid, meta.base_dir, meta, random_frame=True))
+        folder_id = meta.uuid or Path(execution_path).name
+        cover = asyncio.run(xxx_fallback_cover(list(meta.filelist or []), folder_id, meta.base_dir, meta, random_frame=True))
         if not cover:
             return jsonify({"success": False, "error": "Could not generate a new cover from the source video"}), 422
-        cache_key = _execution_preview_cover_cache_key(session_id, meta.uuid or str(meta_file))
+        cache_key = _execution_preview_cover_cache_key(session_id, folder_id)
         return jsonify(
             {
                 "success": True,

--- a/web_ui/static/js/app.js
+++ b/web_ui/static/js/app.js
@@ -2396,6 +2396,11 @@ function AudionutsUAGUI() {
     };
   }, [API_BASE, isExecuting, sessionId]);
 
+  useEffect(() => {
+    coverRequestRef.current += 1;
+    setCoverAction("");
+  }, [executionPreview?.media_id]);
+
   const refreshExecutionScreenshots = async () => {
     const refreshed = await apiFetch(
       `${API_BASE}/execution_screenshots?session_id=${encodeURIComponent(sessionId)}`,
@@ -2436,14 +2441,15 @@ function AudionutsUAGUI() {
   };
 
   const regenerateExecutionCover = async () => {
-    if (!sessionId || coverAction) return;
+    const mediaId = executionPreview?.media_id;
+    if (!sessionId || !mediaId || coverAction) return;
     const requestToken = ++coverRequestRef.current;
     setCoverAction("regenerate");
     try {
       const response = await apiFetch(`${API_BASE}/execution_preview_cover/regenerate`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ session_id: sessionId }),
+        body: JSON.stringify({ session_id: sessionId, media_id: mediaId }),
       });
       const data = await response.json().catch(() => null);
       if (!response.ok || !data?.success) {
@@ -2452,7 +2458,9 @@ function AudionutsUAGUI() {
       }
       if (coverRequestRef.current === requestToken) {
         setExecutionPreview((previous) =>
-          previous ? { ...previous, poster_url: data.poster_url } : previous,
+          previous?.media_id === mediaId
+            ? { ...previous, poster_url: data.poster_url }
+            : previous,
         );
       }
     } catch (error) {

--- a/web_ui/static/js/app.js
+++ b/web_ui/static/js/app.js
@@ -1497,6 +1497,7 @@ function AudionutsUAGUI() {
     useState(false);
   const [screenshotActionId, setScreenshotActionId] = useState("");
   const [coverAction, setCoverAction] = useState("");
+  const coverRequestRef = useRef(0);
   const [expandedScreenshot, setExpandedScreenshot] = useState(null);
   const themePaletteRef = useRef(null);
   const screenshotModalRef = useRef(null);
@@ -2277,6 +2278,7 @@ function AudionutsUAGUI() {
   }, [hasDescFile, hasDescLink]);
 
   useEffect(() => {
+    coverRequestRef.current += 1;
     if (!isExecuting || !sessionId) {
       setExecutionPreview(null);
       setProgressItems([]);
@@ -2435,6 +2437,7 @@ function AudionutsUAGUI() {
 
   const regenerateExecutionCover = async () => {
     if (!sessionId || coverAction) return;
+    const requestToken = ++coverRequestRef.current;
     setCoverAction("regenerate");
     try {
       const response = await apiFetch(`${API_BASE}/execution_preview_cover/regenerate`, {
@@ -2447,14 +2450,16 @@ function AudionutsUAGUI() {
         window.alert(data?.error || "Could not regenerate the XXX cover.");
         return;
       }
-      setExecutionPreview((previous) =>
-        previous ? { ...previous, poster_url: data.poster_url } : previous,
-      );
+      if (coverRequestRef.current === requestToken) {
+        setExecutionPreview((previous) =>
+          previous ? { ...previous, poster_url: data.poster_url } : previous,
+        );
+      }
     } catch (error) {
       console.error("Could not regenerate XXX cover:", error);
       window.alert("Could not regenerate the XXX cover. Please try again.");
     } finally {
-      setCoverAction("");
+      if (coverRequestRef.current === requestToken) setCoverAction("");
     }
   };
 
@@ -4788,10 +4793,17 @@ function AudionutsUAGUI() {
                     type="button"
                     onClick={regenerateExecutionCover}
                     disabled={Boolean(coverAction)}
+                    aria-label={
+                      coverAction === "regenerate"
+                        ? "Generating a new XXX cover"
+                        : "Generate a new XXX cover"
+                    }
                     className={`flex-shrink-0 inline-flex items-center gap-1.5 rounded-lg px-2.5 py-2 text-xs font-semibold transition-colors disabled:cursor-wait disabled:opacity-60 ${isDarkMode ? "bg-purple-700 text-white hover:bg-purple-600" : "bg-purple-600 text-white hover:bg-purple-700"}`}
                     title="Generate another cover from a different video frame"
                   >
-                    {coverAction === "regenerate" ? <SpinnerIcon /> : <RefreshIcon />}
+                    <span aria-hidden="true">
+                      {coverAction === "regenerate" ? <SpinnerIcon /> : <RefreshIcon />}
+                    </span>
                   </button>
                 )}
               </div>

--- a/web_ui/static/js/app.js
+++ b/web_ui/static/js/app.js
@@ -4780,7 +4780,10 @@ function AudionutsUAGUI() {
                     className="max-w-full max-h-full object-contain"
                   />
                 </div>
-                {category === "XXX" && (
+                {category === "XXX" &&
+                  String(media.poster_url).startsWith(
+                    "/api/execution_preview_cover?",
+                  ) && (
                   <button
                     type="button"
                     onClick={regenerateExecutionCover}

--- a/web_ui/static/js/app.js
+++ b/web_ui/static/js/app.js
@@ -1241,6 +1241,22 @@ const SpinnerIcon = () => (
   </svg>
 );
 
+const RefreshIcon = () => (
+  <svg
+    className="w-4 h-4"
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M20 11a8.1 8.1 0 00-14.8-4.5L3 9m0 0V4m0 5h5M4 13a8.1 8.1 0 0014.8 4.5L21 15m0 0v5m0-5h-5"
+    />
+  </svg>
+);
+
 const metadataProviderStyles = {
   tmdb: {
     light: "border-[#06B4E2] bg-transparent text-[#067A98]",
@@ -1480,6 +1496,7 @@ function AudionutsUAGUI() {
   const [canAddExecutionScreenshot, setCanAddExecutionScreenshot] =
     useState(false);
   const [screenshotActionId, setScreenshotActionId] = useState("");
+  const [coverAction, setCoverAction] = useState("");
   const [expandedScreenshot, setExpandedScreenshot] = useState(null);
   const themePaletteRef = useRef(null);
   const screenshotModalRef = useRef(null);
@@ -2271,6 +2288,7 @@ function AudionutsUAGUI() {
       setDescriptionVersion(0);
       setDescriptionDirty(false);
       setCanAddExecutionScreenshot(false);
+      setCoverAction("");
       setExpandedScreenshot(null);
       setIsScreenshotReviewOpen(false);
       setIsDescriptionReviewOpen(false);
@@ -2412,6 +2430,31 @@ function AudionutsUAGUI() {
       window.alert(`Could not ${action} screenshot. Please try again.`);
     } finally {
       setScreenshotActionId("");
+    }
+  };
+
+  const regenerateExecutionCover = async () => {
+    if (!sessionId || coverAction) return;
+    setCoverAction("regenerate");
+    try {
+      const response = await apiFetch(`${API_BASE}/execution_preview_cover/regenerate`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ session_id: sessionId }),
+      });
+      const data = await response.json().catch(() => null);
+      if (!response.ok || !data?.success) {
+        window.alert(data?.error || "Could not regenerate the XXX cover.");
+        return;
+      }
+      setExecutionPreview((previous) =>
+        previous ? { ...previous, poster_url: data.poster_url } : previous,
+      );
+    } catch (error) {
+      console.error("Could not regenerate XXX cover:", error);
+      window.alert("Could not regenerate the XXX cover. Please try again.");
+    } finally {
+      setCoverAction("");
     }
   };
 
@@ -4728,13 +4771,26 @@ function AudionutsUAGUI() {
           >
             {media?.poster_url ? (
               <div
-                className={`w-full ${posterHeight} flex items-center justify-center p-3 ${isDarkMode ? "bg-gray-950" : "bg-stone-100"}`}
+                className={`w-full ${posterHeight} flex items-center justify-center gap-3 p-3 ${isDarkMode ? "bg-gray-950" : "bg-stone-100"}`}
               >
-                <img
-                  src={media.poster_url}
-                  alt={previewTitle}
-                  className="max-w-full max-h-full object-contain"
-                />
+                <div className="min-w-0 h-full flex-1 flex items-center justify-center">
+                  <img
+                    src={media.poster_url}
+                    alt={previewTitle}
+                    className="max-w-full max-h-full object-contain"
+                  />
+                </div>
+                {category === "XXX" && (
+                  <button
+                    type="button"
+                    onClick={regenerateExecutionCover}
+                    disabled={Boolean(coverAction)}
+                    className={`flex-shrink-0 inline-flex items-center gap-1.5 rounded-lg px-2.5 py-2 text-xs font-semibold transition-colors disabled:cursor-wait disabled:opacity-60 ${isDarkMode ? "bg-purple-700 text-white hover:bg-purple-600" : "bg-purple-600 text-white hover:bg-purple-700"}`}
+                    title="Generate another cover from a different video frame"
+                  >
+                    {coverAction === "regenerate" ? <SpinnerIcon /> : <RefreshIcon />}
+                  </button>
+                )}
               </div>
             ) : (
               <div


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic fallback cover generation from valid video frames when artwork is unavailable.
  * Added controls to regenerate execution preview covers from a random video frame.
  * Added support for JPG, JPEG, and WebP screenshots.

* **Bug Fixes**
  * Improved preview image refreshing to prevent stale cached covers.
  * Prevented preview updates from applying to the wrong media item.
  * Enhanced screenshot discovery, ordering, duplicate exclusion, and unsupported-file filtering.
  * Improved fallback cover selection and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->