### PR TITLE
feat: update STC approved image hosts

### DIFF
--- a/src/trackers/UNIT3D/skipthecommercials.py
+++ b/src/trackers/UNIT3D/skipthecommercials.py
@@ -24,8 +24,8 @@ class SkipTheCommercials(UNIT3D):
     allows_bloated_audio = True
     base_url = "https://skipthecommercials.xyz"
     banned_groups = ("",)
-    approved_image_hosts = ("imgbox", "imgbb")
-    image_host_policy = ImageHostPolicy({"ibb.co": "imgbb", "imgbox.com": "imgbox"}, approved_image_hosts)
+    approved_image_hosts = ("imgbox", "imgbb", "onlyimage", "ptscreens")
+    image_host_policy = ImageHostPolicy({"ibb.co": "imgbb", "imgbox.com": "imgbox", "onlyimage.org": "onlyimage", "ptscreens.com": "ptscreens"}, approved_image_hosts)
     id_url = f"{base_url}/api/torrents/"
     upload_url = f"{base_url}/api/torrents/upload"
     search_url = f"{base_url}/api/torrents/filter"


### PR DESCRIPTION
Taken from STC fork of upstream: https://github.com/shawnlocal/Upload-Assistant/blob/f247bb0ee52a02ca7657196f58b3734e5d4df143/src/trackers/STC.py#L40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for images hosted on OnlyImage and PTScreens.
  * Images from these hosts are now recognized and handled correctly in SkipTheCommercials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->