### PR TITLE
fix: format audiobook series titles for BJShare

### DIFF
--- a/src/book_extractors.py
+++ b/src/book_extractors.py
@@ -138,19 +138,22 @@ def extract_series_from_filename(filename: str) -> tuple[str, str]:
 
 
 def extract_audiobook_series_from_title(title: str) -> tuple[str, str, str]:
-    """Split ``Title: Series, Livro N`` audiobook metadata when unambiguous."""
-    match = re.match(
-        r"^(?P<title>.+)\s*:\s*(?P<series>.+),\s*(?:livro|book)\s*(?P<index>\d+(?:\.\d+)?)\s*$",
-        title.strip(),
-        re.IGNORECASE,
+    """Split unambiguous audiobook title/series formats."""
+    value = title.strip()
+    patterns = (
+        r"^(?P<title>.+?)\s*:\s*Hist[oó]ria\s+(?P<index>\d+(?:\.\d+)?)\s+de\s+(?P<series>.+)$",
+        r"^(?P<title>.+?)\s*:\s*(?P<series>.+?)[,]?\s*(?:livro|book)\s*(?P<index>\d+(?:\.\d+)?)\s*$",
+        r"^(?P<title>.+?)\s*:\s*(?P<series>(?:saga|série|serie|trilogia|duologia|antologia|coleção|colecao|universo)\b.+?)\s+(?P<index>\d+(?:\.\d+)?)\s*$",
     )
-    if not match:
-        return title.strip(), "", ""
-    return (
-        match.group("title").strip(),
-        match.group("series").strip(),
-        normalize_series_index(match.group("index")),
-    )
+    for pattern in patterns:
+        match = re.match(pattern, value, re.IGNORECASE)
+        if match:
+            return (
+                match.group("title").strip(),
+                match.group("series").strip(),
+                normalize_series_index(match.group("index")),
+            )
+    return value, "", ""
 
 
 def extract_cbr_cbz_metadata(filepath: str) -> dict[str, Any]:

--- a/src/book_prep.py
+++ b/src/book_prep.py
@@ -341,7 +341,9 @@ async def gather_book_prep(
             tracks = meta.mediainfo.get("media", {}).get("track", [])
             if not isinstance(tracks, list):
                 tracks = []
-            general_track = next((t for t in tracks if isinstance(t, dict) and t.get("@type") == "General"), None)
+            # Filter to only dictionary entries to prevent errors when calling .get() later
+            tracks = [t for t in tracks if isinstance(t, dict)]
+            general_track = next((t for t in tracks if t.get("@type") == "General"), None)
             if general_track:
                 # 1. Title/Album
                 album = _unescape_meta_val(general_track.get("Album") or general_track.get("album"))

--- a/src/book_prep.py
+++ b/src/book_prep.py
@@ -201,6 +201,11 @@ def _unescape_meta_val(val: Any) -> str | None:
     return html.unescape(str(val)).strip()
 
 
+def _is_chapter_title(value: str | None) -> bool:
+    """Return whether a MediaInfo title is only an audiobook chapter label."""
+    return bool(value and re.fullmatch(r"(?:cap[ií]tulo|chapter)\s+\d+(?:\.\d+)?", value.strip(), re.IGNORECASE))
+
+
 async def gather_book_prep(
     meta: Meta,
     videopath: str,
@@ -334,12 +339,16 @@ async def gather_book_prep(
     if meta.mediainfo:
         try:
             tracks = meta.mediainfo.get("media", {}).get("track", [])
-            general_track = next((t for t in tracks if t.get("@type") == "General"), None)
+            if not isinstance(tracks, list):
+                tracks = []
+            general_track = next((t for t in tracks if isinstance(t, dict) and t.get("@type") == "General"), None)
             if general_track:
                 # 1. Title/Album
                 album = _unescape_meta_val(general_track.get("Album") or general_track.get("album"))
                 track_name = _unescape_meta_val(general_track.get("Track_name") or general_track.get("track_name"))
                 title_tag = _unescape_meta_val(general_track.get("Title") or general_track.get("title"))
+                if _is_chapter_title(title_tag) and album and not _is_chapter_title(album):
+                    title_tag = album
 
                 # Detect if the audiobook is Unabridged or Abridged from file metadata
                 detected_edition = None
@@ -410,12 +419,14 @@ async def gather_book_prep(
                             meta.book_series_index = _normalize_series_index(part_val)
 
                 if not cli_overrides["title"] and meta.title:
-                    parsed_title, parsed_series, parsed_index = _extract_audiobook_series_from_title(meta.title)
+                    original_title = meta.title
+                    parsed_title, parsed_series, parsed_index = _extract_audiobook_series_from_title(original_title)
                     if parsed_series:
                         meta.title = parsed_title
-                        if not meta.book_series:
+                        localized_history_series = re.search(r":\s*Hist[oó]ria\s+\d+(?:\.\d+)?\s+de\s+.+$", original_title, re.IGNORECASE)
+                        if localized_history_series or not meta.book_series:
                             meta.book_series = parsed_series
-                        if parsed_index and not meta.book_series_index:
+                        if parsed_index and (localized_history_series or not meta.book_series_index):
                             meta.book_series_index = parsed_index
 
                 # 6. Overview/Comment

--- a/src/trackers/bjshare.py
+++ b/src/trackers/bjshare.py
@@ -459,7 +459,7 @@ class BJShare:
 
                 width_num = round((16 / 9) * height_num)
                 width = str(width_num)
-            except ValueError, TypeError:
+            except (ValueError, TypeError):
                 pass
 
         else:
@@ -580,8 +580,19 @@ class BJShare:
                 title = f"{series}: {title}"
             if series_index:
                 normalized_index = legacy_match.group("index") if legacy_match else series_index
-                if re.fullmatch(r"\d+", normalized_index):
-                    normalized_index = normalized_index.zfill(2)
+                # Recognize decimal legacy indices like "4.0" as integer-valued and normalize
+                try:
+                    float_val = float(normalized_index)
+                    if float_val == int(float_val):
+                        normalized_index = str(int(float_val)).zfill(2)
+                    else:
+                        # Non-integer decimal, preserve as-is but try zero-padding if pure integer
+                        if re.fullmatch(r"\d+", normalized_index):
+                            normalized_index = normalized_index.zfill(2)
+                except (ValueError, TypeError):
+                    # Not a valid number, check if pure integer for zero-padding
+                    if re.fullmatch(r"\d+", normalized_index):
+                        normalized_index = normalized_index.zfill(2)
                 title += f" - Vol. {normalized_index}"
             return self.common.portuguese_title_capitalization(title), ""
 
@@ -1017,7 +1028,7 @@ class BJShare:
 
                 try:
                     size_in_gb = meta.bdinfo["size"]
-                except KeyError, IndexError, TypeError:
+                except (KeyError, IndexError, TypeError):
                     size_in_gb = 0
 
                 if size_in_gb > 66:
@@ -1238,7 +1249,7 @@ class BJShare:
                 bit_depth_str = meta.discs[0]["bdinfo"]["video"][0]["bit_depth"]
                 if "10" in bit_depth_str:
                     is_10_bit = True
-            except KeyError, IndexError, TypeError:
+            except (KeyError, IndexError, TypeError):
                 pass
         else:
             if meta.bit_depth == "10":

--- a/src/trackers/bjshare.py
+++ b/src/trackers/bjshare.py
@@ -550,9 +550,39 @@ class BJShare:
 
     def get_titles(self, meta: Meta) -> tuple[str, str]:
         if meta.category == "BOOK":
-            title = f"{meta.book_series.strip()}: " if meta.book_series else ""
-            title += meta.title.strip()
-            title += f" {meta.book_series_index.strip()}" if meta.book_series_index else ""
+            title = meta.title.strip()
+            series = meta.book_series.strip()
+            series_index = meta.book_series_index.strip()
+
+            # Some older audiobook metadata uses the legacy form
+            # "Book title: História N de Series".
+            legacy_match = re.fullmatch(
+                r"(?P<book>.+?)\s*:\s*Hist[oó]ria\s+(?P<index>\d+(?:\.\d+)?)\s+de\s+(?P<series>.+)",
+                title,
+                re.IGNORECASE,
+            )
+            if legacy_match:
+                title = legacy_match.group("book").strip()
+                series = legacy_match.group("series").strip()
+                series_index = legacy_match.group("index")
+            elif series:
+                legacy_match = re.fullmatch(
+                    r"Hist[oó]ria\s+(?P<index>\d+(?:\.\d+)?)\s+de\s+(?P<series>.+)",
+                    title,
+                    re.IGNORECASE,
+                )
+                if legacy_match:
+                    title = series
+                    series = legacy_match.group("series").strip()
+                    series_index = legacy_match.group("index")
+
+            if series:
+                title = f"{series}: {title}"
+            if series_index:
+                normalized_index = legacy_match.group("index") if legacy_match else series_index
+                if re.fullmatch(r"\d+", normalized_index):
+                    normalized_index = normalized_index.zfill(2)
+                title += f" - Vol. {normalized_index}"
             return self.common.portuguese_title_capitalization(title), ""
 
         if meta.category == "GAME":

--- a/tests/test_audiobook_series_titles.py
+++ b/tests/test_audiobook_series_titles.py
@@ -1,0 +1,17 @@
+from src.book_extractors import extract_audiobook_series_from_title
+
+
+def test_extract_audiobook_series_without_comma():
+    assert extract_audiobook_series_from_title("Crescendo: Hush, hush Livro 2") == ("Crescendo", "Hush, hush", "2")  # noqa: S101
+
+
+def test_extract_audiobook_history_series_format():
+    assert extract_audiobook_series_from_title("O Casamento de Narizinho: História 4 de Reinações de Narizinho") == (  # noqa: S101
+        "O Casamento de Narizinho",
+        "Reinações de Narizinho",
+        "4",
+    )
+
+
+def test_extract_audiobook_series_keeps_regular_subtitle():
+    assert extract_audiobook_series_from_title("Morte no Internato: Uma investigação") == ("Morte no Internato: Uma investigação", "", "")  # noqa: S101

--- a/tests/test_bjshare_book_titles.py
+++ b/tests/test_bjshare_book_titles.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+
+from src.trackers.bjshare import BJShare
+from src.trackers.common import Common
+
+
+def test_get_titles_reorders_legacy_audiobook_series_title():
+    tracker = object.__new__(BJShare)
+    tracker.common = Common({})
+    meta = SimpleNamespace(
+        category="BOOK",
+        title="História 4 de Reinações de Narizinho",
+        book_series="O Casamento de Narizinho",
+        book_series_index="",
+    )
+
+    assert tracker.get_titles(meta) == ("Reinações de Narizinho: O Casamento de Narizinho - Vol. 04", "")  # noqa: S101
+
+
+def test_get_titles_reorders_legacy_title_with_book_prefix():
+    tracker = object.__new__(BJShare)
+    tracker.common = Common({})
+    meta = SimpleNamespace(
+        category="BOOK",
+        title="O Casamento de Narizinho: História 4 de Reinações de Narizinho",
+        book_series="",
+        book_series_index="",
+    )
+
+    assert tracker.get_titles(meta) == ("Reinações de Narizinho: O Casamento de Narizinho - Vol. 04", "")  # noqa: S101
+
+
+def test_get_titles_prefers_localized_legacy_series_over_api_series():
+    tracker = object.__new__(BJShare)
+    tracker.common = Common({})
+    meta = SimpleNamespace(
+        category="BOOK",
+        title="O gato Félix: História 6 de Reinações de Narizinho",
+        book_series="The Adventures of Lucia Little Nose",
+        book_series_index="6",
+    )
+
+    assert tracker.get_titles(meta) == ("Reinações de Narizinho: O Gato Félix - Vol. 06", "")  # noqa: S101
+
+
+def test_get_titles_keeps_regular_book_title_format():
+    tracker = object.__new__(BJShare)
+    tracker.common = Common({})
+    meta = SimpleNamespace(
+        category="BOOK",
+        title="O Hobbit",
+        book_series="Terra-media",
+        book_series_index="1",
+    )
+
+    assert tracker.get_titles(meta) == ("Terra-Media: O Hobbit - Vol. 01", "")  # noqa: S101


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved audiobook title recognition across additional series formats, including localized “História N de” titles and legacy naming styles.
  - Audiobook metadata now better preserves valid series information while correcting chapter-based titles and volume numbering.
  - Book titles are formatted more consistently, with clearer series ordering and standardized two-digit volume numbers.

- **Bug Fixes**
  - Improved handling of incomplete or irregular audiobook metadata to prevent incorrect title and series displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->