### PR TITLE
fix(trackers): HD-Space upload payload

### DIFF
--- a/src/cookie_auth.py
+++ b/src/cookie_auth.py
@@ -496,8 +496,8 @@ class CookieValidator:
         )
         failure_path = await self.common.save_html_file(meta, tracker, text, "Failed_Login")
         logger.info(
-            f"The web page has been saved to [yellow]{failure_path}[/yellow] for analysis.\n"
-            "[red]Do not share this file publicly[/red], as it may contain confidential information such as passkeys, IP address, e-mail, etc.\n"
+            f"The web page has been saved to {failure_path} for analysis.\n"
+            "Do not share this file publicly, as it may contain confidential information such as passkeys, IP address, e-mail, etc.\n"
             "You can open this file in a web browser to see what went wrong.\n"
         )
 
@@ -809,8 +809,8 @@ class CookieAuthUploader:
 
         failure_path = await self.common.save_html_file(meta, tracker, response.text, "Failed_Upload")
         message.append(
-            f"The web page has been saved to [yellow]{failure_path}[/yellow] for analysis.\n"
-            "[red]Do not share this file publicly[/red], as it may contain confidential information such as passkeys, IP address, e-mail, etc.\n"
+            f"The web page has been saved to {failure_path} for analysis.\n"
+            "Do not share this file publicly, as it may contain confidential information such as passkeys, IP address, e-mail, etc.\n"
             "You can open this file in a web browser to see what went wrong.\n"
         )
 

--- a/src/trackers/hdspace.py
+++ b/src/trackers/hdspace.py
@@ -282,7 +282,6 @@ class HDSpace:
 
         return await self.cookie_auth_uploader.handle_upload(
             meta=meta,
-            torrent_name=meta.clean_name,
             tracker=self.tracker,
             source_flag=self.source_flag,
             torrent_url=self.torrent_url,

--- a/src/trackers/hdspace.py
+++ b/src/trackers/hdspace.py
@@ -240,7 +240,7 @@ class HDSpace:
         data: dict[str, Any] = {
             "category": await self.get_category_id(meta),
             "filename": await self.get_name(meta),
-            "genre": str(meta.genres),
+            "genre": ", ".join(meta.genres) if meta.genres else "",
             "imdb": str(meta.imdb),
             "info": await self.generate_description(meta),
             "nuk_rea": "",
@@ -282,6 +282,7 @@ class HDSpace:
 
         return await self.cookie_auth_uploader.handle_upload(
             meta=meta,
+            torrent_name=meta.clean_name,
             tracker=self.tracker,
             source_flag=self.source_flag,
             torrent_url=self.torrent_url,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cookie validation and upload failure messages by removing unwanted formatting markup.
  * Genres are now displayed as a clear, comma-separated list.
  * Uploaded torrents now use the cleaned torrent name for more consistent naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->