### PR TITLE
fix(bjshare): extract database credits

### DIFF
--- a/src/trackers/bjshare.py
+++ b/src/trackers/bjshare.py
@@ -1355,7 +1355,7 @@ class BJShare:
 
         if BJShare.already_has_the_info:
             database_credit = BJShare.database_cast if role == "cast" else BJShare.database_creator
-        if database_credit:
+            if database_credit:
                 return database_credit
             return "N/A"
 

--- a/src/trackers/bjshare.py
+++ b/src/trackers/bjshare.py
@@ -51,6 +51,8 @@ class BJShare:
     database_title: str = ""
     database_identifier: str = ""
     database_overview: str = ""
+    database_creator: str = ""
+    database_cast: str = ""
     tmdb_localization_requirements: ClassVar = {
         "pt-BR": {
             "main": "credits,videos,content_ratings",
@@ -737,6 +739,19 @@ class BJShare:
             tag.decompose()
         return body.get_text(strip=True)
 
+    def get_database_credits(self, soup: BeautifulSoup, role: str) -> str:
+        """Extract credits shown on an existing BJShare details page."""
+        label = "Criador:" if role in ("director", "creator") else "Elenco:"
+        for box in soup.find_all("div", class_="box"):
+            header = box.find("div", class_="head")
+            if not header or "informa" not in unidecode(header.get_text()).lower():
+                continue
+            for row in box.find_all("tr"):
+                cells = row.find_all("td")
+                if len(cells) >= 2 and label.casefold() in unidecode(cells[0].get_text(" ", strip=True)).casefold():
+                    return cells[1].get_text(" ", strip=True)
+        return ""
+
     async def search_existing(self, meta: Meta) -> list[dict[str, str | list[str]]]:
         dupes: list[dict[str, str | list[str]]] = []
         category = meta.category
@@ -787,6 +802,8 @@ class BJShare:
         BJShare.database_title = ""
         BJShare.database_identifier = ""
         BJShare.database_overview = ""
+        BJShare.database_creator = ""
+        BJShare.database_cast = ""
 
         search_params = [params]
         title_already_queried = False
@@ -853,6 +870,8 @@ class BJShare:
             BJShare.database_title = self.get_database_title(soup)
             BJShare.database_identifier = self.get_database_identifier(soup)
             BJShare.database_overview = self.get_database_overview(soup)
+            BJShare.database_creator = self.get_database_credits(soup, "creator")
+            BJShare.database_cast = self.get_database_credits(soup, "cast")
 
             for row in torrent_details_table.find_all("tr"):
                 row_id = row.get("id")
@@ -1332,7 +1351,9 @@ class BJShare:
 
     async def get_credits(self, meta: Meta, role: str) -> str:
         if BJShare.already_has_the_info:
-            return "N/A"
+            database_credit = BJShare.database_cast if role == "cast" else BJShare.database_creator
+            if database_credit:
+                return database_credit
 
         role_map = {
             "director": ("directors", "tmdb_directors"),

--- a/src/trackers/bjshare.py
+++ b/src/trackers/bjshare.py
@@ -1350,10 +1350,14 @@ class BJShare:
         return normalized_names
 
     async def get_credits(self, meta: Meta, role: str) -> str:
+        if role not in {"director", "creator", "cast"}:
+            return "N/A"
+
         if BJShare.already_has_the_info:
             database_credit = BJShare.database_cast if role == "cast" else BJShare.database_creator
-            if database_credit:
+        if database_credit:
                 return database_credit
+            return "N/A"
 
         role_map = {
             "director": ("directors", "tmdb_directors"),
@@ -1366,9 +1370,6 @@ class BJShare:
             "creator": "Criador",
             "cast": "Elenco",
         }
-
-        if role not in role_map:
-            return "N/A"
 
         imdb_key, tmdb_key = role_map[role]
 

--- a/tests/test_bjshare.py
+++ b/tests/test_bjshare.py
@@ -98,6 +98,20 @@ def test_get_database_overview_extracts_synopsis():
     assert overview == "Em busca de uma vida melhor, Lu Xiao Fan deixa o interior..."  # noqa: S101
 
 
+def test_get_database_credits_extracts_creator_and_cast():
+    soup = BeautifulSoup(
+        '<div class="box"><div class="head">InformaÃ§Ãµes</div><table>'
+        '<tr><td><b>Criador:</b></td><td>Ron Howard</td></tr>'
+        '<tr><td><b>Elenco:</b></td><td>Russell Crowe, RenÃ©e Zellweger</td></tr>'
+        "</table></div>",
+        "html.parser",
+    )
+    tracker = object.__new__(BJShare)
+
+    assert tracker.get_database_credits(soup, "creator") == "Ron Howard"  # noqa: S101
+    assert tracker.get_database_credits(soup, "cast") == "Russell Crowe, RenÃ©e Zellweger"  # noqa: S101
+
+
 def test_get_overview_returns_database_overview_when_already_has_the_info():
     tracker = object.__new__(BJShare)
     tracker.main_tmdb_data = {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving creator and cast credits from existing BJShare entries.
  - Credit information is now preserved and displayed when matching content is found.

- **Bug Fixes**
  - Prevented existing entries from incorrectly showing “N/A” when database credits are available.

- **Tests**
  - Added coverage to verify creator and cast credit extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->