### PR TITLE
feat: localize tracker descriptions

### DIFF
--- a/src/description_languages.py
+++ b/src/description_languages.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 BOOK_LABELS = {
     "en": {
         "author": "Author",
@@ -89,6 +91,12 @@ MUSIC_LABELS = {
         "channels": "Channels",
         "bitrate": "Bitrate",
         "external_ids": "External IDs",
+        "external_id_labels": {
+            "musicbrainz_release": "MusicBrainz Release",
+            "musicbrainz_release_group": "MusicBrainz Release Group",
+            "discogs_release": "Discogs Release",
+            "discogs_master": "Discogs Master",
+        },
     },
     "pt-BR": {
         "details": "Detalhes da Música",
@@ -112,6 +120,12 @@ MUSIC_LABELS = {
         "channels": "Canais",
         "bitrate": "Bitrate",
         "external_ids": "IDs Externos",
+        "external_id_labels": {
+            "musicbrainz_release": "Lançamento MusicBrainz",
+            "musicbrainz_release_group": "Grupo de Lançamentos MusicBrainz",
+            "discogs_release": "Lançamento Discogs",
+            "discogs_master": "Master Discogs",
+        },
     },
 }
 
@@ -129,7 +143,7 @@ COMMON_LABELS = {
 }
 
 
-def get_labels(labels: dict[str, dict[str, str]], language: str) -> dict[str, str]:
+def get_labels(labels: dict[str, dict[str, Any]], language: str) -> dict[str, Any]:
     try:
         return labels[language]
     except KeyError as error:

--- a/src/description_languages.py
+++ b/src/description_languages.py
@@ -1,0 +1,136 @@
+BOOK_LABELS = {
+    "en": {
+        "author": "Author",
+        "average_bitrate": "Average Bitrate",
+        "book_translator": "Translator",
+        "duration": "Duration",
+        "edition": "Edition",
+        "narrator": "Narrator",
+        "overview": "Overview",
+        "publisher": "Publisher",
+        "technical_details": "Technical Details",
+        "year": "Release Year",
+    },
+    "pt-BR": {
+        "author": "Autor",
+        "average_bitrate": "Bitrate Médio",
+        "book_translator": "Tradutor",
+        "duration": "Duração",
+        "edition": "Edição",
+        "narrator": "Narrador",
+        "overview": "Visão Geral",
+        "publisher": "Editora",
+        "technical_details": "Detalhes Técnicos",
+        "year": "Ano de Lançamento",
+    },
+}
+
+
+def get_book_labels(language: str) -> dict[str, str]:
+    try:
+        return BOOK_LABELS[language]
+    except KeyError as error:
+        raise ValueError(f"Unsupported description language: {language}") from error
+
+
+GAME_LABELS = {
+    "en": {
+        "technical_details": "Technical Details",
+        "overview": "Overview",
+        "platform": "Platform",
+        "version": "Version",
+        "genre": "Genre",
+        "developer": "Developer",
+        "publisher": "Publisher",
+        "system_requirements": "System Requirements",
+        "minimum": "Minimum",
+        "recommended": "Recommended",
+        "official_supported_languages": "Officially Supported Languages",
+        "language": "Language",
+        "support": "Support",
+    },
+    "pt-BR": {
+        "technical_details": "Detalhes Técnicos",
+        "overview": "Visão Geral",
+        "platform": "Plataforma",
+        "version": "Versão",
+        "genre": "Gênero",
+        "developer": "Desenvolvedor",
+        "publisher": "Distribuidora",
+        "system_requirements": "Requisitos do Sistema",
+        "minimum": "Mínimo",
+        "recommended": "Recomendado",
+        "official_supported_languages": "Idiomas Oficialmente Suportados",
+        "language": "Idioma",
+        "support": "Suporte",
+    },
+}
+
+MUSIC_LABELS = {
+    "en": {
+        "details": "Music Details",
+        "artist": "Artist",
+        "album": "Album",
+        "year": "Original Release Year",
+        "release_year": "Release Year",
+        "edition": "Edition",
+        "edition_year": "Edition Year",
+        "type": "Release Type",
+        "media": "Media",
+        "label": "Label",
+        "catalogue": "Catalogue Number",
+        "genres": "Genres",
+        "tracks": "Tracks",
+        "discs": "Discs",
+        "format": "Format",
+        "codec": "Codec",
+        "bit_depth": "Bit Depth",
+        "sample_rate": "Sample Rate",
+        "channels": "Channels",
+        "bitrate": "Bitrate",
+        "external_ids": "External IDs",
+    },
+    "pt-BR": {
+        "details": "Detalhes da Música",
+        "artist": "Artista",
+        "album": "Álbum",
+        "year": "Ano de Lançamento Original",
+        "release_year": "Ano desta Edição",
+        "edition": "Edição",
+        "edition_year": "Ano da Edição",
+        "type": "Tipo de Lançamento",
+        "media": "Mídia",
+        "label": "Gravadora",
+        "catalogue": "Número de Catálogo",
+        "genres": "Gêneros",
+        "tracks": "Faixas",
+        "discs": "Discos",
+        "format": "Formato",
+        "codec": "Codec",
+        "bit_depth": "Profundidade de Bits",
+        "sample_rate": "Taxa de Amostragem",
+        "channels": "Canais",
+        "bitrate": "Bitrate",
+        "external_ids": "IDs Externos",
+    },
+}
+
+COMMON_LABELS = {
+    "en": {
+        "audio_languages": "Audio Language/s",
+        "subtitle_languages": "Subtitle Language/s",
+        "hardcoded_subtitles": "Hardcoded Subtitle Language/s",
+    },
+    "pt-BR": {
+        "audio_languages": "Idioma(s) de Áudio",
+        "subtitle_languages": "Idioma(s) das Legendas",
+        "hardcoded_subtitles": "Idioma(s) das Legendas Queimadas (HC)",
+    },
+}
+
+
+def get_labels(labels: dict[str, dict[str, str]], language: str) -> dict[str, str]:
+    try:
+        return labels[language]
+    except KeyError as error:
+        raise ValueError(f"Unsupported description language: {language}") from error

--- a/src/get_desc.py
+++ b/src/get_desc.py
@@ -20,6 +20,7 @@ from langcodes.tag_parser import LanguageTagError
 from src.bbcode import BBCODE
 from src.cogs.redaction import PathAwareEncoder
 from src.console import logger
+from src.description_languages import COMMON_LABELS, MUSIC_LABELS, get_book_labels, get_labels
 from src.description_review import apply_saved_draft
 from src.languages import languages_manager
 from src.mediainfo import MediaInfo
@@ -204,10 +205,11 @@ async def gen_desc(
 
 
 class DescriptionBuilder:
-    def __init__(self, tracker: str, config: dict[str, Any]):
+    def __init__(self, tracker: str, config: dict[str, Any], language: str = "en"):
         self.config: dict[str, Any] = config
         self.common = Common(config)
         self.tracker: str = tracker
+        self.language = language
         self.takescreens_manager = TakeScreensManager(config)
         self.uploadscreens_manager = UploadScreensManager(config)
 
@@ -711,20 +713,19 @@ class DescriptionBuilder:
         publisher = meta.publisher
         year = str(meta.year) if meta.year is not None else ""
 
-        use_pt_br = self.tracker in ("AMIGOSSHARE", "BRASILTRACKER", "CAPYBARABR", "SAMARITANO", "BJSHARE")
-
+        labels = get_book_labels(self.language)
         str_asin = "ASIN"
-        str_author = "Author" if not use_pt_br else "Autor"
-        str_avg_bitrate = "Average Bitrate" if not use_pt_br else "Bitrate Médio"
-        str_book_translator = "Translator" if not use_pt_br else "Tradutor"
-        str_duration = "Duration" if not use_pt_br else "Duração"
-        str_edition = "Edition" if not use_pt_br else "Edição"
+        str_author = labels["author"]
+        str_avg_bitrate = labels["average_bitrate"]
+        str_book_translator = labels["book_translator"]
+        str_duration = labels["duration"]
+        str_edition = labels["edition"]
         str_isbn = "ISBN"
-        str_narrator = "Narrator" if not use_pt_br else "Narrador"
-        str_overview = "Overview" if not use_pt_br else "Visão Geral"
-        str_publisher = "Publisher" if not use_pt_br else "Editora"
-        str_technical_details = "Technical Details" if not use_pt_br else "Detalhes Técnicos"
-        str_year = "Release Year" if not use_pt_br else "Ano de Lançamento"
+        str_narrator = labels["narrator"]
+        str_overview = labels["overview"]
+        str_publisher = labels["publisher"]
+        str_technical_details = labels["technical_details"]
+        str_year = labels["year"]
 
         if overview:
             overview = html_to_bbcode(overview)
@@ -822,7 +823,7 @@ class DescriptionBuilder:
         header = "[h2]" if not header_size else f"[size={header_size}][b]"
         header_end = "[/h2]" if not header_size else "[/b][/size]\n"
 
-        use_pt_br = self.tracker in ("AMIGOSSHARE", "BRASILTRACKER", "CAPYBARABR", "SAMARITANO", "BJSHARE")
+        use_pt_br = self.language == "pt-BR"
         str_technical_details = "Technical Details" if not use_pt_br else "Detalhes Técnicos"
         str_overview = "Overview" if not use_pt_br else "Visão Geral"
         str_platform = "Platform" if not use_pt_br else "Plataforma"
@@ -983,7 +984,7 @@ class DescriptionBuilder:
 
         header = "[h2]" if not header_size else f"[size={header_size}][b]"
         header_end = "[/h2]" if not header_size else "[/b][/size]\n"
-        use_pt_br = self.tracker in ("AMIGOSSHARE", "BRASILTRACKER", "CAPYBARABR", "SAMARITANO", "BJSHARE")
+        use_pt_br = self.language == "pt-BR"
 
         def value(name: str, fallback: Any = "") -> Any:
             """Return a populated normalized release field or its fallback."""
@@ -1039,6 +1040,7 @@ class DescriptionBuilder:
             "bitrate": "Bitrate",
             "external_ids": "External IDs" if not use_pt_br else "IDs Externos",
         }
+        text.update(get_labels(MUSIC_LABELS, self.language))
 
         def musicbrainz_link(kind: str, identifier: Any) -> str:
             """Return a safe MusicBrainz BBCode link for a canonical UUID."""
@@ -1156,16 +1158,17 @@ class DescriptionBuilder:
 
         # Language
         if languages:
+            language_labels = get_labels(COMMON_LABELS, self.language)
             try:
                 if not meta.language_checked:
                     await languages_manager.process_desc_language(meta, self.tracker)
                 if meta.audio_languages and meta.write_audio_languages:
-                    desc_parts.append(f"[code]Audio Language/s: {', '.join(meta.audio_languages)}[/code]")
+                    desc_parts.append(f"[code]{language_labels['audio_languages']}: {', '.join(meta.audio_languages)}[/code]")
 
                 if meta.subtitle_languages and meta.write_subtitle_languages:
-                    desc_parts.append(f"[code]Subtitle Language/s: {', '.join(meta.subtitle_languages)}[/code]")
+                    desc_parts.append(f"[code]{language_labels['subtitle_languages']}: {', '.join(meta.subtitle_languages)}[/code]")
                 if meta.subtitle_languages and meta.write_hc_languages:
-                    desc_parts.append(f"[code]Hardcoded Subtitle Language/s: {', '.join(meta.subtitle_languages)}[/code]")
+                    desc_parts.append(f"[code]{language_labels['hardcoded_subtitles']}: {', '.join(meta.subtitle_languages)}[/code]")
             except Exception as e:
                 logger.warning(f"[yellow]Warning: Error processing language: {e!s}[/yellow]")
 

--- a/src/get_desc.py
+++ b/src/get_desc.py
@@ -20,7 +20,7 @@ from langcodes.tag_parser import LanguageTagError
 from src.bbcode import BBCODE
 from src.cogs.redaction import PathAwareEncoder
 from src.console import logger
-from src.description_languages import COMMON_LABELS, MUSIC_LABELS, get_book_labels, get_labels
+from src.description_languages import COMMON_LABELS, GAME_LABELS, MUSIC_LABELS, get_book_labels, get_labels
 from src.description_review import apply_saved_draft
 from src.languages import languages_manager
 from src.mediainfo import MediaInfo
@@ -837,6 +837,20 @@ class DescriptionBuilder:
         str_official_supported_languages = "Officially Supported Languages" if not use_pt_br else "Idiomas Oficialmente Suportados"
         str_language = "Language" if not use_pt_br else "Idioma"
         str_support = "Support" if not use_pt_br else "Suporte"
+        game_labels = get_labels(GAME_LABELS, self.language)
+        str_technical_details = game_labels["technical_details"]
+        str_overview = game_labels["overview"]
+        str_platform = game_labels["platform"]
+        str_version = game_labels["version"]
+        str_genre = game_labels["genre"]
+        str_developer = game_labels["developer"]
+        str_publisher = game_labels["publisher"]
+        str_system_requirements = game_labels["system_requirements"]
+        str_minimum = game_labels["minimum"]
+        str_recommended = game_labels["recommended"]
+        str_official_supported_languages = game_labels["official_supported_languages"]
+        str_language = game_labels["language"]
+        str_support = game_labels["support"]
 
         # 1. Technical Details
         fields: list[tuple[str, str]] = []
@@ -1041,6 +1055,7 @@ class DescriptionBuilder:
             "external_ids": "External IDs" if not use_pt_br else "IDs Externos",
         }
         text.update(get_labels(MUSIC_LABELS, self.language))
+        external_id_labels = text["external_id_labels"]
 
         def musicbrainz_link(kind: str, identifier: Any) -> str:
             """Return a safe MusicBrainz BBCode link for a canonical UUID."""
@@ -1061,10 +1076,10 @@ class DescriptionBuilder:
             return f"[url=https://www.discogs.com/{kind}/{numeric_identifier}]{numeric_identifier}[/url]" if numeric_identifier else ""
 
         external_id_links = [
-            ("MusicBrainz Release", musicbrainz_link("release", external_ids.get("musicbrainz_release"))),
-            ("MusicBrainz Release Group", musicbrainz_link("release-group", external_ids.get("musicbrainz_release_group"))),
-            ("Discogs Release", discogs_link("release", external_ids.get("discogs_release"))),
-            ("Discogs Master", discogs_link("master", external_ids.get("discogs_master"))),
+            (external_id_labels["musicbrainz_release"], musicbrainz_link("release", external_ids.get("musicbrainz_release"))),
+            (external_id_labels["musicbrainz_release_group"], musicbrainz_link("release-group", external_ids.get("musicbrainz_release_group"))),
+            (external_id_labels["discogs_release"], discogs_link("release", external_ids.get("discogs_release"))),
+            (external_id_labels["discogs_master"], discogs_link("master", external_ids.get("discogs_master"))),
         ]
         external_id_links = [f"{label}: {link}" for label, link in external_id_links if link]
 

--- a/src/trackers/UNIT3D/capybarabr.py
+++ b/src/trackers/UNIT3D/capybarabr.py
@@ -147,7 +147,7 @@ class CapybaraBR(UNIT3D):
     async def get_description(self, meta: Meta) -> dict[str, str]:
         signature = f"[right][url=https://github.com/wastaken7/Upload-Assistant][size=4]Compartilhado com {meta.ua_name} {meta.current_version} (fork)[/size][/url][/right]"
         return {
-            "description": await DescriptionBuilder(self.tracker, self.config).general_description_generator(
+            "description": await DescriptionBuilder(self.tracker, self.config, "pt-BR").general_description_generator(
                 meta,
                 mediainfo=False,
                 nfo=False,

--- a/src/trackers/UNIT3D/locadora.py
+++ b/src/trackers/UNIT3D/locadora.py
@@ -102,7 +102,7 @@ class Locadora(UNIT3D):
     async def get_description(self, meta: Meta) -> dict[str, str]:
         signature = f"[right][url=https://github.com/wastaken7/Upload-Assistant][size=4]Compartilhado com {meta.ua_name} {meta.current_version} (fork)[/size][/url][/right]"
         return {
-            "description": await DescriptionBuilder(self.tracker, self.config).general_description_generator(
+            "description": await DescriptionBuilder(self.tracker, self.config, "pt-BR").general_description_generator(
                 meta,
                 mediainfo=False,
                 nfo=False,

--- a/src/trackers/UNIT3D/samaritano.py
+++ b/src/trackers/UNIT3D/samaritano.py
@@ -167,7 +167,7 @@ class Samaritano(UNIT3D):
     async def get_description(self, meta: Meta) -> dict[str, str]:
         signature = f"[right][url=https://github.com/wastaken7/Upload-Assistant][size=4]Compartilhado com {meta.ua_name} {meta.current_version} (fork)[/size][/url][/right]"
         return {
-            "description": await DescriptionBuilder(self.tracker, self.config).general_description_generator(
+            "description": await DescriptionBuilder(self.tracker, self.config, "pt-BR").general_description_generator(
                 meta,
                 mediainfo=False,
                 nfo=False,

--- a/src/trackers/amigosshare.py
+++ b/src/trackers/amigosshare.py
@@ -383,7 +383,7 @@ class AmigosShare:
         description_parts.append("[/center]")
 
         # Book details using DescriptionBuilder
-        builder = DescriptionBuilder(self.tracker, self.config)
+        builder = DescriptionBuilder(self.tracker, self.config, "pt-BR")
         book_section = builder._build_book_desc_section(meta, header_size=3, table=False)
         if book_section:
             description_parts.append(book_section)
@@ -733,7 +733,7 @@ class AmigosShare:
 
     async def build_game_description(self, meta: Meta) -> str:
         """Build GAME description using only the _build_game_desc_section block."""
-        builder = DescriptionBuilder(self.tracker, self.config)
+        builder = DescriptionBuilder(self.tracker, self.config, "pt-BR")
         desc_parts: list[str] = []
 
         game_section = builder._build_game_desc_section(meta, header_size=5, table=False)

--- a/src/trackers/bjshare.py
+++ b/src/trackers/bjshare.py
@@ -162,7 +162,7 @@ class BJShare:
             pc_platforms = {"PC", "MAC", "LINUX"}
             platform = meta.platform.upper().strip()
             if platform in pc_platforms:
-                builder = DescriptionBuilder(self.tracker, self.config)
+                builder = DescriptionBuilder(self.tracker, self.config, "pt-BR")
                 has_install_notes = await builder.get_user_description(meta)
                 if not has_install_notes:
                     logger.info(
@@ -644,7 +644,7 @@ class BJShare:
         return "", ""
 
     async def build_description(self, meta: Meta) -> str:
-        builder = DescriptionBuilder(self.tracker, self.config)
+        builder = DescriptionBuilder(self.tracker, self.config, "pt-BR")
         meta.episode_tmdb_data = self.episode_tmdb_data
 
         return await builder.general_description_generator(

--- a/src/trackers/brasiltracker.py
+++ b/src/trackers/brasiltracker.py
@@ -220,7 +220,7 @@ class BrasilTracker:
             pc_platforms = {"PC", "MAC", "LINUX"}
             platform = meta.platform.upper().strip()
             if platform in pc_platforms:
-                builder = DescriptionBuilder(self.tracker, self.config)
+                builder = DescriptionBuilder(self.tracker, self.config, "pt-BR")
                 has_install_notes = await builder.get_user_description(meta)
                 if not has_install_notes:
                     logger.info(
@@ -608,7 +608,7 @@ class BrasilTracker:
         return "", ""
 
     async def get_description(self, meta: Meta) -> str:
-        builder = DescriptionBuilder(self.tracker, self.config)
+        builder = DescriptionBuilder(self.tracker, self.config, "pt-BR")
         # Set episode_tmdb_data on meta for general_description_generator to pick it up
         meta.episode_tmdb_data = self.episode_tmdb_data
 
@@ -1152,7 +1152,7 @@ class BrasilTracker:
 
     def build_book_desc(self, meta: Meta) -> str:
         """Build the BBCode table for BOOK-category uploads."""
-        builder = DescriptionBuilder(self.tracker, self.config)
+        builder = DescriptionBuilder(self.tracker, self.config, "pt-BR")
         return builder._build_book_desc_section(meta, header_size=3, table=False)
 
     async def get_book_cover(self, meta: Meta) -> str:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added English and Brazilian Portuguese localization for book, game, music, and shared media description labels.
  - Generated descriptions now support language-specific labels and Portuguese output where applicable.
  - Added validation for unsupported description languages.

- **Improvements**
  - Brazilian Portuguese descriptions are now generated consistently across supported trackers and content types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->