### PR TITLE
feat: add option to skip auto-torrent when upload is a personal release

### DIFF
--- a/data/example_config.py
+++ b/data/example_config.py
@@ -194,6 +194,8 @@ config: dict[str, Any] = {
         # this will search qbittorrent clients for matching torrents
         # and use found torrent id's for existing hash and site searching
         "skip_auto_torrent": False,
+        # Set true to also skip automated torrent searching for personal releases
+        "skip_auto_torrent_personalrelease": False,
         # Set to true to always just use the largest playlist on a blu-ray, without selection prompt.
         "use_largest_playlist": False,
         # Import policy for releases found on other trackers. Choose one:

--- a/docs/example-config.md
+++ b/docs/example-config.md
@@ -214,6 +214,7 @@ These can be [overridden per-tracker](#tracker-overridable-settings) by adding t
 
 - `default_torrent_client` (str): Name of the client config to use (matches a key under `TORRENT_CLIENTS`, e.g. `"qbittorrent"`).
 - `skip_auto_torrent` (bool): Skip automated torrent searching in your qBitTorrent client.
+- `skip_auto_torrent_personalrelease` (bool): Also skip automated torrent searching when the upload is a personal release.
 
 Implementation notes:
 

--- a/src/configvalidator.py
+++ b/src/configvalidator.py
@@ -82,6 +82,7 @@ DEFAULT_KEY_TYPES: dict[str, tuple[type, ...]] = {
     "processLimit": (str, int),
     "default_torrent_client": (str,),
     "skip_auto_torrent": (bool,),
+    "skip_auto_torrent_personalrelease": (bool,),
     "sfx_on_prompt": (bool,),
     "console_show_time": (bool,),
     "console_show_level": (bool,),

--- a/src/prep_helpers.py
+++ b/src/prep_helpers.py
@@ -171,7 +171,10 @@ def init_meta(prep_instance: Any, meta: Meta, mode: str) -> tuple[bool, bool, Cl
     base_dir = meta.base_dir
     meta.saved_description = False
     client = Clients(config=prep_instance.config)
-    meta.skip_auto_torrent = meta.skip_auto_torrent or prep_instance.config["DEFAULT"].get("skip_auto_torrent", False)
+    default_config = prep_instance.config["DEFAULT"]
+    meta.skip_auto_torrent = (
+        meta.skip_auto_torrent or default_config.get("skip_auto_torrent", False) or (meta.personalrelease and default_config.get("skip_auto_torrent_personalrelease", False))
+    )
     hash_ids = ["infohash", "torrent_hash", "skip_auto_torrent"]
     from src.trackersetup import api_trackers
 

--- a/src/trackers/tvchaosuk.py
+++ b/src/trackers/tvchaosuk.py
@@ -488,10 +488,7 @@ class TVChaosUK:
         if original_lang and not original_lang.startswith("en") and original_lang not in ["ga", "gd", "cy"]:
             is_foreign = True
         elif not original_lang:
-            if not meta.is_disc:
-                mi = meta.mediainfo
-            else:
-                mi = meta.bdinfo if meta.bdinfo else {}
+            mi = meta.mediainfo if not meta.is_disc else meta.bdinfo if meta.bdinfo else {}
             if isinstance(mi, dict) and mi:
                 audio_langs = self.get_audio_languages(mi)
                 if audio_langs and "English" not in audio_langs:
@@ -512,8 +509,7 @@ class TVChaosUK:
         if meta.sdh_subs:
             tvc_name = tvc_name.replace(" SUBS]", " (ENG + SDH SUBS)]") if meta.eng_subs else tvc_name.replace("]", " (SDH SUBS)]")
 
-        tvc_name = await self.append_country_code(meta, tvc_name)
-        return tvc_name
+        return await self.append_country_code(meta, tvc_name)
 
     async def upload(self, meta: Meta) -> bool | None:
         common = Common(config=self.config)

--- a/tests/test_prep_early_screenshots.py
+++ b/tests/test_prep_early_screenshots.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from src import prep_helpers
 from src.meta import Meta
 from src.prep import Prep, populate_hdr_for_early_capture
 from src.screenshot_manifest import register
@@ -73,6 +74,16 @@ def test_early_capture_skips_hdr_probe_without_video_metadata() -> None:
     asyncio.run(populate_hdr_for_early_capture(meta, None, None))
 
     assert meta.hdr == ""
+
+
+def test_personal_release_config_skips_auto_torrent_before_client_search(tmp_path: Path) -> None:
+    prep = Prep.__new__(Prep)
+    prep.config = {"DEFAULT": {"skip_auto_torrent_personalrelease": True}}
+    meta = Meta(base_dir=str(tmp_path), path=str(tmp_path), personalrelease=True)
+
+    prep_helpers.init_meta(prep, meta, "cli")
+
+    assert meta.skip_auto_torrent
 
 
 def test_registered_main_screenshots_are_reused_when_title_changes(tmp_path: Path) -> None:

--- a/web_ui/server.py
+++ b/web_ui/server.py
@@ -4018,7 +4018,7 @@ def _configured_cookie_tracker_names(
     for tracker_name in supported_trackers:
         try:
             has_cookie_file = Path(cookie_file_finder(str(state_dir), tracker_name, user_config)).is_file()
-        except (AttributeError, OSError, TypeError, ValueError):
+        except AttributeError, OSError, TypeError, ValueError:
             has_cookie_file = False
         if has_cookie_file:
             configured.add(tracker_name.upper())


### PR DESCRIPTION
Reason: If you're uploading a personal, there probably aren't any torrents for it yet. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to skip automated torrent searches for personal-release uploads.
  * The setting is disabled by default and can be configured in the default configuration section.

* **Bug Fixes**
  * Personal-release settings are now applied before automated torrent-client searches begin.

* **Documentation**
  * Documented the new personal-release torrent-search setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->