### PR TITLE
feat(theleachzone): add pre-release type detection

### DIFF
--- a/src/trackers/UNIT3D/tlzdigital.py
+++ b/src/trackers/UNIT3D/tlzdigital.py
@@ -25,6 +25,34 @@ class TheLeachZone(UNIT3D):
     supported_categories = ("TV", "MOVIE")
     tracker_urls = ("https://tlzdigital.com/",)
 
+    # TLZ type IDs: 1 = Film, 2 = CAM / pre-release, 3 = Episode, 4 = Pack.
+    _pre_release_types = frozenset(
+        {
+            "CAM",
+            "CAMRIP",
+            "DCP",
+            "DVDSCR",
+            "HDCAM",
+            "HD CAM",
+            "HD-CAM",
+            "HD_CAM",
+            "HDTS",
+            "PDVD",
+            "R5",
+            "SCR",
+            "SCREENER",
+            "TC",
+            "TELECINE",
+            "TELESYNC",
+            "TELE SYNC",
+            "TELE-SYNC",
+            "TELE_SYNC",
+            "TS",
+            "WORKPRINT",
+            "WP",
+        }
+    )
+
     def __init__(self, config: Config) -> None:
         super().__init__(config, tracker_name="THELEACHZONE")
         self.config: Config = config
@@ -32,7 +60,7 @@ class TheLeachZone(UNIT3D):
 
     async def get_category_id(self, meta: Meta, category: str | None = None, reverse: bool = False, mapping_only: bool = False) -> dict[str, str]:
         _ = (category, reverse, mapping_only)
-        category_value = str(meta.category)
+        category_value = str(meta.category or "").strip().upper()
         category_id = {
             "MOVIE": "1",
             "TV": "2",
@@ -41,7 +69,9 @@ class TheLeachZone(UNIT3D):
 
     async def get_type_id(self, meta: Meta, type: str | None = None, reverse: bool = False, mapping_only: bool = False) -> dict[str, str]:
         _ = (type, reverse, mapping_only)
-        type_value = str(meta.type)
+        type_value = str(meta.type or "").strip().upper()
+        source_value = str(meta.source or "").strip().upper()
+        category_value = str(meta.category or "").strip().upper()
         type_id = {
             "FILM": "1",
             "EPISODE": "3",
@@ -50,10 +80,11 @@ class TheLeachZone(UNIT3D):
 
         if meta.tv_pack:
             type_id = "4"
+        elif meta.pre_release or type_value in self._pre_release_types or source_value in self._pre_release_types:
+            type_id = "2"
+        elif category_value == "MOVIE":
+            type_id = "1"
         elif type_id != "4":
             type_id = "3"
-
-        if str(meta.category) == "MOVIE":
-            type_id = "1"
 
         return {"type_id": type_id}

--- a/tests/test_tlzdigital.py
+++ b/tests/test_tlzdigital.py
@@ -1,0 +1,63 @@
+import asyncio
+
+import pytest
+
+from src.meta import Meta
+from src.trackers.UNIT3D.tlzdigital import TheLeachZone
+
+
+def _tracker() -> TheLeachZone:
+    return TheLeachZone({"DEFAULT": {}, "TRACKERS": {"THELEACHZONE": {}}})
+
+
+@pytest.mark.parametrize(
+    ("meta", "expected_type_id"),
+    (
+        (Meta(category="MOVIE", type="WEBDL"), "1"),
+        (Meta(category="TV", type="WEBDL"), "3"),
+        (Meta(category="TV", type="WEBDL", tv_pack=True), "4"),
+        (Meta(category="TV", type="PACK"), "4"),
+    ),
+)
+def test_tlzdigital_maps_standard_release_types(meta: Meta, expected_type_id: str):
+    assert asyncio.run(_tracker().get_type_id(meta)) == {"type_id": expected_type_id}  # noqa: S101
+
+
+def test_tlzdigital_normalizes_category_case():
+    tracker = _tracker()
+
+    assert asyncio.run(tracker.get_category_id(Meta(category="movie"))) == {"category_id": "1"}  # noqa: S101
+    assert asyncio.run(tracker.get_type_id(Meta(category="movie", type="webdl"))) == {"type_id": "1"}  # noqa: S101
+
+
+@pytest.mark.parametrize(
+    "meta",
+    (
+        Meta(category="MOVIE", type="CAM"),
+        Meta(category="MOVIE", type="HDCAM"),
+        Meta(category="MOVIE", source="R5"),
+        Meta(category="MOVIE", type="WEBDL", pre_release=True),
+        Meta(category="TV", type="TELESYNC"),
+    ),
+)
+def test_tlzdigital_maps_pre_releases_to_cam_type(meta: Meta):
+    assert asyncio.run(_tracker().get_type_id(meta)) == {"type_id": "2"}  # noqa: S101
+
+
+def test_tlzdigital_tv_pack_takes_priority_over_pre_release_type():
+    meta = Meta(category="TV", type="CAM", pre_release=True, tv_pack=True)
+
+    assert asyncio.run(_tracker().get_type_id(meta)) == {"type_id": "4"}  # noqa: S101
+
+
+def test_tlzdigital_does_not_infer_type_from_movie_title():
+    meta = Meta(category="MOVIE", title="The Line", name="The.Line.2024.1080p.WEB-DL", type="WEBDL", source="WEB")
+
+    assert asyncio.run(_tracker().get_type_id(meta)) == {"type_id": "1"}  # noqa: S101
+
+
+@pytest.mark.parametrize("source", ("LD", "LaserDisc", "LINE", "LINE AUDIO"))
+def test_tlzdigital_does_not_treat_ambiguous_sources_as_cam(source: str):
+    meta = Meta(category="MOVIE", type="ENCODE", source=source)
+
+    assert asyncio.run(_tracker().get_type_id(meta)) == {"type_id": "1"}  # noqa: S101


### PR DESCRIPTION
## Summary

TheLeachZone provides a dedicated CAM / pre-release upload type, so this change adds detection for those releases and assigns them to TLZ type ID `2` instead of treating them as standard films.

*This only adds correct handling for the existing upload type, it is not an endorsement of CAM or other pre-release uploads.*

## Changes

- Detect pre-release uploads using structured `pre_release`, `type`, and `source` metadata
- Support CAM, HDCAM, telesync, telecine, screener, workprint, R5, and similar formats
- Preserve the existing type mappings:
  - Film: `1`
  - CAM / pre-release: `2`
  - Episode: `3`
  - Pack: `4`
- Normalize category, type, and source values
- Avoid title-based detection to prevent false positives
- Exclude ambiguous `LD` and `LINE` markers from CAM detection
- Add regression tests for standard releases, pre-releases, TV packs, case normalization, and ambiguous sources

## Testing

- Python syntax validation passed
- TLZ type-mapping smoke tests passed
- Added automated tests covering the updated type-detection behaviour

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release-type classification for standard movie and TV releases.
  * Added consistent handling for capitalization and missing category or type values.
  * Correctly identifies explicitly labeled pre-releases as CAM while preserving TV-pack classification priority.
  * Prevented inaccurate type detection based solely on movie titles or ambiguous source labels.

* **Tests**
  * Added comprehensive coverage for release-type mapping, normalization, pre-release handling, and classification edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->