### PR TITLE
fix(prompt): remove rich formatting tags from interactive prompt strings

### DIFF
--- a/src/trackers/AVISTAZ/__init__.py
+++ b/src/trackers/AVISTAZ/__init__.py
@@ -420,7 +420,7 @@ class AZTrackerBase:
                         return {}
                     logger.info(f"{self.tracker}: No audio language/s found.")
                     logger.info(f"{self.tracker}: You must enter (comma-separated) languages for all audio tracks, eg: English, Spanish: ")
-                    user_input_raw = await prompt_in_thread(cli_ui.ask_string, "[bold yellow]Enter languages: [/bold yellow]")
+                    user_input_raw = await prompt_in_thread(cli_ui.ask_string, "Enter languages: ")
                     user_input = (user_input_raw or "").strip()
                     langs = [lang.strip() for lang in user_input.split(",")]
                     for lang in langs:

--- a/src/trackers/bjshare.py
+++ b/src/trackers/bjshare.py
@@ -1854,7 +1854,7 @@ class BJShare:
             return ""
 
         logger.info(f"{self.tracker}: [bold red]Sinopse não encontrada no TMDb. Por favor, insira manualmente.[/bold red]")
-        user_input_raw = await prompt_in_thread(cli_ui.ask_string, f'"{self.tracker}: [green]Digite a sinopse:[/green]"')
+        user_input_raw = await prompt_in_thread(cli_ui.ask_string, f"{self.tracker}: Digite a sinopse: ")
         user_input = (user_input_raw or "").strip()
         if user_input:
             return user_input

--- a/src/uphelper.py
+++ b/src/uphelper.py
@@ -522,7 +522,7 @@ class UploadHelper:
         if not possible:
             return
 
-        question = "[bold magenta]Found BDInfo content in potential duplicates.[/bold magenta] Perform a comparison?"
+        question = "Found BDInfo content in potential duplicates. Perform a comparison?"
         if await self.prompt_yes_no(question, default=True):
             warnings: list[str] = []
             results: list[str] = []

--- a/tests/test_uphelper_prompts.py
+++ b/tests/test_uphelper_prompts.py
@@ -77,7 +77,7 @@ async def test_dupe_check_keeps_each_result_list_with_its_prompt(monkeypatch: py
 
 
 @pytest.mark.asyncio
-async def test_bdinfo_comparison_prompt_uses_rich_markup(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_bdinfo_comparison_prompt_uses_plain_text(monkeypatch: pytest.MonkeyPatch) -> None:
     question: str | None = None
 
     async def prompt_yes_no(value: str, *, default: bool = False) -> bool:
@@ -91,7 +91,7 @@ async def test_bdinfo_comparison_prompt_uses_rich_markup(monkeypatch: pytest.Mon
 
     await helper.ask_bdinfo_comparison({}, [{}], "AITHER")
 
-    assert question == "[bold magenta]Found BDInfo content in potential duplicates.[/bold magenta] Perform a comparison?"
+    assert question == "Found BDInfo content in potential duplicates. Perform a comparison?"
     assert "\033" not in question
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Simplified interactive prompts to use clear, plain text.
  - Removed visual markup from language entry, synopsis, and BDInfo comparison prompts.
  - Improved consistency and readability across command-line interactions.

- **Tests**
  - Updated prompt coverage to verify the new plain-text BDInfo comparison message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->