### PR TITLE
fix: generalize manual overview

### DIFF
--- a/src/args.py
+++ b/src/args.py
@@ -87,7 +87,7 @@ Common options:
   --queue (queue name)       Process an entire folder (including files/subfolders) in a queue
   -mf, --manual_frames       Comma-separated list of frame numbers to use for screenshots
   -df, --descfile            Path to custom description file
-  -boverview, --book-overview  Book/Audiobook overview/synopsis (overrides auto-detected value)
+  -boverview, --book-overview  Overview/synopsis (overrides auto-detected value)
   -serv, --service           Streaming service
   --no-aka                   Remove AKA from title
   -daily, --daily            Air date of a daily type episode (YYYY-MM-DD)
@@ -483,10 +483,10 @@ class Args:
             "--book-overview",
             "-ov",
             "--overview",
-            dest="book_overview",
+            dest="manual_overview",
             nargs="*",
             required=False,
-            help="Book/Audiobook overview/synopsis (overrides auto-detected value)",
+            help="Overview/synopsis (overrides auto-detected value)",
             type=str,
         )
         parser.add_argument(
@@ -1018,14 +1018,11 @@ class Args:
         *langcodes* so both a human-readable name and the ISO 639-3 code are stored.
         Falls back gracefully when *langcodes* is unavailable or the code is unknown.
         """
-        book_overview_arg = meta.book_overview or meta.overview
-        if book_overview_arg not in (None, "", []):
-            overview_str = " ".join(str(x) for x in book_overview_arg if str(x)).strip() if isinstance(book_overview_arg, list) else str(book_overview_arg).strip()
+        manual_overview = meta.manual_overview
+        if manual_overview not in (None, "", []):
+            overview_str = " ".join(str(x) for x in manual_overview if str(x)).strip() if isinstance(manual_overview, list) else str(manual_overview).strip()
             meta.overview = overview_str
             meta.book_overview = overview_str
-        else:
-            meta.overview = ""
-            meta.book_overview = ""
 
         book_author_arg = meta.book_author
         if book_author_arg not in (None, ""):

--- a/src/meta.py
+++ b/src/meta.py
@@ -251,6 +251,7 @@ class Meta:
     manual_language: str | dict[str, Any] | None = None
     manual_multi: bool = False
     manual_name: str | None = None
+    manual_overview: str | None = None
     manual_platform: str | None = None
     manual_season: str | int | None = None
     manual_source: str | None = None

--- a/src/trackers/brasiltracker.py
+++ b/src/trackers/brasiltracker.py
@@ -1043,6 +1043,8 @@ class BrasilTracker:
                     }
                 )
         elif meta.category in ("MOVIE", "TV"):
+            if meta.overview:
+                self.main_tmdb_data["overview"] = meta.overview
             has_pt_subtitles, subtitle_ids = await self.get_subtitle(meta)
             resolution_width, resolution_height = await self.get_resolution(meta)
             data.update(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for manually overriding book overviews through the `--book-overview` and `--overview` options.
  * Manual overview text is now applied to movie and TV upload descriptions when provided.

* **Bug Fixes**
  * Existing overview values are preserved when no manual override is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->