### PR TITLE
fix(book): preserve title without series

### DIFF
--- a/src/book_prep.py
+++ b/src/book_prep.py
@@ -708,6 +708,8 @@ def normalize_audiobook_title(title: str, series: str) -> str:
     """Remove a repeated series name from the beginning or end of an audiobook title."""
     title = title.strip()
     series = series.strip()
+    if not series:
+        return title
     if len(title) > len(series):
         if title.casefold().endswith(series.casefold()):
             return title[: -len(series)].rstrip(" :-\u2013\u2014")

--- a/tests/test_audiobook_series_titles.py
+++ b/tests/test_audiobook_series_titles.py
@@ -10,6 +10,10 @@ def test_normalize_audiobook_title_keeps_title_equal_to_series():
     assert normalize_audiobook_title("Andersen", "Andersen") == "Andersen"  # noqa: S101
 
 
+def test_normalize_audiobook_title_keeps_title_without_series():
+    assert normalize_audiobook_title("Meu irmãozinho me atrapalha", "") == "Meu irmãozinho me atrapalha"  # noqa: S101
+
+
 def test_normalize_audiobook_title_removes_repeated_series_prefix():
     assert normalize_audiobook_title("Os Contos de Hans Christian Andersen: O bobo", "Os Contos de Hans Christian Andersen") == "O bobo"  # noqa: S101
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved audiobook titles exactly as entered when no series name is provided.
  * Prevented unintended title changes during audiobook preparation.

* **Tests**
  * Added coverage to verify titles remain unchanged without a series name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->