### PR TITLE
fix(book): select audio for audiobooks

### DIFF
--- a/src/book_prep.py
+++ b/src/book_prep.py
@@ -91,8 +91,8 @@ def resolve_book_filelist(
 
     Returns:
         A 4-tuple ``(videopath, filelist, search_term, search_file_folder)``
-        where *videopath* is the primary/largest file used as the "video"
-        reference for downstream processing.
+        where *videopath* is the primary file used as the "video" reference
+        for downstream processing (the largest audio file for audiobooks).
     """
     allowed_extensions = BOOK_EXTENSIONS | AUDIOBOOK_EXTENSIONS
 
@@ -110,16 +110,15 @@ def resolve_book_filelist(
         richer_book_files = [file for file in filelist if Path(file).suffix.lower() in BOOK_EXTENSIONS - {".txt", ".html", ".htm"}]
         if richer_book_files:
             filelist = [file for file in filelist if not (Path(file).suffix.lower() in {".txt", ".html", ".htm"} and Path(file).stem.casefold() in _TEXT_SIDECAR_STEMS)]
-        videopath = sorted(filelist, key=os.path.getsize, reverse=True)[0]
     else:
-        videopath = videoloc
         filelist.append(videoloc)
 
     meta.filelist = filelist
     meta.imdb_id = 0
 
-    primary_ext = Path(videopath).suffix.lower()
-    meta.audiobook = bool(meta.audiobook or (primary_ext in AUDIOBOOK_EXTENSIONS) or any(Path(f).suffix.lower() in AUDIOBOOK_EXTENSIONS for f in filelist))
+    audio_files = [file for file in filelist if Path(file).suffix.lower() in AUDIOBOOK_EXTENSIONS]
+    meta.audiobook = bool(meta.audiobook or audio_files)
+    videopath = max(audio_files if meta.audiobook and audio_files else filelist, key=os.path.getsize)
 
     search_term = Path(filelist[0]).name if filelist else ""
     search_file_folder = "file"

--- a/tests/test_book_detection.py
+++ b/tests/test_book_detection.py
@@ -50,6 +50,20 @@ def test_new_audiobook_formats_are_detected(extension, tmp_path):
     assert meta.audiobook is True
 
 
+def test_audiobook_uses_audio_file_when_pdf_is_larger(tmp_path):
+    pdf = tmp_path / "book.pdf"
+    audiobook = tmp_path / "book.m4b"
+    pdf.write_bytes(b"x" * 100)
+    audiobook.write_bytes(b"audio")
+
+    meta = Meta()
+    videopath, filelist, _, _ = resolve_book_filelist(meta, str(tmp_path))
+
+    assert videopath == str(audiobook.resolve())  # noqa: S101
+    assert filelist == [str(audiobook.resolve()), str(pdf.resolve())]  # noqa: S101
+    assert meta.audiobook is True  # noqa: S101
+
+
 def test_text_sidecars_are_excluded_when_a_richer_book_format_exists(tmp_path):
     book = tmp_path / "book.epub"
     readme = tmp_path / "README.txt"
@@ -82,4 +96,3 @@ def test_map_audiobook_keywords():
     # Fallback to original cleaned genre when not in map
     assert map_audiobook_keywords("Custom Unmapped Genre") == ["custom unmapped genre"]
     assert map_audiobook_keywords("Custom Genre A; Custom Genre B") == ["custom genre a", "custom genre b"]
-


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved audiobook detection when folders contain multiple file types.
  - Audiobooks now select the largest audio file as the primary playback file, even when another file, such as a PDF, is larger.
  - Other accompanying files remain available in the book’s file list.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->