### PR TITLE
fix(takescreens): ignore main group image_list cutoff in pack capture

### DIFF
--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -1823,14 +1823,14 @@ async def screenshots(
     if "image_list" not in meta:
         meta.image_list = []
 
-    image_list_entries = meta.image_list
+    group = capture_group or "main"
+    image_list_entries = meta.image_list if group == "main" else []
     existing_images: list[dict[str, Any]] = [img for img in image_list_entries if str(img.get("img_url", "")).startswith("http")]
 
     if len(existing_images) >= cutoff and not force_screenshots:
         logger.info(f"[yellow]There are already at least {cutoff} images in the image list. Skipping additional screenshots.")
         return None
 
-    group = capture_group or "main"
     if num_screens:
         requested_screens = num_screens
     elif isinstance(manual_frames, str):

--- a/tests/test_prep_early_screenshots.py
+++ b/tests/test_prep_early_screenshots.py
@@ -104,6 +104,50 @@ def test_registered_main_screenshots_are_reused_when_title_changes(tmp_path: Pat
     assert set(result or []) == {str(path) for path in registered}
 
 
+def test_pack_capture_ignores_uploaded_images_from_main_group(tmp_path: Path) -> None:
+    release_id = "release"
+    release_dir = tmp_path / "tmp" / release_id
+    release_dir.mkdir(parents=True)
+    (release_dir / "MediaInfo.json").write_text(
+        '{"media": {"track": [{"Duration": "100"}, {"Duration": "100", "Width": "1920", "Height": "1080", "PixelAspectRatio": "1", "DisplayAspectRatio": "1.777", "FrameRate": "24"}]}}',
+        encoding="utf-8",
+    )
+    meta = Meta(
+        category="MOVIE",
+        base_dir=str(tmp_path),
+        uuid=release_id,
+        screens=2,
+        imghost="imgbb",
+        image_list=[{"img_url": "https://images.example/main.png"}],
+    )
+    capture_calls: list[object] = []
+
+    async def capture_stub(args: tuple[object, ...]):
+        capture_calls.append(args)
+        output = Path(str(args[3]))
+        output.write_bytes(b"image")
+        return args[0], str(output)
+
+    with (
+        patch("src.takescreens.get_image_host", new=AsyncMock(return_value="imgbb")),
+        patch("src.takescreens.capture_screenshot", new=capture_stub),
+    ):
+        result = asyncio.run(
+            screenshots(
+                "unused.mkv",
+                "FILE_1",
+                release_id,
+                str(tmp_path),
+                meta,
+                manual_frames=[100, 200],
+                capture_group="FILE_1",
+            )
+        )
+
+    assert len(capture_calls) == 2
+    assert len(result or []) == 2
+
+
 def test_partial_registered_group_captures_only_missing_screenshots(tmp_path: Path) -> None:
     release_id = "release"
     release_dir = tmp_path / "tmp" / release_id


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed grouped screenshot capture so non-main groups are not affected by uploaded images from the main group.
  - Ensured screenshot cutoffs are evaluated using the correct capture group.

- **Tests**
  - Added coverage verifying that grouped captures produce the expected screenshots without reusing unrelated main-group images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->