### PR TITLE
fix(get_desc): collapse duplicated tonemapped headers

### DIFF
--- a/src/get_desc.py
+++ b/src/get_desc.py
@@ -316,6 +316,47 @@ class DescriptionBuilder:
             logger.warning(f"[yellow]Warning: Error setting tonemapped header: {e!s}[/yellow]")
         return ""
 
+    def _tonemapped_header_candidates(self, meta: Meta) -> tuple[str, ...]:
+        """Header spellings an imported description can carry: tag override, tracker
+        override, DEFAULT and the legacy literal. Markup-bearing only (a bare word is
+        indistinguishable from prose), longest first, deterministic tie-break."""
+        # uploads made before a config change carry this exact spelling
+        candidates = {"[center][code] Screenshots have been tonemapped for reference [/code][/center]"}
+        tag_override = self._get_tag_override("tonemapped_header", meta)
+        if tag_override is not None:
+            candidates.add(str(tag_override))
+        for source in (self.tracker_config, self.config["DEFAULT"]):
+            value = source.get("tonemapped_header")
+            if value is not None:
+                candidates.add(str(value))
+        return tuple(sorted((candidate for candidate in candidates if "[" in candidate), key=lambda candidate: (-len(candidate), candidate)))
+
+    def _strip_tonemapped_header(self, text: str, meta: Meta, *, replacing: bool) -> str:
+        """Collapse duplicated tonemapped headers in an imported description.
+
+        ``clean_unit3d_description`` keeps plain BBCode, so an imported header
+        survives and ``get_tonemapped_header`` may append another. Leave one copy
+        when nothing is re-added, none when it is. One pass over the original text
+        only (re-scanning a splice could eat body text), anchored to whitespace,
+        a bracket or a string edge, loose whitespace between tokens.
+        """
+        try:
+            headers = self._tonemapped_header_candidates(meta)
+        except Exception as e:
+            logger.warning(f"[yellow]Warning: Error reading tonemapped header: {e!s}[/yellow]")
+            return text
+        alternatives = "|".join("(?:" + r"\s*".join(re.escape(token) for token in header.split()) + ")" for header in headers)
+        pattern = re.compile(r"(?:^|(?<=[\s\]]))(?:" + alternatives + r")(?=[\s\[]|$)", re.IGNORECASE)
+        keep = 0 if replacing else 1
+        matches = list(pattern.finditer(text))
+        pieces = []
+        cursor = 0
+        for match in matches[keep:]:
+            pieces.append(text[cursor : match.start()])
+            cursor = match.end()
+        pieces.append(text[cursor:])
+        return "".join(pieces)
+
     async def get_logo_section(self, meta: Meta) -> tuple[str, str]:
         """Returns the logo URL and size if applicable."""
         logo, logo_size = "", ""
@@ -1292,6 +1333,10 @@ class DescriptionBuilder:
         ):
             desc_parts.append(meta.nexusphp_description)
 
+        # resolve once: the strip decision must match what is actually appended
+        tonemapped_header_text = await self.get_tonemapped_header(meta) if tonemapped_header else ""
+        replacing_tonemapped_header = bool(tonemapped_header_text.strip())
+
         meta_description_value = meta.description
         if isinstance(meta_description_value, str):
             meta_description = meta_description_value
@@ -1322,9 +1367,9 @@ class DescriptionBuilder:
                         flags=re.DOTALL,
                     )
                     if meta_description:
-                        desc_parts.append(meta_description)
+                        desc_parts.append(self._strip_tonemapped_header(meta_description, meta, replacing=replacing_tonemapped_header))
             elif meta_description:
-                desc_parts.append(meta_description)
+                desc_parts.append(self._strip_tonemapped_header(meta_description, meta, replacing=replacing_tonemapped_header))
 
         # NFO details
         if nfo:
@@ -1352,7 +1397,7 @@ class DescriptionBuilder:
 
         # Tonemapped Header
         if tonemapped_header:
-            desc_parts.append(await self.get_tonemapped_header(meta))
+            desc_parts.append(tonemapped_header_text)
 
         # Discs and Screenshots
         if screenshots:

--- a/src/trackers/AVISTAZ/__init__.py
+++ b/src/trackers/AVISTAZ/__init__.py
@@ -647,6 +647,7 @@ class AZTrackerBase:
     async def edit_desc(self, meta: Meta) -> str:
         builder = DescriptionBuilder(self.tracker, self.config)
         desc_parts: list[str] = []
+        tonemapped_header = await builder.get_tonemapped_header(meta)
 
         # Custom Header
         desc_parts.append(await builder.get_custom_header(meta))
@@ -658,10 +659,17 @@ class AZTrackerBase:
             desc_parts.append(f"[b]Overview:[/b] {episode_overview}")
 
         # User description
-        desc_parts.append(await builder.get_user_description(meta))
+        user_description = await builder.get_user_description(meta)
+        desc_parts.append(
+            builder._strip_tonemapped_header(
+                user_description,
+                meta,
+                replacing=bool(tonemapped_header.strip()),
+            )
+        )
 
         # Tonemapped Header
-        desc_parts.append(await builder.get_tonemapped_header(meta))
+        desc_parts.append(tonemapped_header)
 
         # Audio Spectrograms
         desc_parts.append(await builder.get_audio_spectrogram_section(meta))

--- a/tests/test_avistaz_screenshots_and_desc.py
+++ b/tests/test_avistaz_screenshots_and_desc.py
@@ -81,3 +81,22 @@ def test_avistaz_edit_desc_includes_spectrograms_and_dv_plots(tmp_path: Path) ->
     assert "https://imgbox.com/plot_web" in html_desc  # noqa: S101
     assert "https://images2.imgbox.com/plot_raw.png" in html_desc  # noqa: S101
     assert "<img" in html_desc  # noqa: S101
+
+
+def test_avistaz_edit_desc_deduplicates_imported_tonemapped_header(tmp_path: Path) -> None:
+    header = "[center]Screenshots have been adapted for SDR viewing, for reference only.[/center]"
+    meta = Meta(
+        base_dir=str(tmp_path),
+        uuid="test-uuid",
+        description_file_content=f"Imported description\n{header}",
+        tonemapped=True,
+    )
+    config = {
+        "DEFAULT": {"tonemapped_header": header},
+        "TRACKERS": {"AVISTAZ": {}},
+    }
+
+    html_desc = asyncio.run(AvistaZ(config).edit_desc(meta))
+
+    assert html_desc.count("adapted for SDR viewing") == 1  # noqa: S101
+    assert "Imported description" in html_desc  # noqa: S101

--- a/tests/test_tonemapped_header_import.py
+++ b/tests/test_tonemapped_header_import.py
@@ -1,0 +1,298 @@
+# ruff: noqa: S101
+
+import asyncio
+
+from src.get_desc import DescriptionBuilder
+from src.meta import Meta
+
+HEADER = "[center]Screenshots have been adapted for SDR viewing, for reference only.[/center]"
+IMPORTED = f"[center]Imported body text[/center]\n{HEADER}"
+
+
+def _builder(default_header=HEADER, tracker_header=None):
+    tracker_config = {} if tracker_header is None else {"tonemapped_header": tracker_header}
+    return DescriptionBuilder("TEST", {"DEFAULT": {"tonemapped_header": default_header}, "TRACKERS": {"TEST": tracker_config}})
+
+
+def _render(meta, builder=None, **sections):
+    """Render through the real generator with everything but the description off."""
+    builder = builder or _builder()
+    off = {
+        "audio_spectrogram": False,
+        "bluray": False,
+        "book": False,
+        "custom_header": False,
+        "custom_signature": False,
+        "game": False,
+        "languages": False,
+        "logo": False,
+        "mediainfo": False,
+        "menu_screenshots": False,
+        "nfo": False,
+        "screenshots": False,
+        "tv_info": False,
+        "ua_signature": False,
+        "user_description": False,
+        "music": False,
+        "dynamic_hdr_plot": False,
+    }
+    off.update(sections)
+    return asyncio.run(builder.general_description_generator(meta, **off))
+
+
+def _count(text):
+    return text.count("adapted for SDR viewing")
+
+
+# --- the bug this fixes ----------------------------------------------------
+
+
+def test_an_imported_header_is_not_rendered_twice():
+    """The reported bug: imported copy + UA's own copy both rendered."""
+    meta = Meta(description=IMPORTED, tonemapped=True)
+
+    assert _count(_render(meta)) == 1
+
+
+# --- the regression that gating prevents -----------------------------------
+
+
+def test_an_imported_header_survives_when_this_run_adds_none():
+    """meta.tonemapped is False, so nothing re-adds it, so stripping would delete."""
+    meta = Meta(description=IMPORTED, tonemapped=False)
+
+    assert _count(_render(meta)) == 1
+
+
+def test_an_imported_header_survives_when_the_section_is_disabled():
+    meta = Meta(description=IMPORTED, tonemapped=True)
+
+    assert _count(_render(meta, tonemapped_header=False)) == 1
+
+
+def test_the_imported_body_text_is_never_lost():
+    for tonemapped in (True, False):
+        rendered = _render(Meta(description=IMPORTED, tonemapped=tonemapped))
+        assert "Imported body text" in rendered
+
+
+# --- the helper ------------------------------------------------------------
+
+
+def test_the_helper_removes_every_copy_when_replacing():
+    builder = _builder()
+
+    assert HEADER not in builder._strip_tonemapped_header(HEADER * 3, Meta(), replacing=True)
+
+
+def test_whitespace_drift_from_a_tracker_render_is_tolerated():
+    builder = _builder()
+    reparsed = "[center]Screenshots  have been\nadapted for SDR viewing,   for reference only.[/center]"
+
+    assert builder._strip_tonemapped_header(reparsed, Meta(), replacing=True) == ""
+
+
+def test_similar_text_is_preserved():
+    builder = _builder()
+    near_miss = "[center]Screenshots have been adapted for SDR viewing, for comparison.[/center]"
+
+    assert builder._strip_tonemapped_header(near_miss, Meta(), replacing=True) == near_miss
+
+
+def test_both_the_tracker_header_and_the_default_are_stripped():
+    # The description was imported from ANOTHER tracker, so it carries that
+    builder = _builder(tracker_header="[b]Tonemapped[/b]")
+    text = f"[b]Tonemapped[/b] kept: {HEADER}"
+
+    assert builder._strip_tonemapped_header(text, Meta(), replacing=True).strip() == "kept:"
+
+
+def test_a_header_is_matched_regardless_of_case():
+    builder = _builder(tracker_header="[b]Tonemapped[/b]")
+    text = "before [B]TONEMAPPED[/B] after"
+
+    assert "TONEMAPPED" not in builder._strip_tonemapped_header(text, Meta(), replacing=True)
+
+
+def test_an_unset_header_does_not_strip_an_unrelated_notice():
+    builder = _builder(default_header="")
+    text = f"body {HEADER}"
+
+    assert builder._strip_tonemapped_header(text, Meta(), replacing=True) == text
+
+
+def test_the_legacy_header_is_stripped_when_nothing_is_configured():
+    # Descriptions produced before a config change carry this exact spelling, so it
+    legacy = "[center][code] Screenshots have been tonemapped for reference [/code][/center]"
+    builder = _builder(default_header="")
+    text = f"body {legacy} tail"
+
+    out = builder._strip_tonemapped_header(text, Meta(), replacing=True)
+    assert legacy not in out
+    assert "body" in out and "tail" in out
+
+
+def test_duplicates_collapse_to_one_when_nothing_is_re_added():
+    # The case gating on `replacing` alone missed: the duplicate usually arrives on
+    builder = _builder()
+    text = f"intro {HEADER} middle {HEADER} tail"
+
+    out = builder._strip_tonemapped_header(text, Meta(), replacing=False)
+    assert out.count(HEADER) == 1
+    assert "intro" in out and "middle" in out and "tail" in out
+
+
+def test_a_lone_header_is_never_removed():
+    # It still describes screenshots that are displayed, so removing the only copy
+    builder = _builder()
+    text = f"intro {HEADER} tail"
+
+    assert builder._strip_tonemapped_header(text, Meta(), replacing=False) == text
+
+
+def test_mixed_spellings_collapse_together():
+    # The imported copy uses the source tracker's spelling, ours uses the DEFAULT;
+    builder = _builder(tracker_header="[b]Tonemapped[/b]")
+    out = builder._strip_tonemapped_header(f"x [b]Tonemapped[/b] y {HEADER} z", Meta(), replacing=False)
+    total = out.count(HEADER) + out.count("[b]Tonemapped[/b]")
+    assert total == 1, out
+
+
+def test_a_longer_spelling_wins_over_a_shorter_one_it_contains():
+    # Without longest-first ordering, whichever spelling the alternation tries first
+    long_header = f"{HEADER} [i]see notes[/i]"
+    builder = _builder(tracker_header=long_header)
+    text = f"x {long_header} y {long_header} z"
+
+    out = builder._strip_tonemapped_header(text, Meta(), replacing=False)
+
+    assert out.count(long_header) == 1, out
+    assert out.count("[i]see notes[/i]") == 1, out
+
+
+def test_an_imported_header_survives_a_whitespace_only_configured_header():
+    """Blank is not a header, so nothing meaningful is re-added and the import stays."""
+    builder = _builder(tracker_header="   ")
+    meta = Meta(description=IMPORTED, tonemapped=True)
+
+    assert _count(_render(meta, builder=builder)) == 1
+
+
+def test_only_spans_present_in_the_original_text_are_removed():
+    """Never delete more than what matched before any edit."""
+    builder = _builder(tracker_header="[b]X [/b]")
+    text = f"[b]X {HEADER}[/b]"
+
+    out = builder._strip_tonemapped_header(text, Meta(), replacing=True)
+
+    assert out == "[b]X [/b]", out
+
+
+def test_a_tag_override_spelling_is_stripped():
+    """The release group's own override is a candidate, like the tracker's and DEFAULT's."""
+    builder = DescriptionBuilder(
+        "TEST",
+        {
+            "DEFAULT": {"tonemapped_header": HEADER, "tag_overrides": {"-GRP": {"tonemapped_header": "[b]Group tonemap note[/b]"}}},
+            "TRACKERS": {"TEST": {}},
+        },
+    )
+    meta = Meta(tag="-GRP")
+    text = "body [b]Group tonemap note[/b] tail [b]Group tonemap note[/b]"
+
+    out = builder._strip_tonemapped_header(text, meta, replacing=False)
+
+    assert out.count("[b]Group tonemap note[/b]") == 1, out
+
+
+def test_a_bare_word_header_is_not_stripped_from_prose():
+    """A header with no markup cannot be told apart from ordinary prose."""
+    builder = _builder(tracker_header="SDR")
+    text = "Screenshots were converted from HDR to SDR before capture."
+
+    assert builder._strip_tonemapped_header(text, Meta(), replacing=True) == text
+
+
+def test_removing_a_header_leaves_every_other_byte_alone():
+    """Exact equality, so any whitespace rewriting elsewhere in the text is caught."""
+    builder = _builder()
+    body = "[code]\nSource: UHD Blu-ray\n\nEncoder: x265\n[/code]"
+    # leading and trailing whitespace included: both edges must survive verbatim
+    text = f"\n {body}\n\n{HEADER}\n{HEADER}\n\ntail\n"
+
+    out = builder._strip_tonemapped_header(text, Meta(), replacing=False)
+
+    assert out == f"\n {body}\n\n{HEADER}\n\n\ntail\n", repr(out)
+
+
+def test_whitespace_between_tokens_may_also_be_absent():
+    """The tolerance is zero-or-more, not one-or-more."""
+    builder = _builder(tracker_header="[b]X [/b]")
+    text = "a [b]X[/b] b [b]X[/b] c"
+
+    out = builder._strip_tonemapped_header(text, Meta(), replacing=True)
+
+    assert out == "a  b  c", repr(out)
+
+
+def test_equal_length_spellings_resolve_deterministically():
+    """Equal-length spellings need their own tie-break so the order is always the same."""
+    builder = DescriptionBuilder(
+        "TEST",
+        {
+            "DEFAULT": {"tonemapped_header": "[b]a[/b] [i]"},
+            "TRACKERS": {"TEST": {"tonemapped_header": "[b]a[/b][i]["}},
+        },
+    )
+    text = "[b]a[/b][i][ tail [b]a[/b][i][ x"
+
+    assert builder._strip_tonemapped_header(text, Meta(), replacing=True) == "[ tail [ x"
+
+
+def test_candidates_are_ordered_longest_first_then_lexicographically():
+    """Ordering is deterministic, and the legacy spelling is pinned literally."""
+    builder = _builder(tracker_header="[b]Tonemapped[/b]")
+
+    assert builder._tonemapped_header_candidates(Meta()) == (
+        "[center]Screenshots have been adapted for SDR viewing, for reference only.[/center]",
+        "[center][code] Screenshots have been tonemapped for reference [/code][/center]",
+        "[b]Tonemapped[/b]",
+    )
+
+
+def test_a_header_run_into_preceding_text_is_left_alone():
+    """The left anchor alone: punctuation before the header means it is not a header."""
+    builder = _builder()
+    text = f"body.{HEADER} {HEADER}"
+
+    out = builder._strip_tonemapped_header(text, Meta(), replacing=True)
+
+    assert out == f"body.{HEADER} ", repr(out)
+
+
+def test_a_header_run_into_following_text_is_left_alone():
+    """The right anchor alone: the header is a prefix of a longer word, not a header."""
+    builder = _builder()
+    text = f"{HEADER}-guide {HEADER}"
+
+    out = builder._strip_tonemapped_header(text, Meta(), replacing=True)
+
+    assert out == f"{HEADER}-guide ", repr(out)
+
+
+def test_a_configured_header_with_a_newline_still_matches_a_spaced_copy():
+    """Tokens split on any whitespace, not only spaces."""
+    builder = _builder(tracker_header="[b]Tonemapped\n\tfor reference[/b]")
+    text = "body [b]Tonemapped for reference[/b] tail [b]Tonemapped for reference[/b]"
+
+    out = builder._strip_tonemapped_header(text, Meta(), replacing=True)
+
+    assert out == "body  tail ", repr(out)
+
+
+def test_text_is_returned_untouched_when_the_config_is_unreadable():
+    """A config error must degrade to leaving the description alone, never blanking it."""
+    builder = DescriptionBuilder("TEST", {"TRACKERS": {"TEST": {}}})  # no DEFAULT key
+    text = f"body {HEADER} tail"
+
+    assert builder._strip_tonemapped_header(text, Meta(), replacing=True) == text


### PR DESCRIPTION
An imported description keeps the source tracker's tonemapped header (`clean_unit3d_description` strips images and signatures but not plain BBCode), and `get_tonemapped_header` can then append a second copy, rendering the disclaimer twice. Leave exactly one: none when this run re-adds its own, one otherwise, so the last copy is never removed. Only markup-bearing configured spellings are strippable and only spans matched in the original text are removed, so body text is never altered.

Checks: pytest 840 passed, ruff check/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate tonemapped headers when importing or appending descriptions.
  - Preserved existing description content while normalizing header formatting.
  - Improved handling of configured, legacy, case-variant, whitespace-variant, and tracker-specific header spellings.
  - Added safeguards for malformed settings and unrelated text.

- **Tests**
  - Added comprehensive regression coverage for header deduplication, matching, ordering, and preservation across supported description workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->