### PR TITLE
fix(cli): stop application from hanging when terminal is minimized

### DIFF
--- a/src/cleanup.py
+++ b/src/cleanup.py
@@ -35,11 +35,11 @@ class CleanupManager:
         """Ensure all running tasks, threads, and subprocesses are properly cleaned up before exiting."""
         # console.print("[yellow]Cleaning up tasks before exiting...[/yellow]")
 
-        # Step 1: Shutdown ThreadPoolExecutor **before checking for threads**
+        # Step 1: Shutdown ThreadPoolExecutor **without blocking the event loop**
         global thread_executor
         if thread_executor:
             # console.print("[yellow]Shutting down thread pool executor...[/yellow]")
-            thread_executor.shutdown(wait=True)  # Ensure threads terminate before proceeding
+            thread_executor.shutdown(wait=False, cancel_futures=True)  # Don't block event loop if threads are stuck
             thread_executor = None  # Remove reference
 
         # 🔹 Step 1: Stop the monitoring thread safely

--- a/src/console.py
+++ b/src/console.py
@@ -1,10 +1,12 @@
 # Upload Assistant © 2025 Audionut & wastaken7 — Licensed under UAPL v1.0
 import asyncio
+import builtins
 import contextlib
 import contextvars
 import logging
 import os
 import re
+import sys
 import threading
 from collections.abc import AsyncGenerator, Callable, Generator
 from pathlib import Path
@@ -14,6 +16,28 @@ from rich.console import Console
 from rich.logging import RichHandler
 from rich.progress import Progress
 from rich.text import Text
+
+_original_input = builtins.input
+
+
+def _safe_input(prompt: str = "") -> str:
+    """Thread-safe input that avoids readline terminal state corruption.
+
+    When `readline` is imported, calling `input()` in a background thread makes it
+    vulnerable to terminal state corruption (like losing echo) if a SIGWINCH occurs
+    (e.g., when resizing the terminal or switching windows). Bypassing `readline`
+    by using `sys.stdin.readline` natively fixes this at the cost of history and
+    advanced editing commands, which aren't needed for our CLI prompts.
+    """
+    sys.stdout.write(prompt)
+    sys.stdout.flush()
+    line = sys.stdin.readline()
+    if not line:
+        raise EOFError
+    return line.rstrip("\n")
+
+
+builtins.input = _safe_input
 
 
 def ansi_to_html(ansi_chunk: str, width: int = 120) -> str:

--- a/upload.py
+++ b/upload.py
@@ -2420,7 +2420,7 @@ async def do_the_thing(base_dir: str) -> None:
             finally:
                 logger.info("[yellow]Web UI server stopped[/yellow]")
                 with contextlib.suppress(Exception):
-                    asyncio.run(cleanup_manager.cleanup())
+                    await cleanup_manager.cleanup()
 
             return  # Exit early when running web UI only
 

--- a/upload.py
+++ b/upload.py
@@ -2419,6 +2419,8 @@ async def do_the_thing(base_dir: str) -> None:
                     sys.exit(1)
             finally:
                 logger.info("[yellow]Web UI server stopped[/yellow]")
+                with contextlib.suppress(Exception):
+                    asyncio.run(cleanup_manager.cleanup())
 
             return  # Exit early when running web UI only
 

--- a/upload.py
+++ b/upload.py
@@ -171,7 +171,7 @@ def _handle_shutdown_signal(signum: int, _frame: Any) -> None:
     else:
         # Second signal = force exit
         logger.info("[red]Forced exit[/red]")
-        sys.exit(1)
+        os._exit(1)
 
 
 # ── Restore built-in data/ files when a Docker volume mount hides them ──


### PR DESCRIPTION
this PR fixes three issues with multithreading
1. the cli used a not threadsafe readline implementation causing the application to hang when minimized
2. when in this state it took 4 Sigint calls to exit due to the cleanup routine getting stuck
3. when stopping the webui the cleanup routine for safe exiting wasn't called

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application shutdown responsiveness by canceling pending background tasks instead of waiting for all threads to finish.
  * Ensured forced shutdown completes immediately after a second interrupt signal.
  * Improved console input handling, including clean end-of-input behavior and safer prompt display.
  * Prevented web interface shutdown from blocking while cleanup completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->