### PR TITLE
feat(args): add inline description option

### DIFF
--- a/docs/cli-args.md
+++ b/docs/cli-args.md
@@ -79,6 +79,7 @@ If you pass a `.txt` file as the main positional input path (without specifying 
 ## Description inputs
 
 - `-pb`, `--desclink URL`: Custom description link (hastebin/pastebin).
+- `--description TEXT`: Inline custom description block (quote text containing spaces or BBCode).
 - `-df`, `--descfile PATH`: Custom description file path (or filename in current working directory).
   - Stored as an absolute path.
 - `-nfo`, `--nfo`: Use `.nfo` in directory for description.

--- a/src/args.py
+++ b/src/args.py
@@ -169,6 +169,7 @@ Common options:
   -tvdb, --tvdb              Specify the TVDB id to use
   --queue (queue name)       Process an entire folder (including files/subfolders) in a queue
   -mf, --manual_frames       Comma-separated list of frame numbers to use for screenshots
+  --description              Inline custom description block
   -df, --descfile            Path to custom description file
   -boverview, --book-overview  Book/Audiobook overview/synopsis (overrides auto-detected value)
   -serv, --service           Streaming service
@@ -698,6 +699,13 @@ class Args:
             nargs=1,
             required=False,
             help="Custom description block to insert (link to hastebin/pastebin). This is added as a section inside the final description and does NOT replace the auto-generated description (MediaInfo, screenshots, etc.)",
+        )
+        parser.add_argument(
+            "--description",
+            dest="description_inline",
+            nargs=1,
+            required=False,
+            help="Inline custom description block to insert. This is added as a section inside the final description and does NOT replace auto-generated sections (MediaInfo, screenshots, etc.)",
         )
         parser.add_argument(
             "-df",

--- a/src/get_desc.py
+++ b/src/get_desc.py
@@ -81,6 +81,7 @@ async def gen_desc(
 
     description_link = meta.description_link
     description_file = meta.description_file
+    description_inline = meta.description_inline
     scene_nfo = False
     bhd_nfo = False
 
@@ -109,6 +110,12 @@ async def gen_desc(
                 content_written = True
         except FileNotFoundError:
             logger.info(f"[ERROR] Template '{meta.description_template}' not found.")
+
+    if description_inline and not content_written:
+        cleaned_content = clean_text(description_inline)
+        if cleaned_content:
+            description_lines.append(cleaned_content)
+            content_written = True
     if meta.nfo:
         logger.debug(f"specified_dir_path: {specified_dir}")
         logger.debug(f"sourcedir_path: {source_dir}")

--- a/src/meta.py
+++ b/src/meta.py
@@ -109,6 +109,7 @@ class Meta:
     demographic: str = ""
     description_file_content: str = ""
     description_file: str = ""
+    description_inline: str = ""
     description_link_content: str = ""
     description_link: str = ""
     description_nfo_content: str = ""

--- a/src/trackers/UNIT3D/cinematik.py
+++ b/src/trackers/UNIT3D/cinematik.py
@@ -171,14 +171,14 @@ class Cinematik(UNIT3D):
         return {"resolution_id": resolution_id}
 
     async def get_description(self, meta: Meta) -> dict[str, str]:
-        if meta.description_link or meta.description_file:
+        if meta.description_inline or meta.description_link or meta.description_file:
             desc = await DescriptionBuilder(self.tracker, self.config).general_description_generator(
                 meta,
                 mediainfo=False,
                 nfo=False,
             )
 
-            logger.info(f"{self.tracker}: Custom Description Link/File Path: {desc}", extra={"markup": False})
+            logger.info(f"{self.tracker}: Custom Description: {desc}", extra={"markup": False})
             return {"description": desc}
 
         discs = cast(list[dict[str, Any]], meta.discs)

--- a/src/uphelper.py
+++ b/src/uphelper.py
@@ -596,12 +596,13 @@ class UploadHelper:
             lines.append(("Cover", poster))
 
         elif meta.category == "GAME":
-            notes = meta.description_link or meta.description_file or ""
-            if notes:
+            notes = "Inline description provided" if meta.description_inline else ""
+            if not notes:
+                notes = meta.description_link or meta.description_file or ""
                 # don't leak links or file paths
                 notes = notes[:16] if notes.startswith("http") else f"./{Path(notes).name}"
             if meta.platform == "PC":
-                notes = notes if notes else "[yellow][italic]Installation instructions missing. Use -df or -dp to add them.[/italic][/yellow]"
+                notes = notes if notes else "[yellow][italic]Installation instructions missing. Use --description, -df, or -pb to add them.[/italic][/yellow]"
 
             game_subcategory_str = {"full_game": "Full Game", "full_game_dlc": "Full Game + DLC", "dlc": "DLC", "update": "Update"}.get(meta.game_subcategory, "Unknown")
             game_subcategory = f"[italic]{meta.game_subcategory}[/italic] ({game_subcategory_str})"

--- a/tests/test_inline_description.py
+++ b/tests/test_inline_description.py
@@ -1,0 +1,42 @@
+# ruff: noqa: S101
+
+import asyncio
+
+from src.args import Args
+from src.get_desc import gen_desc
+from src.meta import Meta
+
+
+def test_description_argument_preserves_inline_bbcode(tmp_path) -> None:
+    description = "[alert]Missing S01E10[/alert]"
+
+    meta, _, _ = Args({"DEFAULT": {"screens": 1}}).parse(
+        [str(tmp_path), "--description", description],
+        Meta(),
+    )
+
+    assert meta.description_inline == description
+
+
+def test_inline_description_replaces_imported_text_but_keeps_auto_nfo_available(tmp_path) -> None:
+    async def run() -> None:
+        temp_dir = tmp_path / "tmp" / "release"
+        temp_dir.mkdir(parents=True)
+        (temp_dir / "release.nfo").write_text("NFO contents", encoding="utf-8")
+        meta = Meta(
+            base_dir=str(tmp_path),
+            uuid="release",
+            path=str(tmp_path / "release.mkv"),
+            description="imported tracker description",
+            description_inline="[alert]Missing S01E10[/alert]",
+            nfo=True,
+            auto_nfo=True,
+        )
+
+        await gen_desc(meta, None, None)
+
+        assert meta.description == "[alert]Missing S01E10[/alert]"
+        assert "Scene NFO" not in meta.description
+        assert meta.description_nfo_content == "NFO contents"
+
+    asyncio.run(run())


### PR DESCRIPTION
Useful for small descriptions like link to comps or origin of file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--description` command-line option for supplying a custom inline description.
  * Inline descriptions support BBCode and override imported descriptions when provided.
  * Added confirmation messaging to indicate when an inline description is being used.
* **Documentation**
  * Updated CLI help and documentation with usage guidance, including quoting text containing spaces or BBCode.
* **Bug Fixes**
  * Improved guidance shown when required PC installation instructions are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->