### PR TITLE
fix(metadata): distinguish release groups from technical terms

### DIFF
--- a/src/get_source.py
+++ b/src/get_source.py
@@ -10,6 +10,7 @@ from typing import Any
 from src.console import logger
 from src.exceptions import WeirdSystemError
 from src.meta import Meta
+from src.tags import get_tag
 
 GuessitFn = Callable[[str, dict[str, Any] | None], dict[str, Any]]
 _guessit_module = importlib.import_module("guessit")
@@ -18,6 +19,26 @@ _guessit_fn: GuessitFn = _guessit_module.guessit
 
 def guessit_fn(value: str, options: dict[str, Any] | None = None) -> dict[str, Any]:
     return _guessit_fn(value, options)
+
+
+async def _without_release_group(value: str, meta: Meta) -> str:
+    """Remove a recognized trailing release group before GuessIt detects the source."""
+    tag = await get_tag(value, meta)
+    if not tag:
+        return value
+
+    value_path = Path(value)
+    if value_path.is_dir():
+        stem = value_path.name
+        suffix = ""
+    else:
+        stem = value_path.stem
+        suffix = value_path.suffix
+
+    if not stem.casefold().endswith(tag.casefold()):
+        return value
+
+    return str(value_path.with_name(f"{stem[: -len(tag)]}{suffix}"))
 
 
 async def get_source(type: str, video: str, path: str, is_disc: str, meta: Meta, folder_id: str, base_dir: str) -> tuple[str, str]:
@@ -35,10 +56,12 @@ async def get_source(type: str, video: str, path: str, is_disc: str, meta: Meta,
             source = meta.manual_source
         else:
             try:
-                source = guessit_fn(video).get("source", source)
+                source_input = await _without_release_group(video, meta)
+                source = guessit_fn(source_input).get("source", source)
             except Exception:
                 try:
-                    source = guessit_fn(path).get("source", source)
+                    source_input = await _without_release_group(path, meta)
+                    source = guessit_fn(source_input).get("source", source)
                 except Exception:
                     source = "BluRay"
         if source in ("Blu-ray", "Ultra HD Blu-ray", "BluRay", "BR") or is_disc == "BDMV":

--- a/src/tags.py
+++ b/src/tags.py
@@ -13,6 +13,7 @@ from src.meta import Meta
 
 guessit_module = import_module("guessit")
 GuessitFn = Callable[[str, dict[str, Any] | None], dict[str, Any]]
+_TECHNICAL_HYPHEN_PREFIXES = {"blu", "dts", "web"}
 
 
 def guessit_fn(value: str, options: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -80,9 +81,13 @@ async def get_tag(video: str, meta: Meta, season_pack_check: bool = False) -> st
         )
         if non_anime_match:
             release_group = non_anime_match.group(1).strip()
+            hyphen_idx = non_anime_match.start() - 1
+            technical_prefix_match = re.search(r"([A-Za-z]+)$", basename_stripped[:hyphen_idx])
+            if technical_prefix_match and technical_prefix_match.group(1).casefold() in _TECHNICAL_HYPHEN_PREFIXES:
+                release_group = None
+
             # Prevent misinterpreting "Author - Title" space-hyphen-space separators as release groups
-            if meta.category in ("BOOK", "GAME") and release_group:
-                hyphen_idx = non_anime_match.start() - 1
+            if release_group and meta.category in ("BOOK", "GAME"):
                 if hyphen_idx > 0 and basename_stripped[hyphen_idx - 1].isspace():
                     release_group = None
                 else:

--- a/tests/test_get_source.py
+++ b/tests/test_get_source.py
@@ -1,0 +1,46 @@
+"""Regression tests for release source detection."""
+
+import pytest
+
+from src.get_name import NameManager
+from src.get_source import get_source
+from src.meta import Meta
+
+
+@pytest.mark.asyncio
+async def test_release_group_named_vhs_does_not_override_remux_source(tmp_path):
+    filename = "Example Movie 1995 (Alternate Title) 1080p Remux AVC FLAC 2.0-VHS.mkv"
+    meta = Meta(category="MOVIE", uuid=filename)
+
+    source, release_type = await get_source("REMUX", filename, filename, "", meta, "case", str(tmp_path))
+
+    assert source == "BluRay"
+    assert release_type == "REMUX"
+
+    name_meta = Meta(
+        category="MOVIE",
+        type=release_type,
+        source=source,
+        title="Example Movie",
+        aka="AKA Alternate Title",
+        year=1995,
+        resolution="1080p",
+        uhd="",
+        video_codec="AVC",
+        audio="FLAC 2.0",
+        tag="-VHS",
+    )
+    _name_notag, name, _clean_name, _potential_missing = await NameManager({}).get_name(name_meta)
+
+    assert name == "Example Movie AKA Alternate Title 1995 1080p BluRay REMUX AVC FLAC 2.0-VHS"
+
+
+@pytest.mark.asyncio
+async def test_vhs_source_before_a_distinct_release_group_is_preserved(tmp_path):
+    filename = "Movie.1995.1080p.VHS.Remux.AVC.FLAC.2.0-GROUP.mkv"
+    meta = Meta(category="MOVIE", uuid=filename)
+
+    source, release_type = await get_source("REMUX", filename, filename, "", meta, "case", str(tmp_path))
+
+    assert source == "VHS"
+    assert release_type == "REMUX"

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,0 +1,54 @@
+"""Regression tests for release-group extraction."""
+
+import pytest
+
+from src.get_name import NameManager
+from src.meta import Meta
+from src.tags import get_tag
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "Movie.2005.1080p.WEB-DL.mkv",
+        "Movie.2005.1080p.Blu-ray.mkv",
+    ],
+)
+@pytest.mark.asyncio
+async def test_technical_hyphens_are_not_release_group_separators(filename):
+    tag = await get_tag(filename, Meta(category="MOVIE", uuid=filename))
+
+    assert tag == ""
+
+
+@pytest.mark.asyncio
+async def test_dts_hd_audio_is_not_treated_as_a_release_group():
+    filename = "Example Movie 2005 1080p BluRay REMUX AVC DTS-HD MA 5.1.mkv"
+    tag = await get_tag(filename, Meta(category="MOVIE", uuid=filename))
+
+    assert tag == ""
+
+    name_meta = Meta(
+        category="MOVIE",
+        type="REMUX",
+        source="BluRay",
+        title="Example Movie",
+        year=2005,
+        resolution="1080p",
+        uhd="",
+        video_codec="AVC",
+        audio="DTS-HD MA 5.1",
+        tag=tag,
+    )
+    _name_notag, name, _clean_name, _potential_missing = await NameManager({}).get_name(name_meta)
+
+    assert name == "Example Movie 2005 1080p BluRay REMUX AVC DTS-HD MA 5.1"
+
+
+@pytest.mark.asyncio
+async def test_release_group_after_dts_hd_audio_is_preserved():
+    filename = "Movie.2005.1080p.BluRay.REMUX.AVC.DTS-HD.MA.5.1-GROUP.mkv"
+
+    tag = await get_tag(filename, Meta(category="MOVIE", uuid=filename))
+
+    assert tag == "-GROUP"


### PR DESCRIPTION
### Before / after

- `Example Movie 1995 (Alternate Title) 1080p Remux AVC FLAC 2.0-VHS.mkv`  
  Before: `-VHS`  
  After: `Example Movie AKA Alternate Title 1995 1080p BluRay REMUX AVC FLAC 2.0-VHS`

- `Example Movie 2005 1080p BluRay REMUX AVC DTS-HD MA 5.1.mkv`  
  Before: `Example Movie 2005 1080p BluRay REMUX AVC DTS-HD MA 5.1-HD MA 5.1`  
  After: `Example Movie 2005 1080p BluRay REMUX AVC DTS-HD MA 5.1`

- `Example Movie 2005 1080p WEB-DL.mkv`  
  Before: `Example Movie 2005 1080p WEB-DL-DL`  
  After: `Example Movie 2005 1080p WEB-DL`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release source detection for filenames containing release-group tags.
  * Prevented technical terms such as WEB-DL, Blu-ray, and DTS-HD from being mistaken for release groups.
  * Preserved valid release groups appearing after technical audio or video descriptors.
  * Ensured filenames and detected metadata remain correct in affected cases.

* **Tests**
  * Added regression coverage for source detection and release-group extraction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->