### PR TITLE
fix(unit3d): omit scene NFO from descriptions

### DIFF
--- a/src/get_desc.py
+++ b/src/get_desc.py
@@ -1352,6 +1352,10 @@ class DescriptionBuilder:
         else:
             meta_description = str(meta_description_value)
 
+        if not nfo and meta.auto_nfo and meta.description_nfo_content:
+            scene_nfo_block = f"[center][spoiler=Scene NFO:][code]{meta.description_nfo_content}[/code][/spoiler][/center]"
+            meta_description = meta_description.replace(scene_nfo_block, "").strip()
+
         # Description that may come from API requests
         if description:
             # Add FraMeSToR NFO to AITHER

--- a/tests/test_description_review.py
+++ b/tests/test_description_review.py
@@ -7,6 +7,7 @@ import json
 from src.description_review import load_review
 from src.get_desc import DescriptionBuilder, gen_desc
 from src.meta import Meta
+from src.trackers.UNIT3D import UNIT3D
 from web_ui import server
 
 
@@ -141,5 +142,53 @@ def test_description_file_is_not_rendered_twice_when_both_sections_are_enabled(t
         )
 
         assert result == "release notes"
+
+    asyncio.run(run())
+
+
+def test_unit3d_omits_scene_nfo_from_description_but_keeps_attachment(tmp_path):
+    async def run():
+        temp_dir = tmp_path / "tmp" / "release"
+        temp_dir.mkdir(parents=True)
+        nfo_content = "scene nfo content"
+        (temp_dir / "release.nfo").write_text(nfo_content, encoding="utf-8")
+        meta = Meta(
+            {
+                "base_dir": str(tmp_path),
+                "uuid": "release",
+                "auto_nfo": True,
+                "nfo": True,
+                "description_nfo_content": nfo_content,
+                "description": f"[center][spoiler=Scene NFO:][code]{nfo_content}[/code][/spoiler][/center]\nRelease notes",
+            }
+        )
+        config = {"DEFAULT": {}, "TRACKERS": {"UNIT3D": {}}}
+        builder = DescriptionBuilder("UNIT3D", config)
+
+        description = await builder.general_description_generator(
+            meta,
+            audio_spectrogram=False,
+            bluray=False,
+            book=False,
+            custom_header=False,
+            custom_signature=False,
+            game=False,
+            languages=False,
+            logo=False,
+            mediainfo=False,
+            menu_screenshots=False,
+            nfo=False,
+            screenshots=False,
+            tonemapped_header=False,
+            tv_info=False,
+            ua_signature=False,
+            user_description=False,
+            music=False,
+            dynamic_hdr_plot=False,
+        )
+        files = await UNIT3D(config, "UNIT3D").get_additional_files(meta)
+
+        assert description == "Release notes"
+        assert files["nfo"] == ("nfo_file.nfo", nfo_content.encode(), "text/plain")
 
     asyncio.run(run())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate Scene NFO spoiler sections from appearing in descriptions when NFO display is disabled.
  * Scene NFO files remain available as downloadable attachments.
* **Tests**
  * Added coverage to verify correct description content and NFO attachment handling for UNIT3D releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->