### PR TITLE
fix(dreadvault): canonicalize DVL alias before checks

### DIFF
--- a/src/trackersetup.py
+++ b/src/trackersetup.py
@@ -182,7 +182,10 @@ class TrackerSetup:
             return
 
         supported_trackers: list[str] = []
-        for tracker_name in trackers:
+        for requested_tracker_name in trackers:
+            tracker_name = Meta.canonical_tracker_name(str(requested_tracker_name).strip())
+            if not tracker_name:
+                continue
             tracker_class = tracker_class_map.get(tracker_name.upper())
             if not tracker_class:
                 supported_trackers.append(tracker_name)

--- a/tests/test_dreadvault.py
+++ b/tests/test_dreadvault.py
@@ -4,7 +4,7 @@ import pytest
 
 from src.meta import _TRACKER_ID_ALIASES, Meta
 from src.trackers.UNIT3D.dreadvault import DreadVault
-from src.trackersetup import tracker_class_map
+from src.trackersetup import TrackerSetup, tracker_class_map
 
 
 def _tracker() -> DreadVault:
@@ -21,6 +21,15 @@ def test_dreadvault_dvl_alias_resolves_to_the_canonical_name():
     # DVL is the site's own abbreviation, confirmed by DreadVault staff.
     assert _TRACKER_ID_ALIASES["DVL"] == "DREADVAULT"  # noqa: S101
     assert Meta().canonical_tracker_name("dvl") == "DREADVAULT"  # noqa: S101
+
+
+def test_dreadvault_dvl_cli_alias_is_canonicalized_before_tracker_checks():
+    meta = Meta(category="MOVIE", trackers=["DVL"])
+    setup = TrackerSetup({"TRACKERS": {"DREADVAULT": {"api_key": "test-token"}}})
+
+    setup.filter_unsupported_trackers(meta)
+
+    assert meta.trackers == ["DREADVAULT"]  # noqa: S101
 
 
 def test_dreadvault_bans_the_published_groups():


### PR DESCRIPTION
`-tk DVL` was filtered as unknown before alias canonicalization, so DreadVault dupe search could be skipped.
Canonicalize requested names at the tracker-filter boundary before class and config checks.
Add regression coverage that `DVL` resolves to `DREADVAULT`.
Checks: `pytest` (864 passed, 2 skipped); `ruff check .`.
NAS trial: Ring exact dupe blocked; fresh Bugonia passed through under `-debug -ns`.