### PR TITLE
fix(metadata): improve detecting streaming service from scene NFO

### DIFF
--- a/src/nfo.py
+++ b/src/nfo.py
@@ -1,0 +1,64 @@
+from collections.abc import Mapping
+from urllib.parse import urlsplit
+
+
+def _source_value(line: str) -> str | None:
+    if "==" in line:
+        label, value = line.split("==", 1)
+    elif ":" in line:
+        label, value = line.split(":", 1)
+    else:
+        return None
+
+    label_words = "".join(char if char.isalpha() else " " for char in label).split()
+    if [word.casefold() for word in label_words] != ["source"]:
+        return None
+
+    return value.strip()
+
+
+def _normalize_service_name(value: str) -> str:
+    value = value.strip()
+    if "://" in value or ("." in value and " " not in value):
+        parsed = urlsplit(value if "://" in value else f"//{value}")
+        if parsed.hostname:
+            value = parsed.hostname.removeprefix("www.").split(".", 1)[0]
+
+    value = value.casefold().replace("+", "plus")
+    return "".join(char for char in value if char.isalnum())
+
+
+def _resolve_service(value: str, services: Mapping[str, str]) -> tuple[str, str] | None:
+    normalized_value = _normalize_service_name(value)
+    if not normalized_value:
+        return None
+
+    aliases = [(_normalize_service_name(name), code) for name, code in services.items()]
+
+    for alias, code in aliases:
+        if alias == normalized_value:
+            return code, max((name for name, candidate_code in services.items() if candidate_code == code), key=len, default=code)
+
+    fuzzy_codes = {
+        code
+        for alias, code in aliases
+        if min(len(alias), len(normalized_value)) >= 4 and (alias.startswith(normalized_value) or normalized_value.startswith(alias))
+    }
+    if len(fuzzy_codes) == 1:
+        code = fuzzy_codes.pop()
+        return code, max((name for name, candidate_code in services.items() if candidate_code == code), key=len, default=code)
+
+    return None
+
+
+def parse_nfo_streaming_service(nfo_content: str, services: Mapping[str, str]) -> tuple[str, str, str] | None:
+    """Return the NFO source value, service code, and service name when recognized."""
+    for line in nfo_content.splitlines():
+        source = _source_value(line)
+        if source is None:
+            continue
+        service = _resolve_service(source, services)
+        if service:
+            code, name = service
+            return source, code, name
+    return None

--- a/src/prep.py
+++ b/src/prep.py
@@ -39,6 +39,7 @@ try:
     from src.music.prep import enrich_music_from_discogs as _enrich_music_from_discogs_fn
     from src.music.prep import enrich_music_from_orpheus as _enrich_music_from_orpheus_fn
     from src.music.prep import gather_music_prep as _gather_music_prep_fn
+    from src.nfo import parse_nfo_streaming_service
     from src.prep_game import gather_game_prep as _gather_game_prep_fn
     from src.prep_game import resolve_game_filelist as _resolve_game_filelist_fn
     from src.radarr import RadarrManager
@@ -444,22 +445,12 @@ class Prep:
             async with aiofiles.open(nfo_file, encoding="utf-8", errors="ignore") as f:
                 nfo_content = await f.read()
 
-            # Parse Source field
-            source_match = re.search(r"^Source\s*:\s*(.+?)$", nfo_content, re.MULTILINE | re.IGNORECASE)
-            if source_match:
-                nfo_source = source_match.group(1).strip()
+            services = cast(dict[str, str], await get_service(get_services_only=True))
+            service = parse_nfo_streaming_service(nfo_content, services)
+            if service:
+                nfo_source, meta.service, meta.service_longname = service
                 logger.debug(f"[cyan]Found source in NFO: {nfo_source}[/cyan]")
-
-                # Check if source matches any service
-                services = cast(dict[str, str], await get_service(get_services_only=True))
-
-                # Exact match
-                for service_name, service_code in services.items():
-                    if nfo_source.upper() == service_name.upper() or nfo_source.upper() == service_code.upper():
-                        meta.service = service_code
-                        meta.service_longname = service_name
-                        logger.debug(f"[green]Matched service: {service_code} ({service_name})[/green]")
-                        break
+                logger.debug(f"[green]Matched service: {meta.service} ({meta.service_longname})[/green]")
 
         except Exception as e:
             logger.debug(f"[red]Error parsing NFO file: {e}[/red]")

--- a/src/prep_helpers.py
+++ b/src/prep_helpers.py
@@ -1625,7 +1625,7 @@ async def finalize_metadata(
             meta.service_longname = max((k for k, v in services.items() if v == service_code), key=len, default=service_code)
 
         # Parse NFO for scene releases to get service
-        if meta.scene and not meta.service and meta.category == "TV":
+        if meta.scene and not meta.service and meta.category in ("TV", "MOVIE"):
             await prep_instance.parse_scene_nfo(meta)
 
         # Combine genres from TMDB and IMDb

--- a/src/region.py
+++ b/src/region.py
@@ -2280,6 +2280,7 @@ async def get_service(
         "PMTP": "PMTP",
         "POGO": "POGO",
         "PokerGO": "POGO",
+        "Prime Video": "AMZN",
         "PSN": "PSN",
         "PUHU": "PUHU",
         "QIBI": "QIBI",

--- a/tests/test_nfo_service.py
+++ b/tests/test_nfo_service.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+import pytest
+
+from src.meta import Meta
+from src.nfo import parse_nfo_streaming_service
+from src.prep import Prep
+
+
+@pytest.mark.parametrize(
+    ("source_line", "expected"),
+    [
+        ("  Source       : Netflix", ("NF", "Netflix")),
+        ("Source......: Netflix", ("NF", "Netflix")),
+        ("Source: HULU", ("HULU", "Hulu")),
+        ("Source       : AMAZON", ("AMZN", "Amazon Prime")),
+        ("Source: Prime Video", ("AMZN", "Amazon Prime")),
+        ("source: primevideo.example", ("AMZN", "Amazon Prime")),
+        ("source: peacocktv.example", ("PCOK", "Peacock")),
+        ("source: disneyplus.example", ("DSNP", "Disney+")),
+        ("SOURCE == https://amazon.example/title", ("AMZN", "Amazon Prime")),
+    ],
+)
+def test_parse_nfo_streaming_service_supports_common_source_fields(source_line: str, expected: tuple[str, str]) -> None:
+    service_map = {
+        "Amazon Prime": "AMZN",
+        "AMZN": "AMZN",
+        "Disney": "DSNY",
+        "Disney+": "DSNP",
+        "DSNP": "DSNP",
+        "Hulu": "HULU",
+        "HULU": "HULU",
+        "Netflix": "NF",
+        "NF": "NF",
+        "Peacock": "PCOK",
+        "PCOK": "PCOK",
+        "Prime Video": "AMZN",
+    }
+    nfo = f"Example.Movie.2024.1080p.WEB.H264-GROUP\n{source_line}\n"
+
+    result = parse_nfo_streaming_service(nfo, service_map)
+
+    assert result is not None
+    assert result[1:] == expected
+
+
+@pytest.mark.parametrize(
+    "source_line",
+    [
+        "Source: WEB",
+        "Source: Amazon / iTunes",
+        "Source: Apple",
+        "Video Source: Netflix",
+        "We are looking for Netflix cappers",
+    ],
+)
+def test_parse_nfo_streaming_service_ignores_non_service_and_ambiguous_text(source_line: str) -> None:
+    services = {"Amazon Prime": "AMZN", "Apple TV": "ATV", "Apple TV+": "ATVP", "iTunes": "iT", "Netflix": "NF"}
+    assert parse_nfo_streaming_service(source_line, services) is None
+
+
+@pytest.mark.asyncio
+async def test_parse_scene_nfo_sets_service_for_movie(tmp_path: Path) -> None:
+    nfo_file = tmp_path / "example.movie.2024.1080p.web.h264-group.nfo"
+    nfo_file.write_text("Example.Movie.2024.1080p.WEB.H264-GROUP\nSource: Prime Video\n", encoding="utf-8")
+    meta = Meta(category="MOVIE", scene=True, scene_nfo_file=nfo_file)
+
+    await Prep.__new__(Prep).parse_scene_nfo(meta)
+
+    assert meta.service == "AMZN"
+    assert meta.service_longname == "Amazon Prime"


### PR DESCRIPTION
### Newly supported examples

- `  Source       : Amazon` → `AMZN`
- `Source......: Netflix` → `NF`
- `Source: PEACOCKTV` → `PCOK`
- `source: peacocktv.com` → `PCOK`
- `source: disneyplus.com` → `DSNP`
- `SOURCE == http://amazon.com` → `AMZN`
- `SOURCE == http://hulu.com` → `HULU`
- `Source: Prime Video` → `AMZN`
- `source: primevideo.com` → `AMZN`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added streaming-service detection from NFO metadata, supporting multiple source formats, aliases, and capitalization styles.
  * Extended service detection to movie and TV releases.
  * Added Prime Video as a recognized name for the AMZN service code.

* **Bug Fixes**
  * Improved handling of service names with URLs, separators, and common variations.
  * Prevented generic, ambiguous, or unrelated text from being incorrectly identified as a streaming provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->