### PR TITLE
feat(dupes): configure exact match policy

### DIFF
--- a/data/example_config.py
+++ b/data/example_config.py
@@ -1049,6 +1049,8 @@ config: dict[str, Any] = {
             # Your API Key, obtained from Perfil -> API Key
             "api_key": "",
             "anon": True,
+            # Only block uploads when the existing release exactly matches files.
+            "exact_match_only": False,
             "inject_delay": 0,
         },
         "DARKPEERS": {
@@ -1172,6 +1174,8 @@ config: dict[str, Any] = {
             "use_for_search": False,
             "api_key": "",
             "anon": True,
+            # Only block uploads when the existing release exactly matches files and size.
+            "exact_match_only": True,
             # For authorized users only. Do not change this unless you know what you are doing
             # Upload as featured
             "featured": False,
@@ -1213,6 +1217,8 @@ config: dict[str, Any] = {
             # Maximum number of API hits the script may make within 24 hours for duplicate search.
             # Set to 0 to disable duplicate search via API.
             "daily_api_hit_limit": 0,
+            # Only block uploads when the existing release exactly matches files.
+            "exact_match_only": False,
             "inject_delay": 0,
         },
         "EMUWAREZ": {
@@ -2085,6 +2091,8 @@ config: dict[str, Any] = {
             # Maximum number of API hits the script may make within 24 hours for duplicate search.
             # Set to 0 to disable duplicate search via API.
             "daily_api_hit_limit": 0,
+            # Only block uploads when the existing release exactly matches files.
+            "exact_match_only": False,
             "inject_delay": 0,
         },
         "OLDTOONSWORLD": {
@@ -2196,6 +2204,8 @@ config: dict[str, Any] = {
             "use_for_search": False,
             "api_key": "",
             "anon": True,
+            # Only block uploads when the existing release exactly matches files and size.
+            "exact_match_only": True,
             # Send uploads to PEERGARDEN modq for staff approval
             "modq": False,
             # For authorized users only. Do not change this unless you know what you are doing
@@ -2779,6 +2789,8 @@ config: dict[str, Any] = {
             # "use_for_search": False, set to True if using this tracker for automatic ID searching or description parsing
             "use_for_search": False,
             "api_key": "",
+            # Only block uploads when the existing release exactly matches files and size.
+            "exact_match_only": False,
             # For authorized users only. Do not change this unless you know what you are doing
             # Upload as featured
             "featured": False,
@@ -2942,6 +2954,8 @@ config: dict[str, Any] = {
             # Set to 0 to disable duplicate search via API.
             "daily_api_hit_limit": 0,
             "anon": True,
+            # Only block uploads when the existing release exactly matches files.
+            "exact_match_only": False,
             # If False, the indexer will decide (uses ID "0").
             # If True, the script will resolve the audio language ID:
             #   - 1 language: uses the ID for that language.

--- a/src/configvalidator.py
+++ b/src/configvalidator.py
@@ -714,6 +714,7 @@ def _validate_trackers_section(trackers: dict[str, Any], active_trackers: list[s
             "refundable",
             "sticky",
             "exclusive",
+            "exact_match_only",
         ]
         for field in bool_fields:
             if field in tracker_config_dict:

--- a/src/dupe_checking.py
+++ b/src/dupe_checking.py
@@ -196,7 +196,25 @@ class DupeChecker:
         from src.trackersetup import tracker_class_map
 
         tracker_cls = tracker_class_map.get(tracker_name.upper())
-        is_exact_match_only = bool(getattr(tracker_cls, "exact_match_only", False))
+        # Usenet releases may include optional PAR2 recovery files, so their
+        # reported size can differ even when the payload files are identical.
+        # Torrent releases do not have this packaging difference, so retain
+        # the size check for them.
+        is_usenet = bool(getattr(tracker_cls, "is_usenet", False))
+        tracker_config = self.config.get("TRACKERS", {}).get(tracker_name.upper(), {})
+        supports_exact_match_only = hasattr(tracker_cls, "exact_match_only")
+        has_configured_exact_match_only = isinstance(tracker_config, dict) and "exact_match_only" in tracker_config
+        configured_exact_match_only = tracker_config.get("exact_match_only") if has_configured_exact_match_only else None
+        if has_configured_exact_match_only and not supports_exact_match_only:
+            logger.warning(
+                f"{tracker_name}: 'exact_match_only' is not supported by this tracker and will be ignored.",
+                extra={"markup": False},
+            )
+        is_exact_match_only = (
+            configured_exact_match_only
+            if supports_exact_match_only and isinstance(configured_exact_match_only, bool)
+            else bool(getattr(tracker_cls, "exact_match_only", False))
+        )
 
         async def log_exclusion(reason: str, item: str) -> None:
             if meta.debug:
@@ -211,7 +229,7 @@ class DupeChecker:
             sized = entry.get("size")  # This may come as a string, such as "1.5 GB"
 
             if is_exact_match_only:
-                is_exact = await DupeChecker.is_exact_match(entry, meta)
+                is_exact = await DupeChecker.is_exact_match(entry, meta, ignore_size=is_usenet)
                 if not is_exact:
                     await log_exclusion("non-exact release (allowed on exact-match-only tracker)", each)
                     return True
@@ -847,8 +865,8 @@ class DupeChecker:
         return new_dupes
 
     @staticmethod
-    async def is_exact_match(candidate: dict[str, Any] | DupeEntry, meta: Meta) -> bool:
-        """Check if candidate torrent is an exact match / exact renamed release of local upload."""
+    async def is_exact_match(candidate: dict[str, Any] | DupeEntry, meta: Meta, *, ignore_size: bool = False) -> bool:
+        """Check whether a candidate is an exact (possibly renamed) release of the local upload."""
         from pathlib import Path
 
         from src.uphelper import parse_size_to_bytes
@@ -888,24 +906,25 @@ class DupeChecker:
         files_match = bool(local_files and candidate_files and sorted(local_files) == sorted(candidate_files))
         same_file_count = local_file_count is not None and candidate_file_count > 0 and local_file_count == candidate_file_count
         same_size = local_size is not None and candidate_size is not None and local_size == candidate_size
+        size_match = ignore_size or same_size
 
         # 5. Check if both have file lists
         if local_files and candidate_files:
-            return files_match and same_size
+            return files_match and size_match
 
         # 6. If file list unavailable for one or both (e.g. disc release)
-        if same_size and same_file_count:
+        if size_match and same_file_count:
             return True
 
         # Disc releases have no reliable local file count, so compare their
         # total size when neither side provides a file list.
-        if not local_files and not candidate_files and same_size:
+        if not local_files and not candidate_files and size_match:
             return True
 
         # 7. Exact name match fallback
         candidate_name = str(candidate.get("name", "")).strip().lower()
         local_name = str(meta.name or "").strip().lower()
-        return bool(candidate_name and local_name and candidate_name == local_name and (same_size or local_size is None or candidate_size is None))
+        return bool(candidate_name and local_name and candidate_name == local_name and (size_match or local_size is None or candidate_size is None))
 
     @staticmethod
     async def normalize_filename(filename: str | MutableMapping[str, Any]) -> str:

--- a/src/dupe_checking.py
+++ b/src/dupe_checking.py
@@ -913,12 +913,12 @@ class DupeChecker:
             return files_match and size_match
 
         # 6. If file list unavailable for one or both (e.g. disc release)
-        if size_match and same_file_count:
+        if not ignore_size and size_match and same_file_count:
             return True
 
         # Disc releases have no reliable local file count, so compare their
         # total size when neither side provides a file list.
-        if not local_files and not candidate_files and size_match:
+        if not ignore_size and not local_files and not candidate_files and size_match:
             return True
 
         # 7. Exact name match fallback

--- a/src/trackers/UNIT3D/seedpool.py
+++ b/src/trackers/UNIT3D/seedpool.py
@@ -29,6 +29,7 @@ class Seedpool(UNIT3D):
     supported_categories = ("TV", "MOVIE", "BOOK", "GAME", "MUSIC")
     tracker_urls = ("https://seedpool.org",)
     allows_bloated_audio = True
+    exact_match_only = False
 
     def __init__(self, config: Config) -> None:
         super().__init__(config, tracker_name="SEEDPOOL")

--- a/src/trackers/USENET/curupira.py
+++ b/src/trackers/USENET/curupira.py
@@ -117,6 +117,7 @@ class Curupira:
     supported_categories = ("TV", "MOVIE", "GAME", "BOOK")
     is_usenet = True
     allows_bloated_audio = True
+    exact_match_only = False
 
     def __init__(self, config: Config) -> None:
         self.config = config

--- a/src/trackers/USENET/drunkenslug.py
+++ b/src/trackers/USENET/drunkenslug.py
@@ -37,6 +37,7 @@ class DrunkenSlug:
     torrent_url = f"{base_url}/search/"
     supported_categories = ("TV", "MOVIE", "GAME", "BOOK")
     is_usenet = True
+    exact_match_only = False
 
     def __init__(self, config: Config) -> None:
         self.config = config

--- a/src/trackers/USENET/nzbgeek.py
+++ b/src/trackers/USENET/nzbgeek.py
@@ -35,6 +35,7 @@ class NZBGeek:
     banned_groups: tuple[str, ...] = ()
     supported_categories = ("TV", "MOVIE", "GAME", "BOOK", "MUSIC")
     is_usenet = True
+    exact_match_only = False
 
     def __init__(self, config: Config) -> None:
         self.config = config

--- a/src/trackers/USENET/suio.py
+++ b/src/trackers/USENET/suio.py
@@ -45,6 +45,7 @@ class Suio:
     base_url = "https://suio.cc"
     supported_categories = ("MOVIE", "TV", "GAME", "BOOK", "XXX")
     is_usenet = True
+    exact_match_only = False
 
     def __init__(self, config: Config) -> None:
         self.config = config

--- a/tests/test_suio.py
+++ b/tests/test_suio.py
@@ -1,0 +1,45 @@
+import asyncio
+from unittest.mock import Mock
+
+import src.dupe_checking as dupe_checking
+from src.dupe_checking import DupeChecker
+from src.meta import Meta
+from src.trackers.USENET.suio import Suio
+
+
+def test_suio_uses_exact_match_only_duplicate_detection():
+    assert Suio.exact_match_only is False  # noqa: S101
+
+
+def test_tracker_config_overrides_exact_match_only(monkeypatch):
+    async def non_exact_match(_candidate, _meta, **_kwargs):
+        return False
+
+    monkeypatch.setattr(DupeChecker, "is_exact_match", non_exact_match)
+    candidate = {"name": "related release", "size": 1, "files": []}
+
+    result = asyncio.run(DupeChecker({"TRACKERS": {"SUIO": {"exact_match_only": False}}}).filter_dupes([candidate], Meta(), "SUIO"))
+
+    assert len(result) == 1  # noqa: S101
+    assert result[0]["name"] == candidate["name"]  # noqa: S101
+
+
+def test_suio_exact_match_ignores_size():
+    meta = Meta(name="Release", filelist=["/path/Release.mkv"], source_size=100)
+    candidate = {"name": "Renamed Release", "size": 200, "files": ["Release.mkv"], "file_count": 1}
+
+    result = asyncio.run(DupeChecker({"TRACKERS": {"SUIO": {"exact_match_only": True}}}).filter_dupes([candidate], meta, "SUIO"))
+
+    assert len(result) == 1  # noqa: S101
+
+
+def test_tracker_config_ignores_exact_match_only_when_tracker_does_not_support_it(monkeypatch):
+    warning = Mock()
+    monkeypatch.setattr(dupe_checking.logger, "warning", warning)
+    candidate = {"name": "related release", "size": 1, "files": []}
+
+    result = asyncio.run(DupeChecker({"TRACKERS": {"ASIANCINEMA": {"exact_match_only": True}}}).filter_dupes([candidate], Meta(), "ASIANCINEMA"))
+
+    assert len(result) == 1  # noqa: S101
+    warning.assert_called_once()
+    assert "ignored" in warning.call_args.args[0]  # noqa: S101

--- a/tests/test_suio.py
+++ b/tests/test_suio.py
@@ -33,6 +33,15 @@ def test_suio_exact_match_ignores_size():
     assert len(result) == 1  # noqa: S101
 
 
+def test_suio_incomplete_candidate_is_not_exact_without_file_list():
+    meta = Meta(name="Release", filelist=["/path/Release.mkv"], source_size=100)
+    candidate = {"name": "Related Release", "size": 200, "files": [], "file_count": 1}
+
+    result = asyncio.run(DupeChecker.is_exact_match(candidate, meta, ignore_size=True))
+
+    assert result is False  # noqa: S101
+
+
 def test_tracker_config_ignores_exact_match_only_when_tracker_does_not_support_it(monkeypatch):
     warning = Mock()
     monkeypatch.setattr(dupe_checking.logger, "warning", warning)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable exact-match duplicate detection for supported trackers.
  * Uploads can require an exact file match before being blocked, with tracker-specific size handling.
  * Added default exact-match settings for additional Usenet and torrent trackers.
* **Bug Fixes**
  * Improved duplicate detection consistency across tracker types.
  * Unsupported exact-match settings now generate a warning and are safely ignored.
* **Tests**
  * Added coverage for default behavior, configuration overrides, size handling, and unsupported settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->