### PR TITLE
fix(cli): stop ffmpeg subprocess from grabbing the cli input

### DIFF
--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -385,6 +385,7 @@ async def run_ffmpeg(command: Any) -> tuple[int | None, bytes, bytes]:
     # Spawn the selected bundled binary or the system/default command.
     process = await asyncio.create_subprocess_exec(
         *cmd_list,
+        stdin=asyncio.subprocess.DEVNULL,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
         env=process_env,


### PR DESCRIPTION
ffmpeg was attaching itself to the terminals standard input, causing the cli input fields to be unresponsive

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented background video processing from receiving unintended keyboard input from the parent application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->