### PR TITLE
fix(webui): empty Image Host dropdowns in Config UI

### DIFF
--- a/tests/test_webui_image_hosts.py
+++ b/tests/test_webui_image_hosts.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_config_page_loads_image_host_fallback_before_app() -> None:
+    template = (ROOT / "web_ui" / "templates" / "config.html").read_text(encoding="utf-8")
+    fallback = "js/config_image_host_fallback.js"
+    app = "js/config_app.js"
+
+    assert fallback in template
+    assert template.index(fallback) < template.index(app)
+
+
+def test_image_host_fallback_contains_common_hosts() -> None:
+    script = (ROOT / "web_ui" / "static" / "js" / "config_image_host_fallback.js").read_text(encoding="utf-8")
+
+    for host in ("ptscreens", "imgbb", "imgbox", "pixhost"):
+        assert f'"{host}"' in script
+
+    assert 'includes("/api/config_options")' in script
+    assert 'startsWith("img_host_")' in script

--- a/web_ui/static/js/config_image_host_fallback.js
+++ b/web_ui/static/js/config_image_host_fallback.js
@@ -1,0 +1,82 @@
+// Keep Image Host dropdowns usable when config metadata omits the host list.
+(() => {
+  const IMAGE_HOSTS = Object.freeze([
+    "dalexni",
+    "imgbb",
+    "imgbox",
+    "lensdump",
+    "lostimg",
+    "midnightscene",
+    "onlyimage",
+    "passtheimage",
+    "pixhost",
+    "ptscreens",
+    "seedpool_cdn",
+    "sharex",
+    "utppm",
+    "zipline",
+  ]);
+
+  const originalApiFetch = window.uaApiFetch;
+  if (typeof originalApiFetch !== "function") {
+    return;
+  }
+
+  const ensureImageHostHelp = (data) => {
+    if (!data || !Array.isArray(data.sections)) {
+      return data;
+    }
+
+    const helpLine = `Available image hosts: ${IMAGE_HOSTS.join(", ")}`;
+
+    const visitItems = (items) => {
+      for (const item of items || []) {
+        if (Array.isArray(item.children)) {
+          visitItems(item.children);
+        }
+        if (!String(item.key || "").startsWith("img_host_")) {
+          continue;
+        }
+
+        if (!Array.isArray(item.help)) {
+          item.help = [];
+        }
+        if (
+          !item.help.some((line) =>
+            String(line).toLowerCase().includes("available image hosts"),
+          )
+        ) {
+          item.help.push(helpLine);
+        }
+      }
+    };
+
+    for (const section of data.sections) {
+      visitItems(section.items || []);
+    }
+    return data;
+  };
+
+  window.uaApiFetch = async (...args) => {
+    const response = await originalApiFetch(...args);
+    const url = String(args[0] || "");
+    if (!url.includes("/api/config_options") || !response || !response.ok) {
+      return response;
+    }
+
+    try {
+      const data = ensureImageHostHelp(await response.clone().json());
+      const headers = new Headers(response.headers);
+      headers.delete("content-length");
+      return new Response(JSON.stringify(data), {
+        status: response.status,
+        statusText: response.statusText,
+        headers,
+      });
+    } catch (_error) {
+      return response;
+    }
+  };
+
+  window.UA_IMAGE_HOSTS = IMAGE_HOSTS;
+})();

--- a/web_ui/templates/config.html
+++ b/web_ui/templates/config.html
@@ -74,6 +74,10 @@
       src="{{ url_for('static', filename='js/shared_utils.js') }}"
     ></script>
     <script
+      type="text/javascript"
+      src="{{ url_for('static', filename='js/config_image_host_fallback.js') }}"
+    ></script>
+    <script
       type="text/babel"
       src="{{ url_for('static', filename='js/config_app.js') }}"
     ></script>


### PR DESCRIPTION
Fixes the Config UI Image Host selectors showing only an empty option when image-host metadata is missing.

The dropdown options are normally derived from the `Available image hosts:` metadata returned by `/api/config_options`. When that metadata is absent, the frontend receives an empty host list and all Image Host selectors become unusable.

This change:
- provides the supported image-host list as a fallback when the metadata is missing
- preserves existing configured values
- keeps the existing duplicate-host filtering behavior
- adds regression tests for the fallback and script load order

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved image-host configuration guidance when host metadata is unavailable.
  * Added a fallback list of common image hosts to image-host settings.
  * Ensured image-host help appears across nested configuration options.

* **Tests**
  * Added coverage verifying script loading order and fallback content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->