### PR TITLE
fix(digitalcore): plain img tags; retry torrent download

### DIFF
--- a/src/get_desc.py
+++ b/src/get_desc.py
@@ -2115,6 +2115,7 @@ class DescriptionBuilder:
             description = description.replace("[code]", "[pre]").replace("[/code]", "[/pre]")
 
         if tracker == "DIGITALCORE":
+            description = bbcode.remove_img_resize(description)
             description = description.replace("[user]", "").replace("[/user]", "")
             description = description.replace("[align=left]", "").replace("[/align]", "")
             description = description.replace("[right]", "").replace("[/right]", "")

--- a/src/trackers/common.py
+++ b/src/trackers/common.py
@@ -363,7 +363,7 @@ class Common:
 
                 if hash_is_id:
                     return await self.get_torrent_hash(meta, tracker)
-                return None
+                return path
 
             except Exception as e:
                 logger.warning(f"[yellow]Warning: Could not download torrent file: {e!s}[/yellow]")

--- a/src/trackers/digitalcore.py
+++ b/src/trackers/digitalcore.py
@@ -274,9 +274,14 @@ class DigitalCore:
                             torrent_id = str(response_data["id"])
                             meta.tracker_status[self.tracker]["torrent_id"] = torrent_id + "/"
                             meta.tracker_status[self.tracker]["status_message"] = response_data.get("message")
-                            await self.common.download_tracker_torrent(
-                                meta, self.tracker, headers=dict(self.session.headers), downurl=f"{self.api_base_url}/download/{torrent_id}"
-                            )
+                            # the .torrent is generated asynchronously; an immediate download 404s
+                            for attempt in range(4):
+                                if await self.common.download_tracker_torrent(
+                                    meta, self.tracker, headers=dict(self.session.headers), downurl=f"{self.api_base_url}/download/{torrent_id}"
+                                ):
+                                    break
+                                if attempt < 3:
+                                    await asyncio.sleep(10 * (attempt + 1))
                             return True
 
                         meta.tracker_status[self.tracker]["status_message"] = f"data error: {response_data.get('message', 'Unknown API error.')}"

--- a/tests/test_digitalcore_description.py
+++ b/tests/test_digitalcore_description.py
@@ -1,0 +1,61 @@
+"""Regression tests for DigitalCore description formatting and torrent download."""
+
+import contextlib
+
+import pytest
+
+from src.get_desc import DescriptionBuilder
+from src.meta import Meta
+from src.trackers.common import Common
+
+
+def test_digitalcore_rewrites_sized_img_tags_to_plain_img():
+    builder = DescriptionBuilder("DIGITALCORE", {"DEFAULT": {}, "TRACKERS": {"DIGITALCORE": {}}})
+    description = "[url=https://img.example/1][img=350]https://img.example/1.png[/img][/url]"
+
+    formatted = builder.tracker_specific_formats("DIGITALCORE", description)
+
+    assert "[img=350]" not in formatted
+    assert "[img]https://img.example/1.png[/img]" in formatted
+
+
+def _patch_client(monkeypatch, fail):
+    class Client:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        @contextlib.asynccontextmanager
+        async def stream(self, method, url):
+            yield self
+
+        def raise_for_status(self):
+            if fail:
+                raise RuntimeError("404")
+
+        async def aiter_bytes(self):
+            yield b"torrent-data"
+
+    monkeypatch.setattr("src.trackers.common.httpx.AsyncClient", Client)
+
+
+@pytest.mark.asyncio
+async def test_download_tracker_torrent_returns_the_path_only_on_success(tmp_path, monkeypatch):
+    meta = Meta(base_dir=str(tmp_path), uuid="case")
+    (tmp_path / "tmp" / "case").mkdir(parents=True)
+    torrent_path = tmp_path / "tmp" / "case" / "[TESTTRK].torrent"
+    torrent_path.write_bytes(b"stale")
+    common = Common({})
+
+    _patch_client(monkeypatch, fail=True)
+    assert await common.download_tracker_torrent(meta, "TESTTRK", downurl="https://example.invalid/dl") is None
+    assert torrent_path.read_bytes() == b"stale"
+
+    _patch_client(monkeypatch, fail=False)
+    assert await common.download_tracker_torrent(meta, "TESTTRK", downurl="https://example.invalid/dl")
+    assert torrent_path.read_bytes() == b"torrent-data"


### PR DESCRIPTION
DC renders sized `[img=N]` tags as nothing, so descriptions shipped with invisible screenshots — strip the sizing for DIGITALCORE with `bbcode.remove_img_resize`.
DC also generates the .torrent asynchronously: an immediate download 404s and the fallback seeds a placeholder announce. Retry the download with backoff; `download_tracker_torrent` returns the written path on success so a pre-existing local file doesn't count as a successful download (no call site reads the current return).
Checks: `pytest` (902 passed), `ruff check .` clean.