### PR TITLE
fix(get_source): take the last GuessIt source when it returns a list

### DIFF
--- a/src/get_source.py
+++ b/src/get_source.py
@@ -64,6 +64,8 @@ async def get_source(type: str, video: str, path: str, is_disc: str, meta: Meta,
                     source = guessit_fn(source_input).get("source", source)
                 except Exception:
                     source = "BluRay"
+        if isinstance(source, list):
+            source = source[-1] if source else "BluRay"
         if source in ("Blu-ray", "Ultra HD Blu-ray", "BluRay", "BR") or is_disc == "BDMV":
             if type == "DISC":
                 source = "Blu-ray"

--- a/tests/test_get_source.py
+++ b/tests/test_get_source.py
@@ -44,3 +44,14 @@ async def test_vhs_source_before_a_distinct_release_group_is_preserved(tmp_path)
 
     assert source == "VHS"
     assert release_type == "REMUX"
+
+
+@pytest.mark.asyncio
+async def test_vhs_title_token_alongside_the_real_source_resolves_to_the_real_source(tmp_path):
+    filename = "VHS.85.2023.1080p.BluRay.x264-GROUP.mkv"
+    meta = Meta(category="MOVIE", uuid=filename)
+
+    source, release_type = await get_source("ENCODE", filename, filename, "", meta, "case", str(tmp_path))
+
+    assert source == "BluRay"
+    assert release_type == "ENCODE"


### PR DESCRIPTION
`guessit("VHS.85.2023.1080p.BluRay.x264.mkv")["source"]` returns `['VHS', 'Blu-ray']` and the raw list repr shipped verbatim in the release name (V/H/S/85).
Take the last element — source tokens follow title tokens in release names, and #423 already covers trailing group lookalikes.
Checks: `pytest` (901 passed), `ruff check .` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source detection when media metadata provides multiple source values.
  * Correctly prioritizes a real source, such as BluRay, over a title token like “VHS”.
  * Added a fallback for cases where no source value is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->