### PR TITLE
feat(audio): label 3+ tracks as MULTI

### DIFF
--- a/src/audio.py
+++ b/src/audio.py
@@ -433,8 +433,8 @@ async def _get_audio_v2(
                         bloated_check(meta, non_eng_non_orig_languages, is_eng_original_with_non_eng=is_eng_original)
 
                     if ((eng and (orig or non_en_non_commentary)) or (orig and non_en_non_commentary)) and len(audio_tracks) > 1 and not meta.no_dual:
-                        dual = "Dual-Audio"
-                        meta.dual_audio = True
+                        dual = "MULTI" if len(audio_tracks) >= 3 else "Dual-Audio"
+                        meta.dual_audio = dual == "Dual-Audio"
                     elif eng and not orig and orig_lang not in ["zxx", "xx", "en", None] and not meta.no_dub:
                         dual = "Dubbed"
                 except Exception:

--- a/tests/test_audio_multitrack_naming.py
+++ b/tests/test_audio_multitrack_naming.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from src.audio import AudioManager
+from src.meta import Meta
+
+
+def _audio_track(language: str, title: str = "") -> dict[str, str]:
+    return {
+        "@type": "Audio",
+        "Format": "AAC",
+        "Channels": "2",
+        "Language": language,
+        "Title": title,
+    }
+
+
+def _classify_audio(
+    tracks: list[dict[str, str]],
+    *,
+    no_dual: bool = False,
+    dual_audio: bool = False,
+) -> tuple[str, Meta]:
+    mediainfo = {"media": {"track": tracks}}
+    meta = Meta(
+        mediainfo=mediainfo,
+        original_language="ja",
+        no_dual=no_dual,
+        dual_audio=dual_audio,
+    )
+
+    audio, _, _ = asyncio.run(AudioManager({}).get_audio_v2(mediainfo, meta, None))
+    return audio, meta
+
+
+def test_two_qualifying_audio_tracks_produce_dual_audio() -> None:
+    audio, meta = _classify_audio([_audio_track("ja"), _audio_track("en")])
+
+    assert audio == "Dual-Audio AAC 2.0"
+    assert meta.dual_audio is True
+
+
+@pytest.mark.parametrize("track_count", [3, 4])
+def test_three_or_more_qualifying_audio_tracks_produce_multi(track_count: int) -> None:
+    languages = ["ja", "en", "fr", "de"]
+    audio, meta = _classify_audio([_audio_track(language) for language in languages[:track_count]])
+
+    assert audio == "MULTI AAC 2.0"
+    assert meta.dual_audio is False
+
+
+def test_commentary_and_compatibility_tracks_do_not_increase_count() -> None:
+    audio, meta = _classify_audio(
+        [
+            _audio_track("ja"),
+            _audio_track("en"),
+            _audio_track("en", "Director Commentary"),
+            _audio_track("ja", "Compatibility Track"),
+        ]
+    )
+
+    assert audio == "Dual-Audio AAC 2.0"
+    assert meta.dual_audio is True
+
+
+@pytest.mark.parametrize("track_count", [2, 3])
+def test_no_dual_suppresses_automatic_multitrack_label(track_count: int) -> None:
+    languages = ["ja", "en", "fr"]
+    audio, meta = _classify_audio([_audio_track(language) for language in languages[:track_count]], no_dual=True)
+
+    assert audio == "AAC 2.0"
+    assert meta.dual_audio is False
+
+
+def test_explicit_dual_audio_forces_dual_audio_for_three_tracks() -> None:
+    audio, meta = _classify_audio(
+        [_audio_track("ja"), _audio_track("en"), _audio_track("fr")],
+        dual_audio=True,
+    )
+
+    assert audio == "Dual-Audio AAC 2.0"
+    assert meta.dual_audio is True


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved audio release labels: titles with exactly two qualifying audio tracks are labeled “Dual-Audio,” while those with three or more are labeled “MULTI.”
  - Commentary and compatibility tracks are excluded from multitrack counts.
  - Dual-audio metadata is now enabled only when the release receives the “Dual-Audio” label.

- **Tests**
  - Added coverage for multitrack naming, overrides, and excluded track types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->