### PR TITLE
fix(digitalcore): use the CSP-allowed ptscreens image host

### DIFF
--- a/src/get_desc.py
+++ b/src/get_desc.py
@@ -2116,6 +2116,8 @@ class DescriptionBuilder:
 
         if tracker == "DIGITALCORE":
             description = bbcode.remove_img_resize(description)
+            # DC's CSP img-src allows img2.ptscreens.com, not img.ptscreens.com
+            description = description.replace("//img.ptscreens.com/", "//img2.ptscreens.com/")
             description = description.replace("[user]", "").replace("[/user]", "")
             description = description.replace("[align=left]", "").replace("[/align]", "")
             description = description.replace("[right]", "").replace("[/right]", "")

--- a/tests/test_digitalcore_description.py
+++ b/tests/test_digitalcore_description.py
@@ -19,6 +19,16 @@ def test_digitalcore_rewrites_sized_img_tags_to_plain_img():
     assert "[img]https://img.example/1.png[/img]" in formatted
 
 
+def test_digitalcore_rewrites_ptscreens_host_to_the_csp_allowed_one():
+    builder = DescriptionBuilder("DIGITALCORE", {"DEFAULT": {}, "TRACKERS": {"DIGITALCORE": {}}})
+    description = "[url=https://ptscreens.com/image/x][img]https://img.ptscreens.com/a.png[/img][/url]"
+
+    formatted = builder.tracker_specific_formats("DIGITALCORE", description)
+
+    assert "[img]https://img2.ptscreens.com/a.png[/img]" in formatted
+    assert "[url=https://ptscreens.com/image/x]" in formatted
+
+
 def _patch_client(monkeypatch, fail):
     class Client:
         def __init__(self, *args, **kwargs):


### PR DESCRIPTION
DC serves `content-security-policy: ... img-src 'self' data: blob: https://img.digitalcore.club ... https://img2.ptscreens.com ...`. UA emits `img.ptscreens.com` URLs, which that directive does not cover, so the browser blocks every screenshot and DC descriptions render empty — #433 made the tags plain `[img]` but they were still pointing at the blocked host. Both hosts serve the same objects, so rewrite the host for DIGITALCORE.

Checks: `pytest` (915 passed), `ruff check .` clean.