### PR TITLE
fix(rtorrent): preserve multifile base path

### DIFF
--- a/src/torrent_clients/rtorrent.py
+++ b/src/torrent_clients/rtorrent.py
@@ -252,7 +252,7 @@ class RtorrentClientMixin:
             fr_file = f"{Path(path).parent.as_posix()}/fr.torrent"
             modified_fr = True
             logger.debug(f"[cyan]Modified fast resume file path because path mapping: {fr_file}")
-        if (meta.category in ("BOOK", "GAME") and len(filelist) > 1 and isdir) or isdir is False:
+        if isdir is False:
             path = Path(path).parent.as_posix()
         logger.debug(f"[cyan]Final path for rTorrent: {path}")
 

--- a/src/torrent_clients/rtorrent.py
+++ b/src/torrent_clients/rtorrent.py
@@ -42,7 +42,7 @@ class RtorrentClientMixin:
 
     def rtorrent(self, path: str, torrent_path: str, torrent: Torrent, meta: Meta, local_path: str, remote_path: str, client: dict[str, Any], tracker: str) -> None:
         # Get the appropriate source path (same as in qbittorrent method)
-        tracker_dir: str | None = None
+        tracker_dir: Path | None = None
         dst = path
         filelist = coerce_str_list(meta.filelist)
         src = filelist[0] if len(filelist) == 1 and Path(filelist[0]).is_file() and not meta.keep_folder else meta.path
@@ -117,14 +117,14 @@ class RtorrentClientMixin:
                 if link_target is None:
                     raise RuntimeError("link_target cannot be None")
                 tracker_dir = tracker_directory(link_target, link_dir_name, tracker)
-                Path(tracker_dir).mkdir(parents=True, exist_ok=True)
+                tracker_dir.mkdir(parents=True, exist_ok=True)
 
                 logger.debug(f"[bold yellow]Linking to tracker directory: {tracker_dir}")
                 logger.debug(f"[cyan]Source path: {src}")
 
                 # Extract only the folder or file name from `src`
                 src_name = Path(src.rstrip(os.sep)).name  # Ensure we get just the name
-                dst = Path(tracker_dir) / src_name  # Destination inside linked folder
+                dst = str(tracker_dir / src_name)  # Destination inside linked folder
 
                 # path magic
                 if Path(dst).exists() or Path(dst).is_symlink():
@@ -281,23 +281,27 @@ class RtorrentClientMixin:
     def add_fast_resume(self, metainfo: dict[str, Any], datapath: str, _torrent: Torrent) -> dict[str, Any]:
         """Add fast resume data to a metafile dict."""
         # Get list of files
-        files = metainfo["info"].get("files", None)
-        single = files is None
+        info = cast(dict[str, Any], metainfo["info"])
+        files_value = info.get("files")
+        single = files_value is None
         if single:
             if Path(datapath).is_dir():
-                datapath = Path(datapath) / metainfo["info"]["name"]
-            files = [
+                datapath = str(Path(datapath) / str(info["name"]))
+            files: list[dict[str, Any]] = [
                 {
                     "path": [str(Path(datapath).resolve())],
-                    "length": metainfo["info"]["length"],
+                    "length": info["length"],
                 }
             ]
+        else:
+            files = cast(list[dict[str, Any]], files_value)
 
         # Prepare resume data
-        resume = metainfo.setdefault("libtorrent_resume", {})
-        resume["bitfield"] = len(metainfo["info"]["pieces"]) // 20
-        resume["files"] = []
-        piece_length_value = metainfo["info"]["piece length"]
+        resume = cast(dict[str, Any], metainfo.setdefault("libtorrent_resume", {}))
+        resume["bitfield"] = len(info["pieces"]) // 20
+        resume_files: list[dict[str, int]] = []
+        resume["files"] = resume_files
+        piece_length_value = info["piece length"]
         piece_length = int(piece_length_value) if isinstance(piece_length_value, (int, float, str)) else 0
         if piece_length <= 0:
             raise ValueError(f"Invalid piece length: {piece_length_value!r}")
@@ -305,7 +309,7 @@ class RtorrentClientMixin:
 
         for fileinfo in files:
             # Get the path into the filesystem
-            filepath = str(Path(*fileinfo["path"]))
+            filepath = str(Path(*cast(list[str], fileinfo["path"])))
             if not single:
                 filepath = Path(datapath) / filepath.strip(os.sep)
 
@@ -319,7 +323,7 @@ class RtorrentClientMixin:
                 )
 
             # Add resume data for this file
-            resume["files"].append(
+            resume_files.append(
                 {
                     "priority": 1,
                     "mtime": int(Path(filepath).stat().st_mtime),
@@ -396,7 +400,7 @@ class RtorrentClientMixin:
             torrent_comments = [cast(dict[str, Any], entry) for entry in torrent_comments_list if isinstance(entry, dict)]
             meta.torrent_comments = torrent_comments
 
-            comment_data = {
+            comment_data: dict[str, Any] = {
                 "hash": getattr(torrent, "infohash_v1", "") or "",
                 "name": getattr(torrent, "name", "") or "",
                 "comment": comment,
@@ -417,7 +421,7 @@ class RtorrentClientMixin:
                 logger.info(f"[green]Stored {len(torrent_comments)} torrent comments for later use")
 
             if not pathed:
-                valid, resolved_path = await self.is_valid_torrent(meta, torrent_path, info_hash_v1, "rtorrent", client)
+                valid, resolved_path = await self.is_valid_torrent(meta, str(torrent_path), info_hash_v1, "rtorrent", client)
 
                 if valid:
                     base_torrent_path = Path(extracted_torrent_dir) / "BASE.torrent"

--- a/tests/test_client_path_handling.py
+++ b/tests/test_client_path_handling.py
@@ -4,7 +4,9 @@ import asyncio
 import os
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
+
+import bencode
 
 from src.clients import Clients
 from src.meta import Meta
@@ -48,6 +50,58 @@ def test_clients_remote_path_map_parses_stringified_path_lists() -> None:
 
 def test_rtorrent_coerce_str_list_parses_stringified_paths() -> None:
     assert coerce_str_list("['/local', '/remote']") == ["/local", "/remote"]
+
+
+def test_rtorrent_keeps_multifile_release_directory_as_base(tmp_path: Path) -> None:
+    for category in ("BOOK", "GAME"):
+        release_dir = tmp_path / category
+        release_dir.mkdir()
+        filelist = [release_dir / "part1.bin", release_dir / "part2.bin"]
+        for file_path in filelist:
+            file_path.write_bytes(b"x")
+
+        torrent_path = tmp_path / f"{category}.torrent"
+        bencode.bwrite(
+            {
+                "announce": "https://tracker.invalid/announce",
+                "info": {
+                    "files": [
+                        {"length": 1, "path": ["part1.bin"]},
+                        {"length": 1, "path": ["part2.bin"]},
+                    ],
+                    "name": category,
+                    "piece length": 1,
+                    "pieces": b"0" * 40,
+                },
+            },
+            str(torrent_path),
+        )
+
+        start_verbose = Mock()
+        rtorrent_server = SimpleNamespace(load=SimpleNamespace(start_verbose=start_verbose))
+        meta = Meta(
+            {
+                "category": category,
+                "filelist": [str(file_path) for file_path in filelist],
+                "path": str(release_dir),
+            }
+        )
+        with (
+            patch("src.torrent_clients.rtorrent.xmlrpc.client.Server", return_value=rtorrent_server),
+            patch("src.torrent_clients.rtorrent.time.sleep"),
+        ):
+            Clients({}).rtorrent(
+                str(release_dir),
+                str(torrent_path),
+                SimpleNamespace(),
+                meta,
+                str(tmp_path),
+                str(tmp_path),
+                {"linking": None, "rtorrent_label": None, "rtorrent_url": "https://rtorrent.invalid"},
+                "TRACKER",
+            )
+
+        assert start_verbose.call_args.args[2] == f"d.directory_base.set={release_dir}"
 
 
 def test_tracker_directory_falls_back_to_tracker_name() -> None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected rTorrent path handling for multi-file BOOK and GAME releases.
  * Ensured the release directory is preserved when configuring the download location.
  * Prevented unnecessary parent-directory rewrites for valid directory paths.

* **Tests**
  * Added regression coverage for multi-file release path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->