### PR TITLE
fix(game): make version optional

### DIFF
--- a/docs/game-upload.md
+++ b/docs/game-upload.md
@@ -102,9 +102,9 @@ A duplicate is confirmed if:
 
 ## 5. Console Prompting & User Flow
 
-In attended mode, the terminal guides the user to fill in missing fields, verify game versions, and review final details:
+In attended mode, the terminal guides the user to fill in missing fields and review final details:
 
-- **Missing Fields**: If essential fields (`title`, `year`, `platform`, `game_subcategory`, `game_version`) are missing, the console prompts you to supply them before generating the torrent name.
+- **Missing Fields**: If essential fields (`title`, `year`, `platform`, `game_subcategory`) are missing, the console prompts you to supply them before generating the torrent name. The game version is used when detected or supplied with `--game-version`, but is not prompted for or required for unattended uploads.
 - **PC Installation Notes Check**: For PC game uploads, if no installation instructions are provided via description file or custom description link, a yellow warning is shown: `Installation instructions missing. Use -df or -dp to add them.`
 
 ---

--- a/src/trackerstatus.py
+++ b/src/trackerstatus.py
@@ -140,7 +140,7 @@ class TrackerStatusManager:
 
                 # Check for missing required GAME fields in unattended mode
                 elif local_meta.get("category") == "GAME" and local_meta.get("unattended", False):
-                    game_required_fields = ["title", "year", "platform", "game_version"]
+                    game_required_fields = ["title", "year", "platform"]
                     game_missing: list[str] = []
                     for f in game_required_fields:
                         val = local_meta.get(f)

--- a/upload.py
+++ b/upload.py
@@ -656,7 +656,7 @@ async def _prompt_game_meta(meta: Meta) -> None:
     torrent name is rebuilt so the confirmation screen and the per-tracker
     uploads reflect the new values.
     """
-    game_required_fields = ["title", "year", "platform", "game_version", "game_subcategory"]
+    game_required_fields = ["title", "year", "platform", "game_subcategory"]
     game_missing: list[str] = []
     for f in game_required_fields:
         val = getattr(meta, f, None)
@@ -701,14 +701,6 @@ async def _prompt_game_meta(meta: Meta) -> None:
                     if value:
                         meta[field] = value
                         name_needs_rebuild = True
-                elif field == "game_version":
-                    value = (CLI_UI.ask_string("Enter game version (e.g., 1.15) (leave blank to skip): ") or "").strip()
-                    if value:
-                        from src.prep_game import normalize_version
-
-                        meta[field] = normalize_version(value)
-                        name_needs_rebuild = True
-
                 elif field == "game_subcategory":
                     subcategory_choices = ["full_game (Full Game)", "full_game_dlc (Full Game + DLC)", "dlc (DLC only)", "update (Update only)"]
                     subcategory_values = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Game version is now optional during uploads and is used when detected or provided explicitly.
  - Interactive uploads no longer prompt for a game version.

- **Bug Fixes**
  - Unattended uploads are no longer skipped when game version information is unavailable.

- **Documentation**
  - Updated upload guidance to clarify game version handling in attended and unattended modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->