### PR TITLE
feat(books): link ASINs to Audible

### DIFF
--- a/data/example_config.py
+++ b/data/example_config.py
@@ -320,6 +320,11 @@ config: dict[str, Any] = {
         # Preferred logo language (ISO 639-1). Defaults to English ("en").
         # Falls back to English when a logo in the preferred language is unavailable.
         "logo_language": "",
+        # Audible marketplace used to link ASINs in descriptions. Leave empty
+        # unless you set your marketplace explicitly.
+        # Examples: audible.com, audible.co.uk, audible.com.br.
+        # --audible-url overrides this value for an individual upload.
+        "audible_domain": "",
         # Screenshot thumbnail width where supported. Default: 350 (for example, [img=350]).
         "thumbnail_size": "350",
         # Number of screenshots per row on sites that use the common description.

--- a/docs/book-upload.md
+++ b/docs/book-upload.md
@@ -98,6 +98,7 @@ You can override auto-detected values using the following command-line flags:
 | `-author`    | `--author`        | Overrides the book author                                                                           |
 | `-isbn`      | `--isbn`          | Overrides the ISBN number                                                                           |
 | `-asin`      | `--asin`          | Overrides the ASIN number                                                                           |
+|              | `--audible-url`   | Audible product URL; sets the ASIN and overrides the configured Audible marketplace                 |
 | `-blang`     | `--book-language` | Overrides the book language (e.g. English, Portuguese)                                              |
 | `-openlib`   | `--openlibrary`   | Specifies the OpenLibrary Work ID (e.g. `OL45883W`). Accepts a full OpenLibrary URL or just the ID. |
 | `-comic`     | `--comic`         | Identifies the book upload as a Comic                                                               |

--- a/docs/cli-args.md
+++ b/docs/cli-args.md
@@ -108,6 +108,14 @@ If you pass a `.txt` file as the main positional input path (without specifying 
 
 Note: if a manual TMDb or IMDb id is present in the incoming `meta` before parsing, the parser clears `tmdb_manual`, `tmdb_id`, `tmdb`, `imdb_id`, `imdb` in `meta` so CLI values take precedence cleanly.
 
+### Book and audiobook metadata
+
+- `-asin`, `--asin ASIN`: Override the detected book or audiobook ASIN.
+- `--audible-url URL`: Use an Audible product URL, derive its ASIN, and override the configured `DEFAULT.audible_domain` marketplace for this upload.
+- `-isbn`, `--isbn ISBN`: Override the detected ISBN.
+- `-author`, `--author NAME`: Override the detected author.
+- `-btitle`, `--book-title TITLE`: Override the detected book title.
+
 ### Tags / edition / language
 
 - `-g`, `--tag [GROUP ...]`: Group tag.

--- a/docs/description-builder.md
+++ b/docs/description-builder.md
@@ -124,7 +124,7 @@ For `TV` category items, if `episode_overview` is enabled, it structures and for
 
 #### 7. Book/Audiobook Details
 
-Processes uploads in the `BOOK` category. It compiles fields such as Author, Translator, Narrator, Publisher, ISBN, ASIN, Edition, and Year into a clean list or `[table]`, including audiobook duration and bitrates if applicable.
+Processes uploads in the `BOOK` category. It compiles fields such as Author, Translator, Narrator, Publisher, ISBN, ASIN, Edition, and Year into a clean list or `[table]`, including audiobook duration and bitrates if applicable. ASINs link to the marketplace selected by the `audible_domain` setting (for example, `audible.co.uk` or `audible.com.br`); the setting is empty by default, and `--audible-url` overrides it for an individual upload.
 
 #### 8. Game Specifications
 

--- a/src/args.py
+++ b/src/args.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, TextIO
 import argcomplete
 
 from src.app_paths import DATA_DIR
+from src.audible import normalize_audible_url
 
 if TYPE_CHECKING:
     from src.meta import Meta
@@ -575,6 +576,14 @@ class Args:
             help="Book/Audiobook ASIN (overrides auto-detected value)",
             type=str,
             dest="book_asin",
+        )
+        parser.add_argument(
+            "--audible-url",
+            nargs=1,
+            required=False,
+            help="Audible product URL; sets the ASIN and overrides the configured Audible marketplace",
+            type=normalize_audible_url,
+            dest="audible_url",
         )
         parser.add_argument(
             "-openlib",
@@ -1302,6 +1311,19 @@ class Args:
         book_asin_arg = meta.book_asin
         if book_asin_arg not in (None, ""):
             meta.asin = str(book_asin_arg).strip()
+
+        audible_url_arg = meta.audible_url
+        if audible_url_arg not in (None, ""):
+            audible_url = normalize_audible_url(str(audible_url_arg))
+            audible_asin = audible_url.rsplit("/", 1)[-1]
+            if meta.asin and str(meta.asin).strip().upper() != audible_asin:
+                from src.console import logger
+
+                logger.error("[red]The ASIN in --audible-url does not match --asin.[/red]")
+                sys.exit(1)
+            meta.audible_url = audible_url
+            meta.asin = audible_asin
+            meta.book_asin = audible_asin
 
         openlibrary_arg = meta.openlibrary
         if openlibrary_arg not in (None, ""):

--- a/src/audible.py
+++ b/src/audible.py
@@ -1,0 +1,55 @@
+# Upload Assistant © 2026 Audionut & wastaken7 — Licensed under UAPL v1.0
+from __future__ import annotations
+
+import re
+from urllib.parse import urlsplit
+
+_ASIN_RE = re.compile(r"^[A-Z0-9]{10}$", re.IGNORECASE)
+_AUDIBLE_HOST_RE = re.compile(r"^(?:www\.)?audible\.[a-z]{2,3}(?:\.[a-z]{2})?$", re.IGNORECASE)
+
+
+def normalize_audible_domain(value: str) -> str:
+    """Return a validated Audible marketplace hostname."""
+    candidate = str(value or "").strip().lower().rstrip("/")
+    if "://" in candidate:
+        parsed = urlsplit(candidate)
+        if parsed.scheme != "https" or parsed.path not in ("", "/") or parsed.query or parsed.fragment:
+            raise ValueError("Audible domain must be a hostname, such as audible.co.uk")
+        candidate = parsed.hostname or ""
+    candidate = candidate.removeprefix("www.")
+    if not _AUDIBLE_HOST_RE.fullmatch(candidate):
+        raise ValueError("invalid Audible marketplace domain")
+    return candidate
+
+
+def build_audible_url(asin: str, domain: str) -> str:
+    """Build a canonical Audible product URL from an ASIN and marketplace."""
+    normalized_asin = str(asin or "").strip().upper()
+    if not _ASIN_RE.fullmatch(normalized_asin):
+        raise ValueError("Audible ASIN must contain 10 letters or digits")
+    return f"https://www.{normalize_audible_domain(domain)}/pd/{normalized_asin}"
+
+
+def normalize_audible_url(value: str) -> str:
+    """Validate an Audible product URL and reduce it to its canonical form."""
+    parsed = urlsplit(str(value or "").strip())
+    if parsed.scheme.lower() != "https" or parsed.username or parsed.password or parsed.port:
+        raise ValueError("Audible URL must be an HTTPS product URL")
+    domain = normalize_audible_domain(parsed.hostname or "")
+    asin = next((part for part in reversed(parsed.path.split("/")) if _ASIN_RE.fullmatch(part)), "")
+    if not asin:
+        raise ValueError("Audible URL must contain a 10-character ASIN")
+    return build_audible_url(asin, domain)
+
+
+def resolve_audible_url(asin: str, *, explicit_url: str = "", domain: str = "") -> str:
+    """Resolve the exact Audible URL that should be embedded for an ASIN."""
+    normalized_asin = str(asin or "").strip().upper()
+    if explicit_url:
+        audible_url = normalize_audible_url(explicit_url)
+        if audible_url.rsplit("/", 1)[-1] != normalized_asin:
+            raise ValueError("Audible URL ASIN does not match the book ASIN")
+        return audible_url
+    if domain:
+        return build_audible_url(normalized_asin, domain)
+    return ""

--- a/src/get_desc.py
+++ b/src/get_desc.py
@@ -17,6 +17,7 @@ import langcodes
 from jinja2 import Template
 from langcodes.tag_parser import LanguageTagError
 
+from src.audible import resolve_audible_url
 from src.bbcode import BBCODE
 from src.cogs.redaction import PathAwareEncoder
 from src.console import logger
@@ -792,7 +793,18 @@ class DescriptionBuilder:
         if isbn:
             fields.append((str_isbn, isbn))
         if asin:
-            fields.append((str_asin, asin))
+            asin_display = asin
+            try:
+                audible_url = resolve_audible_url(
+                    asin,
+                    explicit_url=meta.audible_url,
+                    domain=self.config.get("DEFAULT", {}).get("audible_domain", ""),
+                )
+                if audible_url:
+                    asin_display = f"[url={audible_url}]{asin}[/url]"
+            except ValueError:
+                pass
+            fields.append((str_asin, asin_display))
         if edition:
             fields.append((str_edition, edition))
         if year:

--- a/src/meta.py
+++ b/src/meta.py
@@ -52,6 +52,7 @@ class Meta:
     audio_spectrogram: bool | None = None
     dynamic_hdr_plot: bool | None = None
     audio: str = ""
+    audible_url: str = ""
     audiobook_bitrate: int | None = None
     audiobook_duration_formatted: str | None = None
     audiobook_duration: float | None = None

--- a/src/uphelper.py
+++ b/src/uphelper.py
@@ -14,6 +14,7 @@ import aiofiles
 import cli_ui
 from rich.markup import escape
 
+from src.audible import resolve_audible_url
 from src.bdinfo_comparator import compare_bdinfo, has_bdinfo_content
 from src.cleanup import cleanup_manager
 from src.cogs.redaction import Redaction
@@ -586,6 +587,19 @@ class UploadHelper:
             lines.append(("Language", book_language))
             lines.append(("ISBN", isbn))
             lines.append(("ASIN", asin))
+            if asin:
+                try:
+                    audible_url_display = (
+                        resolve_audible_url(
+                            asin,
+                            explicit_url=meta.audible_url,
+                            domain=str(self.default_config.get("audible_domain", "") or ""),
+                        )
+                        or "[yellow][italic]Marketplace missing. Use --audible-url or set DEFAULT.audible_domain (for example, audible.co.uk).[/italic][/yellow]"
+                    )
+                except ValueError:
+                    audible_url_display = "[yellow][italic]Invalid Audible URL or domain. Use --audible-url or set DEFAULT.audible_domain.[/italic][/yellow]"
+                lines.append(("Audible URL", audible_url_display))
             lines.append(("Comic", format_value(comic)))
             lines.append(("Manga", format_value(manga)))
             lines.append(("Magazine", format_value(magazine)))

--- a/tests/test_audible.py
+++ b/tests/test_audible.py
@@ -1,0 +1,69 @@
+# ruff: noqa: S101
+
+import pytest
+
+from src.args import Args
+from src.audible import build_audible_url, normalize_audible_domain, normalize_audible_url
+from src.get_desc import DescriptionBuilder
+from src.meta import Meta
+
+
+def test_audible_url_argument_sets_asin_and_canonical_url(tmp_path):
+    meta, _, _ = Args({"DEFAULT": {"screens": 1}}).parse(
+        [str(tmp_path), "--audible-url", "https://www.audible.co.uk/pd/Book-Title/B01N5AX3TQ?source=tracker"],
+        Meta(),
+    )
+
+    assert meta.asin == "B01N5AX3TQ"
+    assert meta.book_asin == "B01N5AX3TQ"
+    assert meta.audible_url == "https://www.audible.co.uk/pd/B01N5AX3TQ"
+
+
+def test_audible_url_argument_rejects_conflicting_asin(tmp_path):
+    with pytest.raises(SystemExit):
+        Args({"DEFAULT": {"screens": 1}}).parse(
+            [str(tmp_path), "--asin", "B000000001", "--audible-url", "https://www.audible.com.br/pd/B000000002"],
+            Meta(),
+        )
+
+
+def test_audible_helpers_support_regional_marketplaces():
+    assert build_audible_url("B01N5AX3TQ", "audible.com.br") == "https://www.audible.com.br/pd/B01N5AX3TQ"
+    assert normalize_audible_url("https://audible.co.uk/pd/Title/B01N5AX3TQ") == "https://www.audible.co.uk/pd/B01N5AX3TQ"
+
+
+def test_audible_url_rejects_non_audible_host():
+    with pytest.raises(ValueError):
+        normalize_audible_url("https://example.com/pd/B01N5AX3TQ")
+
+
+def test_audible_domain_rejects_non_https_url():
+    with pytest.raises(ValueError):
+        normalize_audible_domain("http://audible.com")
+
+
+def test_book_description_links_asin_using_configured_marketplace():
+    builder = DescriptionBuilder("TEST", {"DEFAULT": {"audible_domain": "audible.com.br"}, "TRACKERS": {"TEST": {}}})
+    meta = Meta(asin="B01N5AX3TQ", audiobook=True)
+
+    description = builder._build_book_desc_section(meta)
+
+    assert "[url=https://www.audible.com.br/pd/B01N5AX3TQ]B01N5AX3TQ[/url]" in description
+
+
+def test_explicit_audible_url_overrides_configured_marketplace():
+    builder = DescriptionBuilder("TEST", {"DEFAULT": {"audible_domain": "audible.com.br"}, "TRACKERS": {"TEST": {}}})
+    meta = Meta(asin="B01N5AX3TQ", audible_url="https://www.audible.co.uk/pd/B01N5AX3TQ", audiobook=True)
+
+    description = builder._build_book_desc_section(meta)
+
+    assert "[url=https://www.audible.co.uk/pd/B01N5AX3TQ]B01N5AX3TQ[/url]" in description
+
+
+def test_asin_remains_plain_text_without_user_provided_marketplace():
+    builder = DescriptionBuilder("TEST", {"DEFAULT": {"audible_domain": ""}, "TRACKERS": {"TEST": {}}})
+
+    description = builder._build_book_desc_section(Meta(asin="B01N5AX3TQ"))
+
+    assert "[url=" not in description
+    assert "B01N5AX3TQ" in description

--- a/tests/test_uphelper_prompts.py
+++ b/tests/test_uphelper_prompts.py
@@ -167,3 +167,28 @@ async def test_dupe_filter_resets_season_pack_state_between_trackers() -> None:
     assert meta.season_pack_id is None
     assert meta.season_pack_link is None
     assert meta.season_pack_name == ""
+
+
+@pytest.mark.asyncio
+async def test_book_confirmation_shows_audible_url_that_will_be_used(monkeypatch: pytest.MonkeyPatch) -> None:
+    messages: list[str] = []
+    monkeypatch.setattr("src.uphelper.logger.info", lambda message, **_kwargs: messages.append(message))
+    meta = Meta(category="BOOK", asin="B01N5AX3TQ", unattended=True)
+
+    assert await UploadHelper({"DEFAULT": {"audible_domain": "audible.com.br"}}).get_confirmation(meta) is True
+
+    assert "Audible URL" in messages[0]
+    assert "https://www.audible.com.br/pd/B01N5AX3TQ" in messages[0]
+
+
+@pytest.mark.asyncio
+async def test_book_confirmation_explains_how_to_add_missing_audible_marketplace(monkeypatch: pytest.MonkeyPatch) -> None:
+    messages: list[str] = []
+    monkeypatch.setattr("src.uphelper.logger.info", lambda message, **_kwargs: messages.append(message))
+    meta = Meta(category="BOOK", asin="B01N5AX3TQ", unattended=True)
+
+    assert await UploadHelper({"DEFAULT": {"audible_domain": ""}}).get_confirmation(meta) is True
+
+    assert "Audible URL" in messages[0]
+    assert "--audible-url" in messages[0]
+    assert "DEFAULT.audible_domain" in messages[0]

--- a/upload.py
+++ b/upload.py
@@ -375,6 +375,7 @@ async def merge_meta(meta: Meta, saved_meta: dict[str, Any]) -> dict[str, Any]:
     overwrite_list = [
         "anon",
         "asin",
+        "audible_url",
         "audiobook_bitrate",
         "audiobook_duration_formatted",
         "audiobook_duration",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Audible marketplace configuration for generating regional product links.
  * Added the `--audible-url` option for setting an audiobook URL and deriving its ASIN.
  * Audible URLs are validated, canonicalized, and checked for ASIN conflicts.
  * Book descriptions and upload confirmations now display marketplace-specific Audible links when available.

* **Bug Fixes**
  * Invalid or unavailable Audible links now fall back to displaying the plain ASIN.

* **Documentation**
  * Updated CLI, upload, and description guides with Audible URL and marketplace configuration details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->