### PR TITLE
fix(metadata): detect MY5 streaming service

### DIFF
--- a/src/region.py
+++ b/src/region.py
@@ -2234,6 +2234,7 @@ async def get_service(
         "MTOD": "MTOD",
         "MTV": "MTV",
         "MUBI": "MUBI",
+        "MY5": "MY5",
         "NATG": "NATG",
         "National Audiovisual Institute": "INA",
         "National Film Board": "NFB",

--- a/tests/test_region_service.py
+++ b/tests/test_region_service.py
@@ -1,0 +1,20 @@
+# ruff: noqa: S101
+
+import pytest
+
+from src.region import get_service
+
+
+@pytest.mark.parametrize(
+    ("service_tag", "expected"),
+    [
+        ("AMZN", ("AMZN", "Amazon")),
+        ("MY5", ("MY5", "MY5")),
+        ("NF", ("NF", "Netflix")),
+    ],
+)
+@pytest.mark.asyncio
+async def test_get_service_detects_release_tag(service_tag: str, expected: tuple[str, str]) -> None:
+    release_name = f"Example.Show.S01E01.1080p.{service_tag}.WEB-DL.AAC2.0.H.264-GROUP"
+
+    assert await get_service(release_name) == expected


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for identifying MY5 streaming service releases.

* **Tests**
  * Added coverage to verify service identification for Amazon, MY5, and Netflix release tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->