### PR TITLE
fix(avistaz): add release tags when keywords are empty

### DIFF
--- a/src/trackers/AVISTAZ/__init__.py
+++ b/src/trackers/AVISTAZ/__init__.py
@@ -611,10 +611,7 @@ class AZTrackerBase:
     async def get_tags(self, meta: Meta) -> list[str]:
         tags: list[str] = []
 
-        genres = meta.keywords
-        if not genres:
-            return tags
-
+        genres = meta.keywords or []
         # cleans spaces and normalizes to lowercase
         phrases = [re.sub(r"\s+", " ", x.strip().lower()) for x in genres if x.strip()]
 

--- a/tests/test_avistaz_tags.py
+++ b/tests/test_avistaz_tags.py
@@ -1,0 +1,41 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from src.trackers.AVISTAZ.avistaz import AvistaZ
+from src.trackers.AVISTAZ.cinemaz import CinemaZ
+from src.trackers.AVISTAZ.privatehd import PrivateHD
+
+TRACKERS = (
+    (AvistaZ, "AVISTAZ", "3773", "943"),
+    (CinemaZ, "CINEMAZ", "1594", "938"),
+    (PrivateHD, "PRIVATEHD", "1448", "415"),
+)
+
+
+async def get_tags(tracker, meta):
+    try:
+        return await tracker.get_tags(meta)
+    finally:
+        await tracker.session.aclose()
+
+
+@pytest.mark.parametrize(("tracker_class", "tracker_name", "personal_tag", "_internal_tag"), TRACKERS)
+def test_personal_release_tag_is_added_without_keywords(tracker_class, tracker_name, personal_tag, _internal_tag):
+    tracker = tracker_class({"TRACKERS": {tracker_name: {}}})
+    meta = SimpleNamespace(keywords=[], personalrelease=True)
+
+    tags = asyncio.run(get_tags(tracker, meta))
+
+    assert tags == [personal_tag]  # noqa: S101
+
+
+@pytest.mark.parametrize(("tracker_class", "tracker_name", "_personal_tag", "internal_tag"), TRACKERS)
+def test_internal_release_tag_is_added_without_keywords(tracker_class, tracker_name, _personal_tag, internal_tag):
+    tracker = tracker_class({"TRACKERS": {tracker_name: {"internal": True}}})
+    meta = SimpleNamespace(keywords=[], personalrelease=False)
+
+    tags = asyncio.run(get_tags(tracker, meta))
+
+    assert tags == [internal_tag]  # noqa: S101


### PR DESCRIPTION
## Summary

Fix personal-release and internal-release tags being omitted when an upload has no keywords.

The shared AvistaZ tag builder returned early when `meta.keywords` was empty, preventing required release tags from being added for:

- AvistaZ
- CinemaZ
- PrivateHD

The tag builder now processes mandatory tags regardless of whether optional keyword tags are present.

## Testing

Added parameterized regression tests covering personal-release and internal-release tags for all three trackers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Tag generation now works correctly when no keywords are provided.
  - Personal release and internal release tags are preserved when applicable, even without keyword metadata.

- **Tests**
  - Added coverage for tag behavior across AvistaZ, CinemaZ, and PrivateHD trackers when keyword information is empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->