### PR TITLE
fix(skipthecommercials): restrict movies to documentaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Sequence Usenet and torrent tracker uploads while limiting contention with qBitt
 | <img src="web_ui/static/img/trackers/samaritano.png" width="16" height="16" />             | Samaritano             | SAMARITANO             | MOVIE, TV, BOOK, GAME        |
 | <img src="web_ui/static/img/trackers/seedpool.png" width="16" height="16" />               | seedpool               | SEEDPOOL               | MOVIE, TV, BOOK, GAME, MUSIC |
 | <img src="web_ui/static/img/trackers/shareisland.png" width="16" height="16" />            | ShareIsland            | SHAREISLAND            | MOVIE, TV                    |
-| <img src="web_ui/static/img/trackers/skipthecommercials.png" width="16" height="16" />     | SkipTheCommerials      | SKIPTHECOMMERCIALS     | MOVIE (Documentary only), TV |
+| <img src="web_ui/static/img/trackers/skipthecommercials.png" alt="" width="16" height="16" /> | SkipTheCommerials      | SKIPTHECOMMERCIALS     | MOVIE (Documentary only), TV |
 | <img src="web_ui/static/img/trackers/speedapp.png" width="16" height="16" />               | SpeedApp               | SPEEDAPP               | MOVIE, TV, BOOK, GAME, MUSIC |
 | <img src="web_ui/static/img/trackers/swarmazon.png" width="16" height="16" />              | Swarmazon              | SWARMAZON              | MOVIE, TV                    |
 | <img src="web_ui/static/img/trackers/theleachzone.png" width="16" height="16" />           | The Leach Zone         | THELEACHZONE           | MOVIE, TV                    |

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Sequence Usenet and torrent tracker uploads while limiting contention with qBitt
 | <img src="web_ui/static/img/trackers/samaritano.png" width="16" height="16" />             | Samaritano             | SAMARITANO             | MOVIE, TV, BOOK, GAME        |
 | <img src="web_ui/static/img/trackers/seedpool.png" width="16" height="16" />               | seedpool               | SEEDPOOL               | MOVIE, TV, BOOK, GAME, MUSIC |
 | <img src="web_ui/static/img/trackers/shareisland.png" width="16" height="16" />            | ShareIsland            | SHAREISLAND            | MOVIE, TV                    |
-| <img src="web_ui/static/img/trackers/skipthecommercials.png" width="16" height="16" />     | SkipTheCommerials      | SKIPTHECOMMERCIALS     | MOVIE, TV                    |
+| <img src="web_ui/static/img/trackers/skipthecommercials.png" width="16" height="16" />     | SkipTheCommerials      | SKIPTHECOMMERCIALS     | MOVIE (Documentary only), TV |
 | <img src="web_ui/static/img/trackers/speedapp.png" width="16" height="16" />               | SpeedApp               | SPEEDAPP               | MOVIE, TV, BOOK, GAME, MUSIC |
 | <img src="web_ui/static/img/trackers/swarmazon.png" width="16" height="16" />              | Swarmazon              | SWARMAZON              | MOVIE, TV                    |
 | <img src="web_ui/static/img/trackers/theleachzone.png" width="16" height="16" />           | The Leach Zone         | THELEACHZONE           | MOVIE, TV                    |

--- a/src/trackers/UNIT3D/skipthecommercials.py
+++ b/src/trackers/UNIT3D/skipthecommercials.py
@@ -16,7 +16,8 @@ Config = dict[str, Any]
 
 class SkipTheCommercials(UNIT3D):
     """
-    SkipTheCommercials (STC) is a Private Torrent Tracker for TV
+    SkipTheCommercials (STC) is a Private Torrent Tracker for TV and
+    documentary movies.
     """
 
     tracker = "SKIPTHECOMMERCIALS"
@@ -56,9 +57,17 @@ class SkipTheCommercials(UNIT3D):
         return {"type_id": type_id}
 
     async def get_additional_checks(self, meta: Meta) -> bool:
-        if str(meta.category) != "TV":
+        category = str(meta.category).upper()
+        if isinstance(meta.combined_genres, list):
+            combined_genres = meta.combined_genres
+        else:
+            combined_genres = [genre.strip() for genre in str(meta.combined_genres).split(",") if genre.strip()]
+        documentary_metadata = [*(meta.genres or []), *(meta.keywords or []), *combined_genres]
+        is_documentary = any(str(value).strip().lower() in {"documentary", "documentaries"} for value in documentary_metadata)
+
+        if category != "TV" and not (category == "MOVIE" and is_documentary):
             if not meta.unattended:
-                logger.info(f"{self.tracker}: [bold red]Only TV uploads allowed at {self.tracker}.[/bold red]")
+                logger.info(f"{self.tracker}: [bold red]Only TV and documentary movie uploads are allowed at {self.tracker}.[/bold red]")
             return False
 
         genres = f"{', '.join(meta.keywords)} {meta.combined_genres}"

--- a/src/trackers/UNIT3D/skipthecommercials.py
+++ b/src/trackers/UNIT3D/skipthecommercials.py
@@ -70,7 +70,7 @@ class SkipTheCommercials(UNIT3D):
                 logger.info(f"{self.tracker}: [bold red]Only TV and documentary movie uploads are allowed at {self.tracker}.[/bold red]")
             return False
 
-        genres = f"{', '.join(meta.keywords)} {meta.combined_genres}"
+        genres = ", ".join(str(value) for value in [*(meta.keywords or []), *combined_genres])
         adult_keywords = ["xxx", "erotic", "porn", "adult", "orgy", "hentai", "adult animation", "softcore"]
         if any(re.search(rf"(^|,\s*){re.escape(keyword)}(\s*,|$)", genres, re.IGNORECASE) for keyword in adult_keywords):
             if not meta.unattended or (bool(meta.unattended) and meta.unattended_confirm):

--- a/tests/test_skipthecommercials.py
+++ b/tests/test_skipthecommercials.py
@@ -35,3 +35,15 @@ def test_skipthecommercials_allows_tv_and_documentary_movies(tracker: SkipTheCom
 )
 def test_skipthecommercials_rejects_non_documentary_movies_and_other_categories(tracker: SkipTheCommercials, meta: Meta) -> None:
     assert asyncio.run(tracker.get_additional_checks(meta)) is False  # noqa: S101
+
+
+@pytest.mark.parametrize(
+    "meta",
+    [
+        Meta(category="TV", combined_genres=["Porn"], unattended=True),
+        Meta(category="TV", keywords=["porn"], unattended=True),
+        Meta(category="MOVIE", combined_genres=["Documentary", "Porn"], unattended=True),
+    ],
+)
+def test_skipthecommercials_rejects_adult_list_metadata(tracker: SkipTheCommercials, meta: Meta) -> None:
+    assert asyncio.run(tracker.get_additional_checks(meta)) is False  # noqa: S101

--- a/tests/test_skipthecommercials.py
+++ b/tests/test_skipthecommercials.py
@@ -1,0 +1,37 @@
+import asyncio
+
+import pytest
+
+from src.meta import Meta
+from src.trackers.UNIT3D.skipthecommercials import SkipTheCommercials
+
+
+@pytest.fixture
+def tracker() -> SkipTheCommercials:
+    return SkipTheCommercials({"DEFAULT": {}, "TRACKERS": {"SKIPTHECOMMERCIALS": {}}})
+
+
+@pytest.mark.parametrize(
+    "meta",
+    [
+        Meta(category="TV"),
+        Meta(category="MOVIE", genres=["Documentary"]),
+        Meta(category="MOVIE", keywords=["documentary"]),
+        Meta(category="MOVIE", combined_genres="History, Documentary"),
+        Meta(category="MOVIE", combined_genres=["Documentaries"]),
+    ],
+)
+def test_skipthecommercials_allows_tv_and_documentary_movies(tracker: SkipTheCommercials, meta: Meta) -> None:
+    assert asyncio.run(tracker.get_additional_checks(meta)) is True  # noqa: S101
+
+
+@pytest.mark.parametrize(
+    "meta",
+    [
+        Meta(category="MOVIE", genres=["Action", "Drama"], unattended=True),
+        Meta(category="MOVIE", keywords=["documentary filmmaker"], unattended=True),
+        Meta(category="MUSIC", genres=["Documentary"], unattended=True),
+    ],
+)
+def test_skipthecommercials_rejects_non_documentary_movies_and_other_categories(tracker: SkipTheCommercials, meta: Meta) -> None:
+    assert asyncio.run(tracker.get_additional_checks(meta)) is False  # noqa: S101


### PR DESCRIPTION
## Summary

Updates the SkipTheCommercials tracker logic so that:

- TV uploads remain supported.
- Documentary movies are allowed.
- General, non-documentary movies are rejected.
- Unsupported categories remain rejected.

Documentary movies are detected using exact, case-insensitive matches against the release’s genres, combined TMDB/IMDb genres, and metadata keywords. Exact matching prevents unrelated terms such as `mockumentary` or `documentary filmmaker` from incorrectly bypassing the restriction.

Previously, the tracker declared Movie support but rejected every non-TV upload, including valid documentary movies.

## Testing

Added regression tests covering:

- TV uploads
- Documentary genres
- Documentary keywords
- Combined TMDB/IMDb documentary genres
- Non-documentary movies
- False-positive documentary terms
- Unsupported categories

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - SkipTheCommercials now supports documentary movies in addition to TV content.
  - Documentary eligibility is recognized from relevant genre and keyword metadata.

- **Bug Fixes**
  - Prevented unsupported categories, non-documentary movies, unattended uploads, and music content from being accepted.

- **Documentation**
  - Updated the supported categories listing to clarify documentary-only movie support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->