### PR TITLE
fix(bjshare): simplify adult media check to category

### DIFF
--- a/src/trackers/bjshare.py
+++ b/src/trackers/bjshare.py
@@ -1770,10 +1770,6 @@ class BJShare:
     def get_adulto(self, meta: Meta) -> str:
         """
         Check for adult classification eligibility.
-
-        Adheres to upload guidelines where:
-        - Movies: Classified as adult only if pornographic.
-        - Anime TV Shows: Classified as adult only if hentai.
         """
         adult_yes = "1"
         adult_no = "2"

--- a/src/trackers/bjshare.py
+++ b/src/trackers/bjshare.py
@@ -1778,17 +1778,7 @@ class BJShare:
         adult_yes = "1"
         adult_no = "2"
 
-        if meta.adult_media:
-            return adult_yes
-
-        keywords_str = ", ".join(meta.keywords)
-        genres = f"{keywords_str} {meta.combined_genres}"
-        adult_keywords = ["xxx", "erotic", "porn", "adult", "orgy"]
-
-        if meta.anime and "hentai" in genres.lower():
-            return adult_yes
-
-        if any(re.search(rf"(^|,\s*){re.escape(keyword)}(\s*,|$)", genres, re.IGNORECASE) for keyword in adult_keywords):
+        if meta.category == "XXX":
             return adult_yes
 
         return adult_no


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adult-only labeling is now applied exclusively to uploads categorized as `XXX`; other categories are treated as non-adult.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->