### PR TITLE
refactor(description): hide standalone screenshot header

### DIFF
--- a/data/example_config.py
+++ b/data/example_config.py
@@ -366,6 +366,8 @@ config: dict[str, Any] = {
         # Header added above the screenshot section where supported.
         # Can be overridden per tracker by adding the same setting to its configuration.
         "screenshot_header": "[h2]Screenshots[/h2]",
+        # Set to False to keep the screenshot header even when screenshots are the only section.
+        "hide_screenshot_header_if_only_section": True,
         # Header added above screenshots after HDR tone mapping.
         # Can be overridden per tracker by adding the same setting to its configuration.
         "tonemapped_header": "[center]Screenshots have been adapted for SDR viewing, for reference only.[/center]",

--- a/src/get_desc.py
+++ b/src/get_desc.py
@@ -1530,7 +1530,8 @@ class DescriptionBuilder:
         if ua_signature:
             if not signature:
                 script_signature = meta.ua_signature
-                signature = f"[right][url=https://github.com/wastaken7/Upload-Assistant][size=4]{script_signature}[/size][/url][/right]"
+                if script_signature:
+                    signature = f"[right][url=https://github.com/wastaken7/Upload-Assistant][size=4]{script_signature}[/size][/url][/right]"
             ua_signature_section = signature
         else:
             ua_signature_section = ""

--- a/src/get_desc.py
+++ b/src/get_desc.py
@@ -1520,37 +1520,48 @@ class DescriptionBuilder:
             if not description or user_description_content.strip() != meta_description.strip():
                 desc_parts.append(user_description_content)
 
-        # Menu Screenshots
-        if menu_screenshots:
-            desc_parts.append(await self.menu_section(meta))
-
-        # Tonemapped Header
-        if tonemapped_header:
-            desc_parts.append(tonemapped_header_text)
-
-        # Discs and Screenshots
-        if screenshots:
-            discs_and_screenshots = await self._handle_discs_and_screenshots(meta, approved_image_hosts, images, multi_screens)
-            desc_parts.append(discs_and_screenshots)
-
-        # Audio Spectrograms
-        if audio_spectrogram:
-            desc_parts.append(await self.get_audio_spectrogram_section(meta))
-
-        # Dynamic HDR metadata plots (Dolby Vision / HDR10+)
-        if dynamic_hdr_plot:
-            desc_parts.append(await self.get_dynamic_hdr_plot_section(meta))
-
-        # Custom Signature
-        if custom_signature:
-            desc_parts.append(await self.get_custom_signature(meta))
-
-        # UA Signature
+        # Render the remaining optional sections before deciding whether a
+        # standalone screenshot section needs its heading.
+        menu_section = await self.menu_section(meta) if menu_screenshots else ""
+        tonemapped_section = tonemapped_header_text if tonemapped_header else ""
+        audio_spectrogram_section = await self.get_audio_spectrogram_section(meta) if audio_spectrogram else ""
+        dynamic_hdr_plot_section = await self.get_dynamic_hdr_plot_section(meta) if dynamic_hdr_plot else ""
+        custom_signature_section = await self.get_custom_signature(meta) if custom_signature else ""
         if ua_signature:
             if not signature:
                 script_signature = meta.ua_signature
                 signature = f"[right][url=https://github.com/wastaken7/Upload-Assistant][size=4]{script_signature}[/size][/url][/right]"
-            desc_parts.append(signature)
+            ua_signature_section = signature
+        else:
+            ua_signature_section = ""
+
+        other_sections = [*desc_parts, menu_section, tonemapped_section, audio_spectrogram_section, dynamic_hdr_plot_section, custom_signature_section, ua_signature_section]
+        include_screenshot_header = not (self._get_bool_config("hide_screenshot_header_if_only_section", True) and not any(part.strip() for part in other_sections))
+
+        # Menu Screenshots
+        desc_parts.append(menu_section)
+
+        # Tonemapped Header
+        desc_parts.append(tonemapped_section)
+
+        # Discs and Screenshots
+        if screenshots:
+            discs_and_screenshots = await self._handle_discs_and_screenshots(meta, approved_image_hosts, images, multi_screens, include_screenshot_header)
+            desc_parts.append(discs_and_screenshots)
+
+        # Audio Spectrograms
+        desc_parts.append(audio_spectrogram_section)
+
+        # Dynamic HDR metadata plots (Dolby Vision / HDR10+)
+        if dynamic_hdr_plot:
+            desc_parts.append(dynamic_hdr_plot_section)
+
+        # Custom Signature
+        if custom_signature:
+            desc_parts.append(custom_signature_section)
+
+        # UA Signature
+        desc_parts.append(ua_signature_section)
 
         description_str: str = "\n".join(part for part in desc_parts if part.strip())
 
@@ -1630,11 +1641,18 @@ class DescriptionBuilder:
                 logger.warning(f"[yellow]Warning: Could not load pack image data: {e!s}[/yellow]")
         return pack_images_data
 
-    async def _handle_discs_and_screenshots(self, meta: Meta, approved_image_hosts: list[str], images: list[dict[str, str]], multi_screens: int) -> str:
+    async def _handle_discs_and_screenshots(
+        self,
+        meta: Meta,
+        approved_image_hosts: list[str],
+        images: list[dict[str, str]],
+        multi_screens: int,
+        include_header: bool = True,
+    ) -> str:
         if not images:
             return ""
         try:
-            screenheader = await self.screenshot_header(meta)
+            screenheader = await self.screenshot_header(meta) if include_header else ""
         except Exception:
             screenheader = None
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to hide the screenshot header when screenshots are the only section in a description.
  * The screenshot header is now omitted by default in screenshot-only descriptions, reducing unnecessary visual clutter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->