### PR TITLE
fix(get_desc): keep per-file pack screenshots without a tracker image override

### DIFF
--- a/src/get_desc.py
+++ b/src/get_desc.py
@@ -1319,13 +1319,11 @@ class DescriptionBuilder:
             image_list = []
         if approved_image_hosts is None:
             approved_image_hosts = []
-        # get_tracker_image_collection falls back to meta.image_list; only a real override zeroes multi_screens.
-        if image_list and has_tracker_image_collection(meta, self.tracker, "screenshots"):
-            images = image_list
-            multi_screens = 0
-        else:
-            images = meta.image_list
-            multi_screens = self._get_int_config("multiScreens", 2)
+        # get_tracker_image_collection falls back to meta.image_list, so only a real override
+        # replaces the base screenshots. It never disables per-file pack screenshots: those
+        # upload through allowed_hosts, so a tracker's host policy is honoured either way.
+        images = image_list if image_list and has_tracker_image_collection(meta, self.tracker, "screenshots") else meta.image_list
+        multi_screens = self._get_int_config("multiScreens", 2)
         if meta.sorted_filelist:
             multi_screens = 0
 

--- a/src/get_desc.py
+++ b/src/get_desc.py
@@ -28,7 +28,7 @@ from src.mediainfo import MediaInfo
 from src.meta import Meta
 from src.screenshot_manifest import files as manifest_files
 from src.takescreens import TakeScreensManager
-from src.tracker_images import get_tracker_image_collection
+from src.tracker_images import get_tracker_image_collection, has_tracker_image_collection
 from src.trackers.common import Common
 from src.uploadscreens import UploadScreensManager
 
@@ -1319,7 +1319,8 @@ class DescriptionBuilder:
             image_list = []
         if approved_image_hosts is None:
             approved_image_hosts = []
-        if image_list:
+        # get_tracker_image_collection falls back to meta.image_list; only a real override zeroes multi_screens.
+        if image_list and has_tracker_image_collection(meta, self.tracker, "screenshots"):
             images = image_list
             multi_screens = 0
         else:

--- a/tests/test_pack_multi_screens.py
+++ b/tests/test_pack_multi_screens.py
@@ -1,0 +1,50 @@
+# ruff: noqa: S101
+import asyncio
+
+from src.get_desc import DescriptionBuilder
+from src.meta import Meta
+from src.tracker_images import set_tracker_image_collection
+
+
+def test_pack_multi_screens_only_zeroed_by_tracker_override() -> None:
+    async def run() -> None:
+        tracker = "TEST"
+        builder = DescriptionBuilder(tracker, {"DEFAULT": {"multiScreens": 4}, "TRACKERS": {tracker: {}}})
+        release_images = [{"web_url": "https://example.com/release", "raw_url": "https://example.com/release.jpg"}]
+        override_images = [{"web_url": "https://example.com/override", "raw_url": "https://example.com/override.jpg"}]
+        meta = Meta(category="TV", season=1, filelist=["episode-1.mkv", "episode-2.mkv"], image_list=release_images)
+        calls = []
+
+        async def capture_screenshot_args(_meta, _approved_image_hosts, images, multi_screens, _include_header=True):
+            calls.append((images, multi_screens))
+            return ""
+
+        builder._handle_discs_and_screenshots = capture_screenshot_args
+        disabled_sections = {
+            "audio_spectrogram": False,
+            "bluray": False,
+            "book": False,
+            "custom_header": False,
+            "custom_signature": False,
+            "description": False,
+            "dynamic_hdr_plot": False,
+            "game": False,
+            "languages": False,
+            "logo": False,
+            "mediainfo": False,
+            "menu_screenshots": False,
+            "music": False,
+            "nfo": False,
+            "tonemapped_header": False,
+            "tv_info": False,
+            "ua_signature": False,
+            "user_description": False,
+        }
+
+        await builder.general_description_generator(meta, **disabled_sections)
+        set_tracker_image_collection(meta, tracker, "screenshots", override_images)
+        await builder.general_description_generator(meta, **disabled_sections)
+
+        assert calls == [(release_images, 4), (override_images, 0)]
+
+    asyncio.run(run())

--- a/tests/test_pack_multi_screens.py
+++ b/tests/test_pack_multi_screens.py
@@ -6,7 +6,7 @@ from src.meta import Meta
 from src.tracker_images import set_tracker_image_collection
 
 
-def test_pack_multi_screens_only_zeroed_by_tracker_override() -> None:
+def test_pack_multi_screens_survive_tracker_override() -> None:
     async def run() -> None:
         tracker = "TEST"
         builder = DescriptionBuilder(tracker, {"DEFAULT": {"multiScreens": 4}, "TRACKERS": {tracker: {}}})
@@ -45,6 +45,6 @@ def test_pack_multi_screens_only_zeroed_by_tracker_override() -> None:
         set_tracker_image_collection(meta, tracker, "screenshots", override_images)
         await builder.general_description_generator(meta, **disabled_sections)
 
-        assert calls == [(release_images, 4), (override_images, 0)]
+        assert calls == [(release_images, 4), (override_images, 4)]
 
     asyncio.run(run())


### PR DESCRIPTION
`get_tracker_image_collection` falls back to `meta.image_list`, so `if image_list:` held for every release with screenshots and forced `multiScreens` to 0: packs rendered only the first file's base screenshots, with no per-file spoilers. #405 fixed the capture cutoff for pack groups (#402); the builder still skipped the per-file loop.

A tracker image override is not a reason to skip that loop either: `rehostimages.py` stores one for every tracker with an image-host policy, even when it is just the base screenshots re-validated, and the per-file captures already upload through `allowed_hosts`. `multiScreens` now comes from config regardless; the override only decides which base images are used.

Multi-disc DVD packs now reach the extra-disc branch, which no longer captures discs after the first (the builder's `dvd_screenshots` call was removed and `prep.py` captures disc 0 only); left for a follow-up.

Checks: `pytest` (979 passed), `ruff check src/get_desc.py tests/test_pack_multi_screens.py` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected screenshot selection to use tracker-specific images only when a valid override is available, otherwise falling back to release images.
  * Preserved the configured multi-screen count when tracker-specific image overrides are used.

* **Tests**
  * Added coverage for screenshot selection and multi-screen behavior with and without tracker-specific overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->