### PR TITLE
fix(tv): fall back when anime match is unresolved

### DIFF
--- a/src/getseasonep.py
+++ b/src/getseasonep.py
@@ -46,11 +46,81 @@ class SeasonEpisodeManager:
     def __init__(self, config: dict[str, Any]) -> None:
         self.tmdb_manager = TmdbManager(config)
 
+    async def _parse_standard_season_episode(self, video: str, meta: Meta, filelist: list[str]) -> tuple[int, int, str, str]:
+        is_daily = False
+        season_int = 1
+        episode_int = 0
+        season = "S01"
+        episode = ""
+
+        try:
+            daily_match = re.search(r"\d{4}[-\.]\d{2}[-\.]\d{2}", video)
+            if (meta.manual_date or daily_match) and not meta.manual_season:
+                if meta.manual_date is None and daily_match is not None:
+                    meta.manual_date = daily_match.group().replace(".", "-")
+                is_daily = True
+                guess_data = _guessit_data(video)
+                guess_date_raw = meta.manual_date or guess_data.get("date")
+                guess_date = str(guess_date_raw) if guess_date_raw else ""
+                tmdb_id_value = _safe_int(meta.tmdb_id, 0)
+                season_int, episode_int = await self.tmdb_manager.daily_to_tmdb_season_episode(tmdb_id_value, guess_date)
+
+                season = f"S{str(season_int).zfill(2)}"
+                episode = f"E{str(episode_int).zfill(2)}"
+                meta.daily_episode_title = meta.manual_date or ""
+            else:
+                try:
+                    guess_year = str(_guessit_data(video).get("year") or "")
+                except Exception:
+                    guess_year = ""
+                try:
+                    guess_data = _guessit_data(video)
+                    season_guess = str(guess_data.get("season") or "")
+                    if season_guess == guess_year:
+                        if f"s{season_guess}" in video.lower():
+                            season_int = int(season_guess)
+                            season = "S" + str(season_int).zfill(2)
+                        else:
+                            season_int = 1
+                            season = "S01"
+                    else:
+                        season_int = int(guess_data.get("season") or 1)
+                        season = "S" + str(season_int).zfill(2)
+                except Exception:
+                    logger.info("[bold yellow]There was an error guessing the season number. Guessing S01. Use [bold green]--season #[/bold green] to correct if needed")
+                    season_int = 1
+                    season = "S01"
+        except Exception:
+            console.print_exception()
+            season_int = 1
+            season = "S01"
+
+        try:
+            if not is_daily:
+                if len(filelist) == 1:
+                    guess_data = _guessit_data(video)
+                    episodes = guess_data.get("episode")
+                    if isinstance(episodes, list):
+                        episode = "".join(f"E{str(item).zfill(2)}" for item in episodes)
+                        episode_int = _safe_int(episodes[0], 0) if episodes else 0
+                    else:
+                        episode_int = _safe_int(episodes, 0)
+                        episode = "E" + str(episode_int).zfill(2) if episodes is not None else ""
+                else:
+                    episode = ""
+                    episode_int = 0
+                    meta.tv_pack = True
+        except Exception:
+            episode = ""
+            episode_int = 0
+            meta.tv_pack = True
+
+        return season_int, episode_int, season, episode
+
     async def get_season_episode(self, video: str, meta: Meta) -> Meta:
         if meta.category == "TV":
             filelist = cast(list[str], meta.filelist)
             meta.tv_pack = False
-            is_daily = False
             season_int = 1
             episode_int = 0
             season = "S01"
@@ -59,81 +129,7 @@ class SeasonEpisodeManager:
             eng_title = ""
             anilist_episodes = 0
             if not meta.anime:
-                try:
-                    daily_match = re.search(r"\d{4}[-\.]\d{2}[-\.]\d{2}", video)
-                    if (meta.manual_date or daily_match) and not meta.manual_season:
-                        # Handle daily episodes
-                        # The user either provided the --daily argument or a date was found in the filename
-
-                        if meta.manual_date is None and daily_match is not None:
-                            meta.manual_date = daily_match.group().replace(".", "-")
-                        is_daily = True
-                        guess_data = _guessit_data(video)
-                        guess_date_raw = meta.manual_date or guess_data.get("date")
-                        guess_date = str(guess_date_raw) if guess_date_raw else ""
-                        tmdb_id_value = _safe_int(meta.tmdb_id, 0)
-                        season_int, episode_int = await self.tmdb_manager.daily_to_tmdb_season_episode(tmdb_id_value, guess_date)
-
-                        season = f"S{str(season_int).zfill(2)}"
-                        episode = f"E{str(episode_int).zfill(2)}"
-                        # For daily shows, pass the supplied date as the episode title
-                        # Season and episode will be stripped later to conform with standard daily episode naming format
-                        meta.daily_episode_title = meta.manual_date or ""
-
-                    else:
-                        try:
-                            guess_year = str(_guessit_data(video).get("year") or "")
-                        except Exception:
-                            guess_year = ""
-                        try:
-                            guess_data = _guessit_data(video)
-                            season_guess = str(guess_data.get("season") or "")
-                            if season_guess == guess_year:
-                                if f"s{season_guess}" in video.lower():
-                                    season_int = int(season_guess)
-                                    season = "S" + str(season_int).zfill(2)
-                                else:
-                                    season_int = 1
-                                    season = "S01"
-                            else:
-                                season_int = int(guess_data.get("season") or 1)
-                                season = "S" + str(season_int).zfill(2)
-                        except Exception:
-                            logger.info(
-                                "[bold yellow]There was an error guessing the season number. Guessing S01. Use [bold green]--season #[/bold green] to correct if needed"
-                            )
-                            season_int = 1
-                            season = "S01"
-
-                except Exception:
-                    console.print_exception()
-                    season_int = 1
-                    season = "S01"
-
-                try:
-                    if is_daily is not True:
-                        episodes = ""
-                        if len(filelist) == 1:
-                            guess_data = _guessit_data(video)
-                            episodes = guess_data.get("episode")
-                            if isinstance(episodes, list):
-                                episode = ""
-                                episodes_list = episodes
-                                for item in episodes_list:
-                                    ep = str(item).zfill(2)
-                                    episode += f"E{ep}"
-                                episode_int = _safe_int(episodes_list[0], 0) if episodes_list else 0
-                            else:
-                                episode_int = _safe_int(episodes, 0)
-                                episode = "E" + str(episode_int).zfill(2) if episodes is not None else ""
-                        else:
-                            episode = ""
-                            episode_int = 0
-                            meta.tv_pack = True
-                except Exception:
-                    episode = ""
-                    episode_int = 0
-                    meta.tv_pack = True
+                season_int, episode_int, season, episode = await self._parse_standard_season_episode(video, meta, filelist)
 
             else:
                 # If Anime
@@ -281,12 +277,10 @@ class SeasonEpisodeManager:
                             logger.info(f"[bold yellow]If [green]{season}[/green] is incorrect, use --season to correct")
                             await asyncio.sleep(3)
                 else:
-                    logger.info("[bold red]Error determining if TV show is anime or not[/bold red]")
-                    logger.info("[bold yellow]Set manual season and episode[/bold yellow]")
-                    season_int = 1
-                    season = "S01"
-                    episode_int = 1
-                    episode = "E01"
+                    logger.info("[yellow]No matching AniList entry found; using standard season and episode parsing[/yellow]")
+                    if not romaji and not eng_title:
+                        meta.demographic = ""
+                    season_int, episode_int, season, episode = await self._parse_standard_season_episode(video, meta, filelist)
 
             if meta.manual_season is None:
                 meta.season = season

--- a/src/prep_helpers.py
+++ b/src/prep_helpers.py
@@ -206,7 +206,6 @@ def init_meta(prep_instance: Any, meta: Meta, mode: str) -> tuple[bool, bool, Cl
     meta.subtitle_languages = None
     meta.aither_trumpable = None
     meta.anime = False
-    meta.not_anime = False
     meta.subtitle_files = cast(list[str], [])
     meta.adult_media = False
     meta.pre_release = check_pre_release(meta)

--- a/src/tmdb.py
+++ b/src/tmdb.py
@@ -1396,7 +1396,10 @@ async def get_anime(response: dict[str, Any], meta: Meta) -> tuple[int, str, boo
             meta.mal_id,
             meta,
         )
-        alt_name = f"AKA {romaji}"
+        if romaji:
+            alt_name = f"AKA {romaji}"
+        else:
+            demographic = ""
         anime = True
         # mal = AnimeSearch(romaji)
         # mal_id = mal.results[0].mal_id

--- a/tests/test_season_episode_fallback.py
+++ b/tests/test_season_episode_fallback.py
@@ -1,0 +1,70 @@
+# ruff: noqa: S101
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from src import prep_helpers
+from src.getseasonep import SeasonEpisodeManager
+from src.meta import Meta
+from src.tmdb import get_anime
+
+
+def test_unconfirmed_anime_season_pack_uses_standard_season_parsing() -> None:
+    manager = SeasonEpisodeManager({"DEFAULT": {"tmdb_api": "test-key"}})
+    manager.tmdb_manager.get_romaji = AsyncMock(return_value=("", 0, "", "", 0, "Mina"))
+    meta = Meta(
+        category="TV",
+        anime=True,
+        mal_id=0,
+        filelist=[],
+        filename="Example Show",
+        tmdb_id=12345,
+    )
+
+    result = asyncio.run(manager.get_season_episode("Example.Show.S03.PAL.DVD.REMUX-GROUP", meta))
+
+    assert result.season == "S03"
+    assert result.season_int == 3
+    assert result.episode == ""
+    assert result.episode_int == 0
+    assert result.tv_pack is True
+    assert result.demographic == ""
+
+
+def test_standard_single_episode_parsing_is_preserved() -> None:
+    manager = SeasonEpisodeManager({"DEFAULT": {"tmdb_api": "test-key"}})
+    meta = Meta(category="TV", anime=False, filelist=["episode.mkv"])
+
+    result = asyncio.run(manager.get_season_episode("Example.Show.S03E04.1080p.WEB-DL-GROUP.mkv", meta))
+
+    assert result.season == "S03"
+    assert result.season_int == 3
+    assert result.episode == "E04"
+    assert result.episode_int == 4
+    assert result.tv_pack is False
+
+
+def test_not_anime_cli_value_survives_metadata_initialization(tmp_path) -> None:
+    prep = SimpleNamespace(config={"DEFAULT": {}})
+    meta = Meta(base_dir=str(tmp_path), path=str(tmp_path), not_anime=True)
+
+    prep_helpers.init_meta(prep, meta, "cli")
+
+    assert meta.not_anime is True
+
+
+def test_unmatched_japanese_animation_has_no_placeholder_demographic() -> None:
+    response = {
+        "genres": [{"id": 16, "name": "Animation"}],
+        "original_language": "en",
+        "origin_country": ["JP"],
+    }
+    meta = Meta(title="Example Show", filename="Example.Show.S03")
+
+    with patch("src.tmdb.get_romaji", new=AsyncMock(return_value=("", 0, "", "", 0, "Mina"))):
+        mal_id, alt_name, anime, demographic = asyncio.run(get_anime(response, meta))
+
+    assert mal_id == 0
+    assert alt_name == ""
+    assert anime is True
+    assert demographic == ""


### PR DESCRIPTION
Before if show was detected as anime but not found on AniList, season and episode number were set to `1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved season and episode detection for standard TV releases, including unconfirmed anime season packs.
  * Preserved single-episode parsing behavior.
  * Improved anime metadata when romaji titles or demographic details are unavailable, avoiding empty or placeholder values.
  * Preserved the command-line setting indicating that content is not anime during metadata processing.

* **Tests**
  * Added regression coverage for season-pack parsing, single episodes, metadata settings, and unmatched Japanese animation metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->