### PR TITLE
fix: fetch Blu-ray metadata for empty fields

### DIFF
--- a/src/prep_helpers.py
+++ b/src/prep_helpers.py
@@ -835,6 +835,17 @@ def _clear_imdb_metadata(meta: Meta) -> None:
     meta.imdb_rating = ""
 
 
+def _should_fetch_bluray_info(meta: Meta, get_bluray_info: bool) -> bool:
+    return bool(
+        meta.is_disc in ("BDMV", "DVD")
+        and get_bluray_info
+        and (not meta.distributor or not meta.region)
+        and meta.imdb_id != 0
+        and not meta.edit
+        and not meta.site_check
+    )
+
+
 async def search_metadata(
     prep_instance: Any,
     meta: Meta,
@@ -1404,14 +1415,7 @@ async def finalize_metadata(
     meta.bluray_score = int(float(prep_instance.config["DEFAULT"].get("bluray_score", 100)))
     meta.bluray_single_score = int(float(prep_instance.config["DEFAULT"].get("bluray_single_score", 100)))
     meta.use_bluray_images = prep_instance.config["DEFAULT"].get("use_bluray_images", False)
-    if (
-        meta.is_disc in ("BDMV", "DVD")
-        and get_bluray_info
-        and (meta.distributor is None or meta.region is None)
-        and meta.imdb_id != 0
-        and not meta.edit
-        and not meta.site_check
-    ):
+    if _should_fetch_bluray_info(meta, get_bluray_info):
         releases = await get_bluray_releases(meta)
 
         if releases and meta.is_disc in ("BDMV", "DVD") and meta.use_bluray_images:

--- a/tests/test_prep_helpers_bluray.py
+++ b/tests/test_prep_helpers_bluray.py
@@ -1,0 +1,24 @@
+# ruff: noqa: S101
+
+from src.meta import Meta
+from src.prep_helpers import _should_fetch_bluray_info
+
+
+def test_bluray_lookup_runs_when_region_and_distributor_are_empty() -> None:
+    meta = Meta(is_disc="BDMV", imdb_id=1234567)
+
+    assert _should_fetch_bluray_info(meta, get_bluray_info=True) is True
+
+
+def test_bluray_lookup_runs_when_only_one_field_is_missing() -> None:
+    missing_region = Meta(is_disc="BDMV", imdb_id=1234567, distributor="TEST DISTRIBUTOR")
+    missing_distributor = Meta(is_disc="BDMV", imdb_id=1234567, region="B")
+
+    assert _should_fetch_bluray_info(missing_region, get_bluray_info=True) is True
+    assert _should_fetch_bluray_info(missing_distributor, get_bluray_info=True) is True
+
+
+def test_bluray_lookup_skips_when_region_and_distributor_are_present() -> None:
+    meta = Meta(is_disc="BDMV", imdb_id=1234567, region="B", distributor="TEST DISTRIBUTOR")
+
+    assert _should_fetch_bluray_info(meta, get_bluray_info=True) is False


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Blu-ray release information is now fetched when distributor or region metadata is empty, ensuring missing details can be completed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->