### PR TITLE
fix: CWTV streaming service detection from NFOs

### DIFF
--- a/src/region.py
+++ b/src/region.py
@@ -2102,6 +2102,7 @@ async def get_service(
         "CW": "CW",
         "CWS": "CWS",
         "CWSeed": "CWS",
+        "CWTV": "CW",
         "Daisuki": "DSKI",
         "DARKROOM": "DARKROOM",
         "DAZN": "DAZN",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for recognizing the CWTV service identifier as CW.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->