### PR TITLE
fix(service): exclude episode titles from service matching

### DIFF
--- a/src/region.py
+++ b/src/region.py
@@ -2409,7 +2409,7 @@ async def get_service(
     if audio and "DTS-HD MA" in audio:
         video_name = video_name.replace("DTS-HD.MA.", "").replace("DTS-HD MA ", "")
     title_guess = guessit_fn(video, {"excludes": ["country", "language"]})
-    title_guess_title = str(title_guess.get("title", ""))
+    title_guess_title = f"{title_guess.get('title', '')} {title_guess.get('episode_title', '')}"
     for key, value in services.items():
         if ((" " + key + " ") in video_name and key not in title_guess_title) or key == service:
             service = value

--- a/src/region.py
+++ b/src/region.py
@@ -2409,9 +2409,10 @@ async def get_service(
     if audio and "DTS-HD MA" in audio:
         video_name = video_name.replace("DTS-HD.MA.", "").replace("DTS-HD MA ", "")
     title_guess = guessit_fn(video, {"excludes": ["country", "language"]})
-    title_guess_title = f"{title_guess.get('title', '')} {title_guess.get('episode_title', '')}"
+    title_guess_title = str(title_guess.get("title", ""))
+    title_guess_episode_title = str(title_guess.get("episode_title", ""))
     for key, value in services.items():
-        if ((" " + key + " ") in video_name and key not in title_guess_title) or key == service:
+        if ((" " + key + " ") in video_name and key not in title_guess_title and key not in title_guess_episode_title) or key == service:
             service = value
     service_longname: str = service
     for key, value in services.items():

--- a/tests/test_region_service.py
+++ b/tests/test_region_service.py
@@ -18,3 +18,24 @@ async def test_get_service_detects_release_tag(service_tag: str, expected: tuple
     release_name = f"Example.Show.S01E01.1080p.{service_tag}.WEB-DL.AAC2.0.H.264-GROUP"
 
     assert await get_service(release_name) == expected
+
+
+@pytest.mark.asyncio
+async def test_get_service_does_not_join_title_fields() -> None:
+    release_name = "Example.Apple.S01E01.TV.1080p.Apple.TV.WEB-DL.AAC2.0.H.264-GROUP"
+
+    assert await get_service(release_name) == ("ATV", "Apple TV")
+
+
+@pytest.mark.parametrize(
+    ("service_tag", "expected"),
+    [
+        ("", ("", "")),
+        ("STAN.", ("STAN", "STAN")),
+    ],
+)
+@pytest.mark.asyncio
+async def test_get_service_distinguishes_episode_title_from_service_tag(service_tag: str, expected: tuple[str, str]) -> None:
+    release_name = f"Example.Show.S01E01.Stan.Goes.on.a.Trip.1080p.{service_tag}WEB-DL.AAC2.0.H.264-GROUP.mkv"
+
+    assert await get_service(release_name) == expected


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming-service detection by keeping release titles and episode titles separate during matching.
  * Prevented text spanning both fields from being incorrectly interpreted as a service name.
  * Improved recognition of valid service tags when episode titles contain similar words, including cases involving Apple TV and Stan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->