### PR TITLE
fix(dreadvault): add the four groups banned on 2026-09-06

### DIFF
--- a/src/trackers/UNIT3D/dreadvault.py
+++ b/src/trackers/UNIT3D/dreadvault.py
@@ -22,8 +22,12 @@ class DreadVault(UNIT3D):
     allows_bloated_audio = True
     base_url = "https://dreadvault.org"
     banned_groups = (
+        "AOC",
+        "AOS",
         "BONE",
         "EVO",
+        "FGT",
+        "LAMA",
         "NeoNoir",
         "PSA",
         "RARBG",

--- a/tests/test_dreadvault.py
+++ b/tests/test_dreadvault.py
@@ -33,11 +33,15 @@ def test_dreadvault_dvl_cli_alias_is_canonicalized_before_tracker_checks():
 
 
 def test_dreadvault_bans_the_published_groups():
-    # Published on the site's rules page 2026-08-24; DreadVault exposes no
+    # Published on the site's rules page 2026-08-24, extended 2026-09-06; DreadVault exposes no
     # /api/bannedReleaseGroups endpoint, so this list is maintained by hand.
     assert set(DreadVault.banned_groups) == {  # noqa: S101
+        "AOC",
+        "AOS",
         "BONE",
         "EVO",
+        "FGT",
+        "LAMA",
         "NeoNoir",
         "PSA",
         "RARBG",


### PR DESCRIPTION
The rules page (updated 2026-09-06) now also bans AOC, AOS, FGT and LAMA.
Still hand-maintained: the site exposes no /api/bannedReleaseGroups endpoint.
Follow-up to #399.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated group filtering to block content associated with four additional groups: AOC, AOS, FGT, and LAMA.
* **Tests**
  * Updated automated checks to verify the expanded group blocklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->