### PR TITLE
feat(webui): manage release group description overrides

### DIFF
--- a/data/example_config.py
+++ b/data/example_config.py
@@ -386,15 +386,16 @@ config: dict[str, Any] = {
         # case-insensitively, with or without their leading hyphen.
         # Per-tracker tag_overrides take precedence over these DEFAULT overrides.
         "tag_overrides": {
-            "MyAwesomeGroupTag": {
-                "custom_description_header": "[center]MyAwesomeGroupTag release[/center]",
-                "screenshot_header": "[h2]MyAwesomeGroupTag Screenshots[/h2]",
-                "disc_menu_header": "[h2]MyAwesomeGroupTag Disc Menu Screenshots[/h2]",
-                "audio_spectrogram_header": "[h2]MyAwesomeGroupTag Audio Spectrogram[/h2]",
-                "dynamic_hdr_plot_header": "[h2]MyAwesomeGroupTag Dynamic HDR Metadata[/h2]",
-                "tonemapped_header": "[center]MyAwesomeGroupTag SDR reference screenshots[/center]",
-                "custom_signature": "[center]MyAwesomeGroupTag signature[/center]",
-            },
+            # Uncomment and rename this example group to configure your own overrides.
+            # "MyAwesomeGroupTag": {
+            #     "custom_description_header": "[center]MyAwesomeGroupTag release[/center]",
+            #     "screenshot_header": "[h2]MyAwesomeGroupTag Screenshots[/h2]",
+            #     "disc_menu_header": "[h2]MyAwesomeGroupTag Disc Menu Screenshots[/h2]",
+            #     "audio_spectrogram_header": "[h2]MyAwesomeGroupTag Audio Spectrogram[/h2]",
+            #     "dynamic_hdr_plot_header": "[h2]MyAwesomeGroupTag Dynamic HDR Metadata[/h2]",
+            #     "tonemapped_header": "[center]MyAwesomeGroupTag SDR reference screenshots[/center]",
+            #     "custom_signature": "[center]MyAwesomeGroupTag signature[/center]",
+            # },
         },
         # --- BLU-RAY SETTINGS ---
         # Set to True to use the largest Blu-ray playlist without a selection prompt.

--- a/tests/test_webui_release_group_overrides.py
+++ b/tests/test_webui_release_group_overrides.py
@@ -1,0 +1,158 @@
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+import web_ui.server as server
+from src.get_desc import DescriptionBuilder
+from src.meta import Meta
+
+
+def test_copied_example_documents_groups_without_enabling_them(tmp_path, monkeypatch):
+    example_path = server.CODE_DIR / "data" / "example_config.py"
+    original_example = example_path.read_bytes()
+    config_path = tmp_path / "data" / "config.py"
+    config_path.parent.mkdir()
+    monkeypatch.setattr(server, "STATE_DIR", tmp_path)
+
+    shutil.copy2(example_path, config_path)
+
+    example = server._load_config_from_file(example_path)
+    saved = server._load_config_from_file(config_path)
+    assert saved == example
+    assert saved["DEFAULT"]["tag_overrides"] == {}
+    assert example_path.read_bytes() == original_example
+    generated_source = config_path.read_text(encoding="utf-8")
+    assert '# "MyAwesomeGroupTag": {' in generated_source
+    assert "# Override description text fields for specific release groups." in generated_source
+    assert "# Per-tracker tag_overrides take precedence over these DEFAULT overrides." in generated_source
+    assert "# Set to True to display a notice when an update is available." in generated_source
+    items = server._build_config_items(example["DEFAULT"], saved["DEFAULT"], {}, {}, ["DEFAULT"])
+    assert next(item for item in items if item["key"] == "tag_overrides")["value"] == {}
+
+
+def test_saved_sample_named_group_remains_editable():
+    user = {"tag_overrides": {"MyAwesomeGroupTag": {"custom_signature": "saved text"}}}
+    items = server._build_config_items({"tag_overrides": {}}, user, {}, {}, ["DEFAULT"])
+
+    assert items[0]["value"] == user["tag_overrides"]
+
+
+@pytest.fixture
+def config_files(tmp_path: Path, monkeypatch):
+    code_dir = tmp_path / "checkout"
+    state_dir = tmp_path / "state"
+    example_path = code_dir / "data" / "example_config.py"
+    config_path = state_dir / "data" / "config.py"
+    example = {
+        "DEFAULT": {"tag_overrides": {"SampleGroup": {"custom_signature": "example"}}},
+        "TRACKERS": {"AITHER": {"api_key": ""}},
+    }
+    user = {
+        "DEFAULT": {"screens": 6, "screenshot_header": "inherited screenshots"},
+        "TRACKERS": {"AITHER": {"api_key": "test-only-key"}},
+    }
+    for path, config in ((example_path, example), (config_path, user)):
+        path.parent.mkdir(parents=True)
+        path.write_text(f"config = {config!r}\n", encoding="utf-8")
+    monkeypatch.setattr(server, "CODE_DIR", code_dir)
+    monkeypatch.setattr(server, "STATE_DIR", state_dir)
+    monkeypatch.setattr(server, "_is_authenticated", lambda: True)
+    monkeypatch.setattr(server, "_verify_csrf_header", lambda: True)
+    monkeypatch.setattr(server, "_verify_same_origin", lambda: True)
+    monkeypatch.setattr(server, "_write_audit_log", lambda *args, **kwargs: None)
+    return example_path, config_path
+
+
+def update(path, value):
+    with server.app.test_request_context("/api/config_update", method="POST", json={"path": path, "value": value}):
+        result = server.config_update()
+        response, status = result if isinstance(result, tuple) else (result, 200)
+        return response.get_json(), status
+
+
+@pytest.mark.parametrize("user", [{}, {"tag_overrides": {}}, {"tag_overrides": {"RealGroup": {"custom_signature": "saved"}}}])
+def test_metadata_uses_only_saved_groups(user):
+    example = {"tag_overrides": {"SampleGroup": {"custom_signature": "example"}}}
+    items = server._build_config_items(example, user, {}, {}, ["DEFAULT"])
+
+    assert items[0]["value"] == user.get("tag_overrides", {})
+    assert items[0]["example_value"] == {}
+    assert items[0]["children"] == []
+    assert {field["key"] for field in items[0]["override_fields"]} == {
+        "custom_description_header", "screenshot_header", "disc_menu_header", "audio_spectrogram_header",
+        "dynamic_hdr_plot_header", "tonemapped_header", "custom_signature",
+    }
+
+
+def test_tracker_metadata_exposes_editor_without_example_groups():
+    items = server._build_config_items({"api_key": ""}, {}, {}, {}, ["TRACKERS", "AITHER"])
+    group_item = next(item for item in items if item["key"] == "tag_overrides")
+
+    assert group_item["value"] == {}
+    assert group_item["override_fields"]
+    assert group_item["source"] == "example"
+
+
+@pytest.mark.parametrize("path", [["DEFAULT", "tag_overrides"], ["TRACKERS", "AITHER", "tag_overrides"]])
+def test_create_edit_rename_and_remove_round_trip(config_files, path):
+    example_path, config_path = config_files
+    original_example = example_path.read_bytes()
+    fields = {
+        "custom_signature": "[b]Grüppe[/b]\nSecond line with 'quotes' and \\slashes",
+        "disc_menu_header": "",
+        "screenshot_header": None,
+        "future_text_field": "preserve existing fields",
+    }
+    for groups in ({"CustomGroup": {}}, {"CustomGroup": fields}, {"RenamedGroup": fields}, {}):
+        result, status = update(path, json.dumps(groups))
+        assert status == 200, result
+        saved = server._load_config_from_file(config_path)
+        assert server._get_nested_value(saved, path) == groups
+        assert saved["DEFAULT"]["screens"] == 6
+        assert saved["TRACKERS"]["AITHER"]["api_key"] == "test-only-key"
+        if groups and next(iter(groups.values())):
+            builder = DescriptionBuilder("AITHER", saved)
+            meta = Meta({"tag": "-" + next(iter(groups)).lower()})
+            assert builder._get_str_config("custom_signature", "fallback", meta) == fields["custom_signature"]
+            assert builder._get_str_config("disc_menu_header", "fallback", meta) == ""
+            assert builder._get_str_config("screenshot_header", "fallback", meta) == "inherited screenshots"
+    assert example_path.read_bytes() == original_example
+
+
+@pytest.mark.parametrize("value", [
+    "{invalid json", [], {"Group": []}, {"Group": {"custom_signature": 12}},
+    {"": {}}, {"---": {}}, {"Bad\nName": {}}, {"Group": {}, "-gRoUp": {}}, {"Straße": {}, "STRASSE": {}},
+])
+def test_invalid_maps_do_not_modify_config(config_files, value):
+    _, config_path = config_files
+    original = config_path.read_bytes()
+
+    result, status = update(["DEFAULT", "tag_overrides"], value)
+
+    assert status == 400
+    assert result["success"] is False
+    assert config_path.read_bytes() == original
+
+
+def test_unknown_tracker_scope_does_not_modify_config(config_files):
+    _, config_path = config_files
+    original = config_path.read_bytes()
+
+    _, status = update(["TRACKERS", "UNKNOWN", "tag_overrides"], {"Group": {}})
+
+    assert status == 400
+    assert config_path.read_bytes() == original
+
+
+@pytest.mark.parametrize("guard,status", [("_is_authenticated", 401), ("_verify_csrf_header", 403), ("_verify_same_origin", 403)])
+def test_updates_require_authenticated_same_origin_session(config_files, monkeypatch, guard, status):
+    _, config_path = config_files
+    original = config_path.read_bytes()
+    monkeypatch.setattr(server, guard, lambda: False)
+
+    _, actual_status = update(["DEFAULT", "tag_overrides"], {"Group": {}})
+
+    assert actual_status == status
+    assert config_path.read_bytes() == original

--- a/web_ui/server.py
+++ b/web_ui/server.py
@@ -2303,6 +2303,7 @@ class ConfigItem(TypedDict, total=False):
     children: list[ConfigItem]
     help: list[str]
     subsection: str | bool
+    override_fields: list[ConfigItem]
 
 
 class ConfigSection(TypedDict, total=False):
@@ -2929,6 +2930,43 @@ def _remove_config_key_in_source(source: str, key_path: list[str]) -> str:
     return source  # Should not reach here
 
 
+_RELEASE_GROUP_OVERRIDE_FIELDS = (
+    "custom_description_header",
+    "screenshot_header",
+    "disc_menu_header",
+    "audio_spectrogram_header",
+    "dynamic_hdr_plot_header",
+    "tonemapped_header",
+    "custom_signature",
+)
+
+
+def _is_release_group_override_path(path: list[str]) -> bool:
+    """Identify the complete DEFAULT or tracker-specific release-group mapping."""
+    return path == ["DEFAULT", "tag_overrides"] or (
+        len(path) == 3 and path[0] == "TRACKERS" and path[2] == "tag_overrides"
+    )
+
+
+def _validate_release_group_overrides(value: object) -> None:
+    """Reject malformed maps and names that collide under description matching."""
+    if not isinstance(value, dict):
+        raise ValueError("Release group overrides must be a dictionary.")
+    seen: set[str] = set()
+    for name, fields in value.items():
+        if not isinstance(name, str) or not name.strip().lstrip("-") or any(ord(char) < 32 for char in name):
+            raise ValueError("Each release group needs a non-empty name without control characters.")
+        normalized_name = name.strip().lstrip("-").casefold()
+        if normalized_name in seen:
+            raise ValueError(f"Duplicate release group: {name}. Names are matched without case or leading hyphens.")
+        seen.add(normalized_name)
+        if not isinstance(fields, dict):
+            raise ValueError(f"Overrides for {name} must be a dictionary.")
+        for field, text in fields.items():
+            if not isinstance(field, str) or not field or (text is not None and not isinstance(text, str)):
+                raise ValueError(f"Overrides for {name} must contain text fields or null values.")
+
+
 def _build_config_items(
     example_section: dict[str, Any],
     user_section: dict[str, Any],
@@ -2942,6 +2980,8 @@ def _build_config_items(
     merged_keys: list[str] = [str(key) for key in example_section]
     if user_section:
         merged_keys.extend([str(key) for key in user_section if key not in example_section])
+    if len(path) == 2 and path[0] == "TRACKERS" and "tag_overrides" not in merged_keys:
+        merged_keys.append("tag_overrides")
 
     current_subsection: str | None = None
     subsection_items: list[ConfigItem] = []
@@ -2969,12 +3009,26 @@ def _build_config_items(
         if subsection_label != current_subsection:
             flush_subsection()
             current_subsection = subsection_label
-        if isinstance(example_value, Mapping) or isinstance(user_value, Mapping):
+        if _is_release_group_override_path(key_path):
+            # Example group names are documentation, not inherited user entries.
+            item: ConfigItem = {
+                "key": key,
+                "value": _json_safe(user_value if key in user_dict else {}),
+                "example_value": {},
+                "source": "config" if key in user_dict else "example",
+                "children": [],
+                "help": help_text or comments_map.get("DEFAULT/tag_overrides", []),
+                "override_fields": [
+                    {"key": field, "help": comments_map.get(f"DEFAULT/{field}", [])}
+                    for field in _RELEASE_GROUP_OVERRIDE_FIELDS
+                ],
+            }
+        elif isinstance(example_value, Mapping) or isinstance(user_value, Mapping):
             example_value = _as_dict(example_value) or {}
             user_value = _as_dict(user_value) or {}
             children = _build_config_items(example_value, user_value, comments_map, subsection_map, key_path)
             source: Literal["config", "example"] = "config" if key in user_dict else "example"
-            item: ConfigItem = {
+            item = {
                 "key": key,
                 "source": source,
                 "children": children,
@@ -4845,7 +4899,12 @@ def config_update():
         and re.fullmatch(r"(?:sonarr|radarr)_(?:url|api_key)_[1-3]", key) is not None
     )
     force_remove_optional_arr_field = is_optional_arr_field and data.get("remove") is True
-    if key in ["injecting_client_list", "searching_client_list"]:
+    is_release_group_override = _is_release_group_override_path(path)
+    if is_release_group_override:
+        if not isinstance(_get_nested_value(example_config, path[:-1]), Mapping):
+            return jsonify({"success": False, "error": "Unknown release group override scope"}), 400
+        example_value = {}
+    elif key in ["injecting_client_list", "searching_client_list"]:
         example_value = []  # Default to empty list
     elif is_optional_arr_field:
         example_value = ""
@@ -4853,6 +4912,11 @@ def config_update():
         return jsonify({"success": False, "error": "Path not found in example config"}), 400
 
     coerced_value = _coerce_config_value(raw_value, example_value)
+    if is_release_group_override:
+        try:
+            _validate_release_group_overrides(coerced_value)
+        except ValueError as error:
+            return jsonify({"success": False, "error": str(error)}), 400
     new_value_literal = _python_literal(coerced_value)
 
     # Keep optional WebUI-managed values out of config.py when they are unused.

--- a/web_ui/static/js/config_app.js
+++ b/web_ui/static/js/config_app.js
@@ -924,6 +924,7 @@ const isSensitiveKeyForPath = (key, pathParts) =>
 const isReadOnlyKeyForPath = (key, pathParts) =>
   pathParts.includes("TORRENT_CLIENTS") && key === "torrent_client";
 const DISPLAY_LABEL_OVERRIDES = {
+  tag_overrides: "Release Group Overrides",
   multiScreens: "Multiple Screenshots",
   charLimit: "Character Limit",
   fileLimit: "File Limit",
@@ -2030,8 +2031,7 @@ function ConfigLeafEditor({
     Array.isArray(item.help) &&
     item.help.some((line) => /SQLite Mode/i.test(String(line)));
   const helpBelongsToTorrentClientOrganizationNote =
-    pathParts.includes("TORRENT_CLIENTS") &&
-    item.key === "use_tracker_as_tag";
+    pathParts.includes("TORRENT_CLIENTS") && item.key === "use_tracker_as_tag";
   const helpBelongsToTorrentClientCrossSeedNote =
     pathParts.includes("TORRENT_CLIENTS") &&
     ["qbit_cross_tag", "qbit_cross_cat", "content_layout"].includes(item.key);
@@ -3423,23 +3423,143 @@ function MetadataCacheServices({
   );
 }
 
+/** Keep disabled text across settings pages until the editing session is reset. */
+const ReleaseGroupDraftContext = React.createContext(null);
+
+/** Read stored or staged overrides without substituting example groups. */
+const parseReleaseGroupOverrides = (value) => {
+  try {
+    const groups =
+      typeof value === "string" ? JSON.parse(value) : (value ?? {});
+    return groups &&
+      typeof groups === "object" &&
+      !Array.isArray(groups) &&
+      Object.values(groups).every(
+        (fields) =>
+          fields && typeof fields === "object" && !Array.isArray(fields),
+      )
+      ? groups
+      : null;
+  } catch {
+    return null;
+  }
+};
+
+/** Compare mappings consistently when edits restore the original configuration. */
+const serializeReleaseGroupOverrides = (groups) =>
+  JSON.stringify(
+    Object.fromEntries(
+      Object.keys(groups)
+        .sort()
+        .map((name) => [
+          name,
+          Object.fromEntries(
+            Object.keys(groups[name])
+              .sort()
+              .map((key) => [key, groups[name][key]]),
+          ),
+        ]),
+    ),
+  );
+
 function ReleaseGroupOverrides({
   item,
   pathParts,
-  depth,
-  isDarkMode,
-  allImageHosts,
-  usedImageHosts,
-  expandedGroups,
-  toggleGroup,
-  torrentClients,
+  pendingValue,
   onValueChange,
 }) {
-  const groupKey = [...pathParts, item.key].join("/");
-  const isOpen = expandedGroups.has(groupKey);
-  const releaseGroups = item.children || [];
-  const helpText = (item.help || []).join(" ");
-  const groupLabel = releaseGroups.length === 1 ? "group" : "groups";
+  const draftCache = React.useContext(ReleaseGroupDraftContext);
+  const [isOpen, setIsOpen] = useState(false);
+  const [openNames, setOpenNames] = useState(new Set());
+  const [newName, setNewName] = useState("");
+  const [renameTarget, setRenameTarget] = useState(null);
+  const [renameName, setRenameName] = useState("");
+  const [error, setError] = useState("");
+  const originalGroups = parseReleaseGroupOverrides(item.value);
+  const groups = parseReleaseGroupOverrides(pendingValue ?? item.value);
+  const fields = item.override_fields || [];
+  const path = [...pathParts, item.key];
+  const pathKey = path.join("/");
+  const fieldPrefix = path.join("--");
+  const groupNames = Object.keys(groups || {});
+
+  const setFieldEnabled = (name, key, enabled) => {
+    const nextValues = { ...groups[name] };
+    if (enabled) {
+      nextValues[key] =
+        draftCache.current.get(pathKey)?.get(name)?.get(key) ?? "";
+    } else {
+      // Remember disabled text only for this editing session, outside the saved map.
+      const scopeDrafts = draftCache.current.get(pathKey) || new Map();
+      const groupDrafts = scopeDrafts.get(name) || new Map();
+      groupDrafts.set(key, nextValues[key]);
+      scopeDrafts.set(name, groupDrafts);
+      draftCache.current.set(pathKey, scopeDrafts);
+      delete nextValues[key];
+    }
+    updateGroups({ ...groups, [name]: nextValues });
+  };
+
+  const updateGroups = (nextGroups) =>
+    onValueChange(path, serializeReleaseGroupOverrides(nextGroups), {
+      originalValue: serializeReleaseGroupOverrides(originalGroups),
+      isSensitive: false,
+      isRedacted: false,
+      readOnly: false,
+    });
+
+  const validateName = (name, currentName = null) => {
+    const normalize = (value) => value.trim().replace(/^-+/, "").toLowerCase();
+    if (!normalize(name) || [...name].some((char) => char.charCodeAt(0) < 32)) {
+      return "Enter a release group name.";
+    }
+    if (
+      groupNames.some(
+        (existing) =>
+          existing !== currentName && normalize(existing) === normalize(name),
+      )
+    ) {
+      return "That release group already exists. Case and leading hyphens are ignored.";
+    }
+    return "";
+  };
+
+  const addGroup = () => {
+    setRenameTarget(null);
+    const name = newName.trim();
+    const message = validateName(name);
+    setError(message);
+    if (message) return;
+    updateGroups({ ...groups, [name]: {} });
+    setOpenNames((current) => new Set([...current, name]));
+    setNewName("");
+  };
+
+  const renameGroup = () => {
+    const name = renameName.trim();
+    const message = validateName(name, renameTarget);
+    setError(message);
+    if (message) return;
+    const scopeDrafts = draftCache.current.get(pathKey);
+    if (scopeDrafts?.has(renameTarget)) {
+      const groupDrafts = scopeDrafts.get(renameTarget);
+      scopeDrafts.delete(renameTarget);
+      scopeDrafts.set(name, groupDrafts);
+    }
+    updateGroups(
+      Object.fromEntries(
+        Object.entries(groups).map(([key, values]) => [
+          key === renameTarget ? name : key,
+          values,
+        ]),
+      ),
+    );
+    setOpenNames(
+      (current) =>
+        new Set([...current].map((key) => (key === renameTarget ? name : key))),
+    );
+    setRenameTarget(null);
+  };
 
   return (
     <section
@@ -3448,7 +3568,7 @@ function ReleaseGroupOverrides({
     >
       <button
         type="button"
-        onClick={() => toggleGroup(groupKey)}
+        onClick={() => setIsOpen((open) => !open)}
         className="ua-config-accordion-trigger flex w-full items-center justify-between gap-4 px-4 py-3 text-left"
         aria-expanded={isOpen}
       >
@@ -3456,117 +3576,286 @@ function ReleaseGroupOverrides({
           <span className="block text-sm font-semibold">
             Release Group Overrides
           </span>
-          {helpText && (
-            <span className="ua-config-service-description mt-1 block text-xs font-normal">
-              {helpText}
-            </span>
-          )}
+          <span className="ua-config-service-description mt-1 block text-xs font-normal">
+            {pathParts[0] === "TRACKERS"
+              ? "Override description text for release groups on this tracker."
+              : "Override description text for specific release groups."}
+          </span>
         </span>
-        <span className="flex shrink-0 items-center gap-3">
-          <span className="ua-config-service-action hidden text-xs font-medium sm:inline">
-            {isOpen
-              ? `Hide ${groupLabel}`
-              : `Show ${releaseGroups.length} ${groupLabel}`}
-          </span>
-          <span
-            className="ua-config-accordion-chevron transition-transform"
-            style={{
-              transform: isOpen ? "rotate(90deg)" : "rotate(0deg)",
-            }}
-            aria-hidden="true"
-          >
-            <svg
-              width="18"
-              height="18"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="m9 18 6-6-6-6"></path>
-            </svg>
-          </span>
+        <span className="ua-config-service-action shrink-0 text-xs font-medium">
+          {isOpen
+            ? "Hide"
+            : `Show ${groupNames.length} ${groupNames.length === 1 ? "group" : "groups"}`}
         </span>
       </button>
-
       {isOpen && (
-        <div className="ua-config-accordion-panel space-y-3 border-t p-4">
-          {releaseGroups.map((releaseGroup) => {
-            const releaseGroupKey = [
-              ...pathParts,
-              item.key,
-              releaseGroup.key,
-            ].join("/");
-            const isReleaseGroupOpen = expandedGroups.has(releaseGroupKey);
-            const fields = releaseGroup.children || [];
-            return (
-              <div
-                key={releaseGroupKey}
-                className="ua-config-accordion overflow-hidden rounded-lg border"
-                data-open={isReleaseGroupOpen ? "true" : "false"}
-              >
-                <button
-                  type="button"
-                  onClick={() => toggleGroup(releaseGroupKey)}
-                  className="ua-config-accordion-trigger flex w-full items-center justify-between gap-3 px-4 py-3 text-left"
-                  aria-expanded={isReleaseGroupOpen}
-                >
-                  <span className="min-w-0">
-                    <span className="block truncate text-sm font-semibold">
-                      {releaseGroup.key}
-                    </span>
-                    <span className="ua-config-service-description mt-1 block text-xs font-normal">
-                      {fields.length} description overrides
-                    </span>
-                  </span>
-                  <span
-                    className="ua-config-accordion-chevron shrink-0 transition-transform"
-                    style={{
-                      transform: isReleaseGroupOpen
-                        ? "rotate(90deg)"
-                        : "rotate(0deg)",
-                    }}
-                    aria-hidden="true"
+        <div className="ua-config-accordion-panel space-y-4 border-t p-4">
+          {!originalGroups || !groups ? (
+            <p role="alert" className="text-sm text-red-500">
+              The existing release group configuration is not a dictionary of
+              groups. Correct it in config.py before editing here.
+            </p>
+          ) : (
+            <>
+              <p className="ua-config-service-description text-xs leading-relaxed">
+                For matching release groups, these overrides take priority over
+                ordinary tracker and global settings. Tracker-specific group
+                overrides take priority over global group overrides.
+              </p>
+              <p className="ua-config-service-description text-xs leading-relaxed">
+                Names are matched without case or leading hyphens. Tick a field
+                to enable its override. Disabled fields inherit their usual
+                text; an enabled field left empty uses blank text.
+              </p>
+              {groupNames.length === 0 && (
+                <p className="ua-config-service-description text-sm">
+                  No release group overrides configured.
+                </p>
+              )}
+              {groupNames.map((name) => {
+                const values = groups[name];
+                const isGroupOpen = openNames.has(name);
+                const activeCount = Object.values(values).filter(
+                  (value) => value !== null,
+                ).length;
+                const additionalKeys = Object.keys(values).filter(
+                  (key) => !fields.some((field) => field.key === key),
+                );
+                return (
+                  <div
+                    key={name}
+                    className="ua-config-accordion overflow-hidden rounded-lg border"
+                    data-open={isGroupOpen ? "true" : "false"}
                   >
-                    <svg
-                      width="18"
-                      height="18"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    >
-                      <path d="m9 18 6-6-6-6"></path>
-                    </svg>
-                  </span>
-                </button>
-                {isReleaseGroupOpen && (
-                  <div className="ua-config-accordion-panel border-t p-4">
-                    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
-                      {fields.map((field) => (
-                        <ConfigLeaf
-                          key={`${releaseGroupKey}/${field.key}`}
-                          item={field}
-                          pathParts={[...pathParts, item.key, releaseGroup.key]}
-                          depth={depth + 2}
-                          isDarkMode={isDarkMode}
-                          fullWidth={true}
-                          allImageHosts={allImageHosts}
-                          usedImageHosts={usedImageHosts}
-                          torrentClients={torrentClients}
-                          onValueChange={onValueChange}
-                        />
-                      ))}
+                    <div className="ua-config-accordion-trigger flex flex-wrap items-center gap-2 px-3 py-2">
+                      <button
+                        type="button"
+                        aria-expanded={isGroupOpen}
+                        aria-label={`Edit overrides for ${name}`}
+                        className="flex min-w-0 flex-1 items-center gap-2 py-1 text-left"
+                        onClick={() =>
+                          setOpenNames((current) => {
+                            const next = new Set(current);
+                            if (next.has(name)) next.delete(name);
+                            else next.add(name);
+                            return next;
+                          })
+                        }
+                      >
+                        <svg
+                          className="ua-config-accordion-chevron shrink-0 transition-transform"
+                          style={{
+                            transform: isGroupOpen
+                              ? "rotate(90deg)"
+                              : "rotate(0deg)",
+                          }}
+                          width="18"
+                          height="18"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          aria-hidden="true"
+                        >
+                          <path d="m9 18 6-6-6-6" />
+                        </svg>
+                        <span className="min-w-0">
+                          <span className="block break-words text-sm font-semibold">
+                            {name}
+                          </span>
+                          <span className="ua-config-service-description block text-xs">
+                            {activeCount}{" "}
+                            {activeCount === 1 ? "override" : "overrides"}
+                          </span>
+                        </span>
+                      </button>
+                      <button
+                        type="button"
+                        aria-label={`Rename group ${name}`}
+                        className="ua-config-service-action rounded-md border px-2.5 py-1.5 text-xs font-semibold"
+                        onClick={() => {
+                          setRenameTarget(name);
+                          setRenameName(name);
+                          setError("");
+                        }}
+                      >
+                        Rename
+                      </button>
+                      <button
+                        type="button"
+                        aria-label={`Remove group ${name}`}
+                        className="rounded-md border border-red-500/40 px-2.5 py-1.5 text-xs font-semibold text-red-500 hover:bg-red-500/10"
+                        onClick={() => {
+                          draftCache.current.get(pathKey)?.delete(name);
+                          updateGroups(
+                            Object.fromEntries(
+                              Object.entries(groups).filter(
+                                ([key]) => key !== name,
+                              ),
+                            ),
+                          );
+                          if (renameTarget === name) setRenameTarget(null);
+                          setError("");
+                        }}
+                      >
+                        Remove
+                      </button>
                     </div>
+                    {renameTarget === name && (
+                      <form
+                        className="flex flex-wrap items-end gap-2 border-t p-3"
+                        onSubmit={(event) => {
+                          event.preventDefault();
+                          renameGroup();
+                        }}
+                      >
+                        <label className="w-full text-xs font-medium sm:min-w-0 sm:flex-1">
+                          New name for {name}
+                          <input
+                            value={renameName}
+                            onChange={(event) =>
+                              setRenameName(event.target.value)
+                            }
+                            className="ua-config-input mt-1 w-full rounded-md border px-3 py-2 text-sm"
+                          />
+                        </label>
+                        <button
+                          type="submit"
+                          className="ua-config-service-action rounded-md border px-3 py-2 text-xs font-semibold"
+                        >
+                          Apply name
+                        </button>
+                        <button
+                          type="button"
+                          className="ua-config-service-action rounded-md border px-3 py-2 text-xs"
+                          onClick={() => {
+                            setRenameTarget(null);
+                            setError("");
+                          }}
+                        >
+                          Cancel
+                        </button>
+                        {error && (
+                          <p
+                            role="alert"
+                            className="w-full text-sm text-red-500"
+                          >
+                            {error}
+                          </p>
+                        )}
+                      </form>
+                    )}
+                    {isGroupOpen && (
+                      <div className="ua-config-accordion-panel space-y-3 border-t p-4">
+                        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
+                          {fields.map((field) => {
+                            const label = formatConfigFieldLabel(
+                              field.key,
+                              path,
+                            );
+                            const enabled =
+                              Object.hasOwn(values, field.key) &&
+                              values[field.key] !== null;
+                            const textId = `${fieldPrefix}--${encodeURIComponent(name)}--${field.key}`;
+                            return (
+                              <div
+                                key={field.key}
+                                className="flex min-w-0 flex-col gap-2"
+                              >
+                                <div className="flex items-center gap-2">
+                                  <label className="flex min-w-0 cursor-pointer items-center gap-2 text-sm font-medium">
+                                    <input
+                                      type="checkbox"
+                                      checked={enabled}
+                                      aria-label={`Override ${label} for ${name}`}
+                                      className="ua-theme-checkbox h-4 w-4 shrink-0"
+                                      onChange={(event) =>
+                                        setFieldEnabled(
+                                          name,
+                                          field.key,
+                                          event.target.checked,
+                                        )
+                                      }
+                                    />
+                                    <span>{label}</span>
+                                  </label>
+                                  {field.help?.length > 0 && (
+                                    <Tooltip content={field.help.join("\n")}>
+                                      <InfoIcon className="ua-config-service-description h-4 w-4 shrink-0" />
+                                    </Tooltip>
+                                  )}
+                                </div>
+                                <input
+                                  id={textId}
+                                  type="text"
+                                  aria-label={`${label} for ${name}`}
+                                  disabled={!enabled}
+                                  value={
+                                    enabled
+                                      ? values[field.key]
+                                      : (draftCache.current
+                                          .get(pathKey)
+                                          ?.get(name)
+                                          ?.get(field.key) ?? "")
+                                  }
+                                  className="ua-config-input mt-auto w-full rounded-md border px-3 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+                                  onChange={(event) =>
+                                    updateGroups({
+                                      ...groups,
+                                      [name]: {
+                                        ...values,
+                                        [field.key]: event.target.value,
+                                      },
+                                    })
+                                  }
+                                />
+                              </div>
+                            );
+                          })}
+                        </div>
+                        {additionalKeys.length > 0 && (
+                          <p className="ua-config-service-description text-xs">
+                            Additional existing fields are preserved:{" "}
+                            {additionalKeys.join(", ")}.
+                          </p>
+                        )}
+                      </div>
+                    )}
                   </div>
-                )}
-              </div>
-            );
-          })}
+                );
+              })}
+              <form
+                className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-end"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  addGroup();
+                }}
+              >
+                <label className="min-w-0 flex-1 text-sm font-medium">
+                  Release group name
+                  <input
+                    value={newName}
+                    onChange={(event) => setNewName(event.target.value)}
+                    placeholder="e.g. MyGroup"
+                    className="ua-config-input mt-1 w-full rounded-md border px-3 py-2"
+                  />
+                </label>
+                <button
+                  type="submit"
+                  className="ua-config-service-action rounded-md border px-3 py-2 text-sm font-semibold"
+                >
+                  Add group
+                </button>
+              </form>
+              {error && renameTarget === null && (
+                <p role="alert" className="text-sm text-red-500">
+                  {error}
+                </p>
+              )}
+            </>
+          )}
         </div>
       )}
     </section>
@@ -4305,8 +4594,8 @@ function TorrentClientSettings({
                 <p>
                   <span className="font-semibold">Content Layout:</span>{" "}
                   Controls qBittorrent&apos;s content layout for every torrent
-                  added through this client, including regular uploads. Leave
-                  it as Original unless your save-path structure requires a
+                  added through this client, including regular uploads. Leave it
+                  as Original unless your save-path structure requires a
                   different layout.
                 </p>
               </div>
@@ -4378,9 +4667,15 @@ function TrackerSettings({
   torrentClients,
   overridesEnabled = false,
   onToggleOverrides = () => {},
+  pendingChanges,
   onValueChange,
 }) {
-  const editableItems = items || [];
+  const releaseGroupOverrides = (items || []).find(
+    (item) => item.key === "tag_overrides",
+  );
+  const editableItems = (items || []).filter(
+    (item) => item.key !== "tag_overrides",
+  );
   const itemByKey = new Map(editableItems.map((item) => [item.key, item]));
   const overrideItems = editableItems.filter((item) =>
     trackerDefaultOverrideKeys.has(item.key),
@@ -4515,6 +4810,18 @@ function TrackerSettings({
           </div>
         </section>
       ))}
+      {releaseGroupOverrides && (
+        <ReleaseGroupOverrides
+          item={releaseGroupOverrides}
+          pathParts={pathParts}
+          pendingValue={
+            pendingChanges?.get(
+              [...pathParts, releaseGroupOverrides.key].join("/"),
+            )?.value
+          }
+          onValueChange={onValueChange}
+        />
+      )}
       {overrideItems.length > 0 && (
         <section className="ua-config-client-settings-group overflow-hidden rounded-lg border">
           <div className="ua-config-section-heading flex flex-col gap-3 border-b px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
@@ -4525,6 +4832,10 @@ function TrackerSettings({
               <p className="ua-config-service-description mt-1 text-xs">
                 Enable only when this tracker should use different description,
                 screenshot, or injection settings from DEFAULT.
+              </p>
+              <p className="ua-config-service-description mt-1 text-xs">
+                Matching release group overrides still take priority for
+                description text.
               </p>
             </div>
             <div className="flex shrink-0 items-center gap-3">
@@ -5640,6 +5951,7 @@ function TrackerManager({
                     allImageHosts={allImageHosts}
                     usedImageHosts={usedImageHosts}
                     torrentClients={torrentClients}
+                    pendingChanges={pendingChanges}
                     overridesEnabled={overridesEnabled}
                     onToggleOverrides={(enabled, overrideItems) =>
                       onToggleTrackerOverrides(name, enabled, overrideItems)
@@ -6672,13 +6984,11 @@ function ItemList({
                 <ReleaseGroupOverrides
                   item={releaseGroupOverrides}
                   pathParts={pathParts}
-                  depth={depth}
-                  isDarkMode={isDarkMode}
-                  allImageHosts={allImageHosts}
-                  usedImageHosts={usedImageHosts}
-                  expandedGroups={expandedGroups}
-                  toggleGroup={toggleGroup}
-                  torrentClients={torrentClients}
+                  pendingValue={
+                    pendingChanges?.get(
+                      [...pathParts, releaseGroupOverrides.key].join("/"),
+                    )?.value
+                  }
                   onValueChange={onValueChange}
                 />
               )}
@@ -8463,6 +8773,16 @@ function ConfigApp() {
   );
   const [expandedGroups, setExpandedGroups] = useState(new Set());
   const [pendingChanges, setPendingChanges] = useState(new Map());
+  const releaseGroupDrafts = useRef(new Map());
+
+  useEffect(() => {
+    const resetDrafts = (event) => {
+      releaseGroupDrafts.current.delete(String(event.detail?.pathKey || ""));
+    };
+    window.addEventListener(CONFIG_FIELD_RESET_EVENT, resetDrafts);
+    return () =>
+      window.removeEventListener(CONFIG_FIELD_RESET_EVENT, resetDrafts);
+  }, []);
   const [pendingTorrentClients, setPendingTorrentClients] = useState(new Map());
   const [pendingRemovedTorrentClients, setPendingRemovedTorrentClients] =
     useState(new Set());
@@ -8802,6 +9122,7 @@ function ConfigApp() {
         throw new Error(data.error || "Failed to load config options");
       }
       const newSections = data.sections || [];
+      releaseGroupDrafts.current.clear();
       const fallbackSection =
         newSections.find((section) => section.section === "DEFAULT") ||
         newSections[0];
@@ -8951,6 +9272,8 @@ function ConfigApp() {
     } else {
       setPendingChanges(new Map());
     }
+
+    releaseGroupDrafts.current.clear();
 
     fieldPathsToReset.forEach((pathKey) => {
       window.dispatchEvent(
@@ -10240,6 +10563,41 @@ function ConfigApp() {
       const path = Array.isArray(update.path) ? update.path : [];
       const key = String(path[path.length - 1] || "");
       const parentPath = path.slice(0, -1);
+      if (
+        key === "tag_overrides" &&
+        ((path[0] === "DEFAULT" && path.length === 2) ||
+          (path[0] === "TRACKERS" && path.length === 3))
+      ) {
+        const originalGroups = parseReleaseGroupOverrides(update.originalValue);
+        const nextGroups = parseReleaseGroupOverrides(update.value);
+        if (!originalGroups || !nextGroups)
+          return "Release group overrides changed";
+        const added = Object.keys(nextGroups).filter(
+          (name) => !Object.prototype.hasOwnProperty.call(originalGroups, name),
+        );
+        const removed = Object.keys(originalGroups).filter(
+          (name) => !Object.prototype.hasOwnProperty.call(nextGroups, name),
+        );
+        const updated = Object.keys(nextGroups).filter(
+          (name) =>
+            Object.prototype.hasOwnProperty.call(originalGroups, name) &&
+            serializeReleaseGroupOverrides({ [name]: originalGroups[name] }) !==
+              serializeReleaseGroupOverrides({ [name]: nextGroups[name] }),
+        );
+        return (
+          [
+            ["Added", added],
+            ["Removed", removed],
+            ["Updated", updated],
+          ]
+            .filter(([, names]) => names.length)
+            .map(
+              ([action, names]) =>
+                `${action} ${names.length === 1 ? "group" : "groups"} ${names.join(", ")}`,
+            )
+            .join("; ") || "Release group overrides changed"
+        );
+      }
       if (path[0] === "TRACKERS" && key === "default_trackers") {
         const normalizeTrackers = (value) =>
           String(value || "")
@@ -10509,6 +10867,10 @@ function ConfigApp() {
       const detailParts = [
         `${settingCount} setting${settingCount === 1 ? "" : "s"} changed`,
       ];
+      const groupUpdate = pathKeys
+        .map((pathKey) => pendingChanges.get(pathKey))
+        .find((update) => update.path[2] === "tag_overrides");
+      if (groupUpdate) detailParts.push(describeValue(groupUpdate));
       if (overrideChange) {
         detailParts.push(
           `DEFAULT overrides ${overrideChange[1] ? "enabled" : "removed"}`,
@@ -10704,7 +11066,7 @@ function ConfigApp() {
     }
   };
 
-  return (
+  const configPage = (
     <div
       className={
         "ua-config-page min-h-screen " +
@@ -11081,6 +11443,12 @@ function ConfigApp() {
         </div>
       </div>
     </div>
+  );
+
+  return (
+    <ReleaseGroupDraftContext.Provider value={releaseGroupDrafts}>
+      {configPage}
+    </ReleaseGroupDraftContext.Provider>
   );
 }
 


### PR DESCRIPTION
Add Release Group Overrides editors to Description Formatting and tracker settings, supporting group creation, renaming, editing and removal.

- Display single-line fields in a responsive grid of up to four columns, with checkboxes beside clickable field titles.
- Keep fields visible and preserve draft text when disabling and re-enabling overrides.
- Integrate group changes with Pending Changes, save and discard.
- Validate group names and values while preserving existing additional fields.
- Explain precedence between release group, tracker and global settings.
- Keep MyAwesomeGroupTag as commented documentation so fresh configurations start without an active example group.

Existing description override precedence remains unchanged. Unticked fields inherit the next applicable setting; enabled fields left empty deliberately use blank text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a web UI for managing release-group description overrides at both default and tracker-specific levels.
  - Create, edit, rename, and remove release groups with inline validation and clear pending-change summaries.
  - Override settings now include fixed, supported fields and preserve unrelated configuration values.
  - Tracker-specific override sections are shown even when no settings have been configured.

- **Bug Fixes**
  - Example release groups are no longer enabled automatically when copying the sample configuration.
  - Invalid group names, duplicate entries, unsupported scopes, and malformed values are rejected safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->