### PR TITLE
fix(prompts): restore confirmation sounds in CLI and WebUI

### DIFF
--- a/data/example_config.py
+++ b/data/example_config.py
@@ -10,7 +10,8 @@ config: dict[str, Any] = {
         "verbose_notification": False,
         # Number of hours to reuse a successful update check. Set to 0 to check every run.
         "update_notification_cache_hours": 4,
-        # Set to True to play a bell sound when prompting for confirmation.
+        # Set to True to play a bell sound before release confirmation (CLI and WebUI).
+        # WebUI sound plays in the browser; allow site audio and keep the tab unmuted.
         "sfx_on_prompt": True,
         # Set to True to apply argument overrides from data/templates/user-args.json.
         "user_overrides": False,

--- a/docs/example-config.md
+++ b/docs/example-config.md
@@ -226,7 +226,7 @@ Implementation notes:
 
 ### UX / safety toggles
 
-- `sfx_on_prompt` (bool): Play a bell sound effect when asking for confirmation.
+- `sfx_on_prompt` (bool, default `True`): Play a bell before release confirmation. CLI runs use the terminal bell; WebUI runs play the sound in the browser after clicking Execute. Allow site audio and keep the tab unmuted. Fully unattended runs skip the sound along with confirmation.
 - `embed_links` (bool): Set true to embed terminal links using terminal hyperlinks (OSC 8). Set false to display the full raw URLs. `embed_dupe_links` remains supported temporarily as a deprecated alias.
 - `tracker_pass_checks` (str): Minimum number of trackers that must pass checks to continue upload.
 - `use_largest_playlist` (bool): Always use the largest Blu-ray playlist without prompting.

--- a/src/prompt_sound.py
+++ b/src/prompt_sound.py
@@ -1,0 +1,18 @@
+"""Deliver confirmation sounds without passing control characters through logging."""
+
+import os
+import sys
+
+PROMPT_SOUND_STDOUT_MARKER = "UA_PROMPT_SOUND"
+
+
+def play_prompt_sound() -> None:
+    """Ring the CLI bell, or ask the WebUI client to play its notification sound."""
+    if os.environ.get("UA_WEBUI_PROMPT_SOUND_STDOUT") == "1":
+        # A printable record survives Windows ConPTY and ANSI-to-HTML conversion.
+        # Leading/trailing newlines keep it separate from unterminated output.
+        output = f"\n{PROMPT_SOUND_STDOUT_MARKER}\n"
+    else:
+        output = "\a"
+    sys.stdout.write(output)
+    sys.stdout.flush()

--- a/src/uphelper.py
+++ b/src/uphelper.py
@@ -21,6 +21,7 @@ from src.cogs.redaction import Redaction
 from src.config_helpers import format_terminal_link
 from src.console import logger, prompt_in_thread
 from src.meta import Meta
+from src.prompt_sound import play_prompt_sound
 from src.trackersetup import tracker_class_map
 
 _dupe_prompt_lock_held = contextvars.ContextVar("dupe_prompt_lock_held", default=False)
@@ -727,9 +728,8 @@ class UploadHelper:
             if meta.debug is True:
                 logger.info("[bold yellow]Unattended mode is enabled, skipping confirmation.[/bold yellow]")
             return True
-        ring_the_bell = "\a" if bool(self.default_config.get("sfx_on_prompt", True)) else ""
-        if ring_the_bell:
-            logger.info(ring_the_bell)
+        if bool(self.default_config.get("sfx_on_prompt", True)):
+            play_prompt_sound()
 
         if meta.is_disc:
             meta.keep_folder = False

--- a/tests/test_prompt_sound.py
+++ b/tests/test_prompt_sound.py
@@ -1,0 +1,110 @@
+import io
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import web_ui.server as server
+from src.meta import Meta
+from src.prompt_sound import PROMPT_SOUND_STDOUT_MARKER, play_prompt_sound
+from src.uphelper import UploadHelper
+
+
+def test_browser_prompt_sound() -> None:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for browser sound tests")
+    subprocess.run([node, "--test", str(Path(__file__).with_name("webui_prompt_sound.test.cjs"))], check=True)
+
+
+@pytest.mark.parametrize("webui", [False, True])
+def test_sound_is_written_directly_and_flushed(monkeypatch, webui) -> None:
+    class Output(io.StringIO):
+        flushed = False
+
+        def flush(self):
+            self.flushed = True
+
+    output = Output()
+    monkeypatch.setenv("UA_WEBUI_PROMPT_SOUND_STDOUT", "1" if webui else "0")
+    monkeypatch.setattr(sys, "stdout", output)
+
+    play_prompt_sound()
+
+    assert output.getvalue() == (f"\n{PROMPT_SOUND_STDOUT_MARKER}\n" if webui else "\a")
+    assert output.flushed
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("webui", [False, True])
+@pytest.mark.parametrize(
+    ("settings", "unattended", "unattended_confirm", "expected_sound"),
+    [
+        ({}, False, False, True),
+        ({"sfx_on_prompt": True}, False, False, True),
+        ({"sfx_on_prompt": False}, False, False, False),
+        ({}, True, False, False),
+        ({}, True, True, True),
+    ],
+)
+async def test_confirmation_honors_sound_setting_and_unattended_mode(
+    monkeypatch, capsys, settings, unattended, unattended_confirm, expected_sound, webui
+) -> None:
+    monkeypatch.setenv("UA_WEBUI_PROMPT_SOUND_STDOUT", "1" if webui else "0")
+    monkeypatch.setattr("src.uphelper.logger.info", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("src.uphelper.cli_ui.ask_yes_no", lambda *_args, **_kwargs: False)
+    helper = UploadHelper({"DEFAULT": settings})
+
+    await helper.get_confirmation(Meta(category="MOVIE", unattended=unattended, unattended_confirm=unattended_confirm))
+
+    expected = f"\n{PROMPT_SOUND_STDOUT_MARKER}\n" if webui else "\a"
+    assert capsys.readouterr().out == (expected if expected_sound else "")
+
+
+def test_webui_child_uses_printable_sound_record() -> None:
+    result = subprocess.run(
+        [sys.executable, "-u", "-c", "from src.prompt_sound import play_prompt_sound; play_prompt_sound()"],
+        text=True,
+        capture_output=True,
+        env=server._webui_subprocess_env(),
+        check=True,
+    )
+
+    assert result.stdout == f"\n{PROMPT_SOUND_STDOUT_MARKER}\n"
+    assert server._subprocess_prompt_type(result.stdout) is None
+
+
+@pytest.mark.parametrize("newline", ["\n", "\r\n"])
+def test_execute_stream_delivers_sound_once_without_rendering_marker(tmp_path, monkeypatch, newline) -> None:
+    class Process:
+        pid = 1
+        stdin = io.StringIO()
+        stdout = io.StringIO(newline.join(["Before", PROMPT_SOUND_STDOUT_MARKER, "After", ""]))
+        stderr = io.StringIO()
+
+        def poll(self):
+            return 0 if self.stdout.tell() == len(self.stdout.getvalue()) else None
+
+        def wait(self):
+            return 0
+
+    process = Process()
+    monkeypatch.setattr(server, "_is_authenticated", lambda: True)
+    monkeypatch.setattr(server, "_verify_csrf_header", lambda: True)
+    monkeypatch.setattr(server, "_verify_same_origin", lambda: True)
+    monkeypatch.setattr(server, "_resolve_user_path", lambda *_args, **_kwargs: str(tmp_path))
+    monkeypatch.setattr(server, "_assert_safe_resolved_path", lambda _: None)
+    monkeypatch.setattr(server, "_spawn_webui_upload_process", lambda *_args: (process, "subprocess"))
+    monkeypatch.setattr(server, "_close_webui_process_io", lambda _: None)
+    response = server.app.test_client().post("/api/execute", json={"path": str(tmp_path), "session_id": "sound-test"})
+    events = [json.loads(line[6:]) for line in response.get_data(as_text=True).splitlines() if line.startswith("data: ")]
+
+    assert response.status_code == 200
+    assert [event for event in events if event["type"] == "prompt_sound"] == [{"type": "prompt_sound"}]
+    html = "".join(event["data"] for event in events if event["type"] == "html")
+    assert "Before" in html and "After" in html
+    assert PROMPT_SOUND_STDOUT_MARKER not in html
+    assert events[-1] == {"type": "exit", "code": 0}

--- a/tests/test_webui_conpty.py
+++ b/tests/test_webui_conpty.py
@@ -8,6 +8,7 @@ import pytest
 
 import web_ui.server as server
 from src.console import ansi_to_html
+from src.prompt_sound import PROMPT_SOUND_STDOUT_MARKER
 
 pytestmark = pytest.mark.skipif(sys.platform != "win32", reason="ConPTY is Windows-only")
 
@@ -42,6 +43,30 @@ def test_conpty_preserves_ansi_and_accepts_webui_input() -> None:
         server._write_webui_process_input(process, "yes")
         output += _read_until(process, "ANSWER=True")
         assert "ANSWER=True" in output
+        assert process.wait(timeout=5) == 0
+    finally:
+        if process.poll() is None:
+            server._terminate_process_tree(process)
+        server._close_webui_process_io(process)
+
+
+def test_conpty_preserves_prompt_sound_record() -> None:
+    command = [
+        sys.executable,
+        "-u",
+        "-c",
+        "from src.prompt_sound import play_prompt_sound; print('Before', end='', flush=True); play_prompt_sound(); answer = input('Continue:'); print(f'ANSWER={answer}')",
+    ]
+    process, mode = server._spawn_webui_upload_process(command, server.CODE_DIR, server._webui_subprocess_env())
+
+    try:
+        output = _read_until(process, "Continue:")
+        assert mode == "conpty"
+        assert sum(line.strip() == PROMPT_SOUND_STDOUT_MARKER for line in output.splitlines()) == 1
+        assert "\a" not in output
+        server._write_webui_process_input(process, "yes")
+        output += _read_until(process, "ANSWER=yes")
+        assert "ANSWER=yes" in output
         assert process.wait(timeout=5) == 0
     finally:
         if process.poll() is None:

--- a/tests/webui_prompt_sound.test.cjs
+++ b/tests/webui_prompt_sound.test.cjs
@@ -1,0 +1,146 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+
+const script = fs.readFileSync(
+  path.join(__dirname, "../web_ui/static/js/prompt_sound.js"),
+  "utf8",
+);
+
+function setup({
+  state = "running",
+  unavailable = false,
+  rejectResume = false,
+} = {}) {
+  const contexts = [];
+  class AudioContext {
+    constructor() {
+      this.state = state;
+      this.currentTime = 10;
+      this.destination = {};
+      this.oscillators = [];
+      this.gains = [];
+      this.resumeCalls = 0;
+      contexts.push(this);
+    }
+    async resume() {
+      this.resumeCalls++;
+      if (rejectResume) throw new Error("Audio blocked");
+      this.state = "running";
+    }
+    createOscillator() {
+      const node = {
+        frequency: { setValueAtTime() {} },
+        connect(target) {
+          this.target = target;
+        },
+        disconnect() {
+          this.disconnected = true;
+        },
+        start(time) {
+          this.startTime = time;
+        },
+        stop(time) {
+          this.stopTime = time;
+        },
+      };
+      this.oscillators.push(node);
+      return node;
+    }
+    createGain() {
+      const node = {
+        gain: {
+          setValueAtTime() {},
+          linearRampToValueAtTime() {},
+          exponentialRampToValueAtTime() {},
+        },
+        connect(target) {
+          this.target = target;
+        },
+        disconnect() {
+          this.disconnected = true;
+        },
+      };
+      this.gains.push(node);
+      return node;
+    }
+  }
+  const window = unavailable ? {} : { AudioContext };
+  vm.runInNewContext(script, { window });
+  return { sound: window.uaPromptSound, contexts };
+}
+
+test("loading the page and receiving sound before Execute create no audio", () => {
+  const { sound, contexts } = setup();
+  sound.play();
+  assert.equal(contexts.length, 0);
+});
+
+test("Execute silently unlocks audio and reuses the context", () => {
+  const { sound, contexts } = setup({ state: "suspended" });
+  sound.unlock();
+  sound.unlock();
+  assert.equal(contexts.length, 1);
+  assert.equal(contexts[0].resumeCalls, 1);
+  assert.equal(contexts[0].oscillators.length, 0);
+});
+
+test("each sound event plays a short tone and disconnects finished nodes", () => {
+  const { sound, contexts } = setup();
+  sound.unlock();
+  sound.play();
+  const context = contexts[0];
+  const oscillator = context.oscillators[0];
+  const gain = context.gains[0];
+  assert.equal(context.oscillators.length, 1);
+  assert.equal(oscillator.startTime, 10);
+  assert.equal(oscillator.stopTime, 10.6);
+  assert.equal(oscillator.target, gain);
+  assert.equal(gain.target, context.destination);
+  oscillator.onended();
+  assert.equal(oscillator.disconnected, true);
+  assert.equal(gain.disconnected, true);
+  sound.play();
+  assert.equal(context.oscillators.length, 2);
+});
+
+test("unsupported audio does not interrupt execution", () => {
+  const { sound } = setup({ unavailable: true });
+  assert.doesNotThrow(() => {
+    sound.unlock();
+    sound.play();
+  });
+});
+
+test("blocked audio is caught and never queues stale prompt sounds", async () => {
+  const { sound, contexts } = setup({ state: "suspended", rejectResume: true });
+  sound.unlock();
+  sound.play();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(contexts[0].oscillators.length, 0);
+  contexts[0].state = "running";
+  assert.equal(contexts[0].oscillators.length, 0);
+});
+
+test("a closed context can be recreated on the next Execute click", () => {
+  const { sound, contexts } = setup();
+  sound.unlock();
+  contexts[0].state = "closed";
+  sound.play();
+  sound.unlock();
+  sound.play();
+  assert.equal(contexts.length, 2);
+  assert.equal(contexts[0].oscillators.length, 0);
+  assert.equal(contexts[1].oscillators.length, 1);
+});
+
+test("audio device errors cannot interrupt the output stream", () => {
+  const { sound, contexts } = setup();
+  sound.unlock();
+  contexts[0].createOscillator = () => {
+    throw new Error("Device unavailable");
+  };
+  assert.doesNotThrow(() => sound.play());
+});

--- a/web_ui/server.py
+++ b/web_ui/server.py
@@ -34,6 +34,7 @@ import psutil
 
 import web_ui.auth as auth_mod
 from src.webui_progress import PROGRESS_STDOUT_PREFIX
+from src.prompt_sound import PROMPT_SOUND_STDOUT_MARKER
 from src.app_paths import CODE_DIR, DATA_DIR, STATE_DIR
 from src.external_tools import EXTERNAL_TOOL_KEYS, check_external_tools
 from src.meta import Meta
@@ -1632,6 +1633,7 @@ def _webui_subprocess_env() -> dict[str, str]:
     env.pop("NO_COLOR", None)
     env["UA_WEBUI_FORCE_COLOR"] = "1"
     env["UA_WEBUI_PROGRESS_STDOUT"] = "1"
+    env["UA_WEBUI_PROMPT_SOUND_STDOUT"] = "1"
     return env
 
 
@@ -6291,6 +6293,10 @@ def execute_command():
 
                             # Flush on newline or when buffer grows large
                             if _should_flush_subprocess_output(buffers[output_type], char):
+                                if buffers[output_type].strip() == PROMPT_SOUND_STDOUT_MARKER:
+                                    buffers[output_type] = ""
+                                    yield f"data: {json.dumps({'type': 'prompt_sound'})}\n\n"
+                                    continue
                                 if not prompt_type:
                                     _set_process_awaiting_input_if_current(session_id, process_state, False)
                                 chunk = buffers[output_type]

--- a/web_ui/static/js/app.js
+++ b/web_ui/static/js/app.js
@@ -4822,6 +4822,8 @@ function AudionutsUAGUI() {
             }
           } else if (data.type === "progress") {
             applyProgressEvent(data.data || {});
+          } else if (data.type === "prompt_sound") {
+            window.uaPromptSound?.play();
           } else if (data.type === "exit") {
             if (!(localController && localController.signal.aborted)) {
               appendSystemMessage("");
@@ -4881,6 +4883,8 @@ function AudionutsUAGUI() {
   };
 
   const executeCommand = async () => {
+    // Run before any await, including queue creation, to retain user activation.
+    window.uaPromptSound?.unlock();
     if (selectedPaths.length > 1) {
       setIsExecuting(true);
       const rootContainer = richOutputRef.current;

--- a/web_ui/static/js/prompt_sound.js
+++ b/web_ui/static/js/prompt_sound.js
@@ -1,0 +1,47 @@
+// Prepare audio during the Execute click; play only on a server sound event.
+(() => {
+  let audioContext = null;
+
+  const unlock = () => {
+    try {
+      const AudioContext = window.AudioContext || window.webkitAudioContext;
+      if (!AudioContext) return;
+      if (!audioContext || audioContext.state === "closed") {
+        audioContext = new AudioContext();
+      }
+      if (audioContext.state !== "running") {
+        // Never delay an upload while waiting for browser audio permission.
+        audioContext.resume().catch(() => {});
+      }
+    } catch {
+      // Sound is optional; unavailable audio must not prevent execution.
+    }
+  };
+
+  const play = () => {
+    // Do not queue sounds that could play later, after a prompt is answered.
+    if (!audioContext || audioContext.state !== "running") return;
+    try {
+      const oscillator = audioContext.createOscillator();
+      const gain = audioContext.createGain();
+      const start = audioContext.currentTime;
+      oscillator.type = "sine";
+      oscillator.frequency.setValueAtTime(880, start);
+      gain.gain.setValueAtTime(0, start);
+      gain.gain.linearRampToValueAtTime(0.16, start + 0.01);
+      gain.gain.exponentialRampToValueAtTime(0.0001, start + 0.55);
+      oscillator.connect(gain);
+      gain.connect(audioContext.destination);
+      oscillator.onended = () => {
+        oscillator.disconnect();
+        gain.disconnect();
+      };
+      oscillator.start(start);
+      oscillator.stop(start + 0.6);
+    } catch {
+      // A muted or unavailable audio device must not interrupt the stream.
+    }
+  };
+
+  window.uaPromptSound = { unlock, play };
+})();

--- a/web_ui/templates/index.html
+++ b/web_ui/templates/index.html
@@ -170,6 +170,7 @@
       type="text/javascript"
       src="{{ url_for('static', filename='js/shared_utils.js') }}"
     ></script>
+    <script src="{{ url_for('static', filename='js/prompt_sound.js') }}"></script>
     <script
       type="text/babel"
       src="{{ url_for('static', filename='js/app.js') }}"


### PR DESCRIPTION
`SFX on Prompt` was enabled by default but failed to produce a confirmation sound in both CLI and WebUI sessions.

In the CLI, UA passed the terminal bell character through Rich logging, which stripped it before it reached the terminal. The WebUI had no browser audio implementation, so enabling the setting could not produce a sound there either.

This change:

- Emits and flushes the CLI bell directly.
- Sends a dedicated WebUI sound event that plays a short tone in the browser.
- Prepares browser audio when Execute is clicked, without delaying execution.
- Preserves silent behaviour when SFX is disabled or confirmation is skipped in fully unattended mode.
- Updates configuration guidance and adds regression coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added prompt sound notifications before release confirmation in CLI and WebUI workflows.
  * WebUI plays a brief browser tone after selecting Execute; site audio must be allowed and the tab unmuted.
  * Unattended runs continue without confirmation or prompt sound.
* **Documentation**
  * Clarified the default setting and prompt sound behavior across CLI, WebUI, and unattended runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->