### PR TITLE
feat: add Prowlarr credential fallback

### DIFF
--- a/data/example_config.py
+++ b/data/example_config.py
@@ -212,6 +212,12 @@ config: dict[str, Any] = {
         # Set to True to also search PreDB for a matching scene release.
         # PreDB can be inconsistent or time out, but it may find releases absent from SRRDB.
         "check_predb": False,
+        # --- PROWLARR CREDENTIAL FALLBACK ---
+        # Optional Prowlarr base URL and API key. When both are set, Upload
+        # Assistant fills missing supported tracker API keys and cookies in
+        # memory at the start of each run. Local credentials always take precedence.
+        "prowlarr_url": "",
+        "prowlarr_api_key": "",
         # --- IMAGE HOSTING ---
         # Order of image hosts, with the primary host first and backups after it.
         # Available image hosts: dalexni, imgbb, imgbox, lensdump, lostimg, midnightscene, onlyimage, passtheimage, pixhost, ptscreens, seedpool_cdn, sharex, utppm, zipline

--- a/docs/example-config.md
+++ b/docs/example-config.md
@@ -252,6 +252,13 @@ Implementation notes:
 - `radarr_api_key` (str): Radarr API key.
 - `radarr_url_1` … `radarr_url_3` / `radarr_api_key_1` … `radarr_api_key_3` (str): Up to three optional additional Radarr instances.
 
+### Prowlarr Credential Fallback
+
+- `prowlarr_url` (str): Optional Prowlarr base URL. Set this together with `prowlarr_api_key` to retrieve supported tracker credentials at the start of each run.
+- `prowlarr_api_key` (str): Optional Prowlarr API key. Credentials retrieved from Prowlarr remain in memory and only fill missing local values.
+
+The integration supports API-key and raw-cookie fields exposed by enabled Cardigann indexers. Prowlarr masks some native-indexer secrets as `********`; UA ignores those values. Local API keys and cookie files take precedence.
+
 UA queries configured instances in order, starting with the unsuffixed primary instance and then continuing through suffixes `_1`, `_2`, and `_3`. Optional instances are omitted by default and can be added from the WebUI when needed.
 
 ### Torrent creation

--- a/src/cookie_auth.py
+++ b/src/cookie_auth.py
@@ -228,7 +228,7 @@ class CookieValidator:
         self.config = config
         self.common = Common(config)
 
-    async def load_session_cookies(self, meta: Meta, tracker: str) -> http.cookiejar.MozillaCookieJar | None:
+    async def load_session_cookies(self, meta: Meta, tracker: str) -> http.cookiejar.CookieJar | None:
         cookie_file = find_cookie_file(meta.base_dir, tracker, self.config)
         cookie_jar = http.cookiejar.MozillaCookieJar(cookie_file)
 
@@ -239,6 +239,13 @@ class CookieValidator:
             logger.info(f"{tracker}: Please ensure the cookie file is in the correct format (Netscape).")
             return None
         except FileNotFoundError:
+            tracker_config = self.config.get("TRACKERS", {}).get(tracker, {})
+            if isinstance(tracker_config, dict):
+                from src.prowlarr import prowlarr_cookie_jar
+
+                if prowlarr_jar := prowlarr_cookie_jar(tracker_config):
+                    return prowlarr_jar
+
             # Attempt automatic login for ALPHARATIO tracker
             if tracker == "ALPHARATIO":
                 logger.info(f"{tracker}: [yellow]Cookie file not found. Attempting automatic login...[/yellow]")
@@ -263,10 +270,12 @@ class CookieValidator:
 
         return cookie_jar
 
-    async def save_session_cookies(self, tracker: str, cookie_jar: http.cookiejar.MozillaCookieJar | None) -> None:
+    async def save_session_cookies(self, tracker: str, cookie_jar: http.cookiejar.CookieJar | None) -> None:
         """Save updated cookies after a successful validation."""
         if not cookie_jar:
             logger.info(f"{tracker}: Cookie jar not initialized, cannot save cookies.")
+            return
+        if not isinstance(cookie_jar, http.cookiejar.MozillaCookieJar):
             return
 
         try:

--- a/src/prowlarr.py
+++ b/src/prowlarr.py
@@ -1,0 +1,272 @@
+# Upload Assistant © 2025 Audionut & wastaken7 — Licensed under UAPL v1.0
+from __future__ import annotations
+
+import http.cookiejar
+import re
+from dataclasses import dataclass, field
+from http.cookies import CookieError, SimpleCookie
+from typing import Any, cast
+from urllib.parse import urlsplit
+
+import httpx
+
+
+class ProwlarrError(RuntimeError):
+    """A safe, user-facing Prowlarr connection or response error."""
+
+
+@dataclass(frozen=True)
+class ProwlarrCredential:
+    api_key: str = ""
+    cookie: str = ""
+    base_url: str = ""
+
+
+@dataclass(frozen=True)
+class ProwlarrCredentialReport:
+    credentials: dict[str, ProwlarrCredential] = field(default_factory=dict[str, ProwlarrCredential])
+    enabled_indexers: int = 0
+    matched_indexers: int = 0
+    masked_credentials: int = 0
+    unsupported_indexers: int = 0
+    version: str = ""
+
+
+_DEFINITION_ALIASES = {
+    "1PTBAR": "1PTBA",
+    "HDSPACECOOKIE": "HDSPACE",
+    "HHD": "HOMIEHELPDESK",
+    "UPLOADCX": "ULCX",
+    "XINGYUNG": "XINGYUNGEPT",
+}
+_MASKED_VALUE = re.compile(r"\*+")
+
+
+def _api_url(base_url: str, path: str) -> str:
+    normalized = str(base_url or "").strip().rstrip("/")
+    parsed = urlsplit(normalized)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname or parsed.query or parsed.fragment:
+        raise ProwlarrError("Prowlarr URL must be an HTTP or HTTPS base URL")
+    return f"{normalized}{path}"
+
+
+def _usable_secret(value: object) -> str:
+    if not isinstance(value, str):
+        return ""
+    normalized = value.strip()
+    if not normalized or _MASKED_VALUE.fullmatch(normalized) or "\r" in normalized or "\n" in normalized:
+        return ""
+    return normalized
+
+
+def _usable_cookie(value: object, base_url: str) -> str:
+    header = _usable_secret(value)
+    parsed = urlsplit(base_url)
+    if not header or parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return ""
+    cookies = SimpleCookie()
+    try:
+        cookies.load(header)
+    except CookieError:
+        return ""
+    return header if cookies else ""
+
+
+def _definition_tracker(definition: object, supported_trackers: set[str]) -> str | None:
+    if not isinstance(definition, str) or not definition.strip():
+        return None
+    normalized = re.sub(r"[^A-Za-z0-9]", "", re.sub(r"-api$", "", definition.strip(), flags=re.IGNORECASE)).upper()
+    tracker = _DEFINITION_ALIASES.get(normalized, normalized)
+    return tracker if tracker in supported_trackers else None
+
+
+def resolve_prowlarr_credentials(indexers: object, supported_trackers: set[str]) -> ProwlarrCredentialReport:
+    """Resolve supported API-key and cookie credentials from an indexer response."""
+    if not isinstance(indexers, list):
+        raise ProwlarrError("Prowlarr returned an invalid indexer response")
+
+    supported = {str(name).strip().upper() for name in supported_trackers}
+    credentials: dict[str, ProwlarrCredential] = {}
+    enabled_count = 0
+    matched_count = 0
+    masked_count = 0
+    unsupported_count = 0
+
+    for indexer_value in cast(list[object], indexers):
+        indexer = cast(dict[str, object], indexer_value) if isinstance(indexer_value, dict) else None
+        if indexer is None or indexer.get("enable") is not True:
+            continue
+        enabled_count += 1
+        fields_value = indexer.get("fields")
+        if not isinstance(fields_value, list):
+            unsupported_count += 1
+            continue
+
+        field_values: dict[str, object] = {}
+        for field_value in cast(list[object], fields_value):
+            if not isinstance(field_value, dict):
+                continue
+            field_item = cast(dict[str, object], field_value)
+            name = field_item.get("name")
+            if isinstance(name, str):
+                field_values[name] = field_item.get("value")
+        raw_api_key = field_values.get("apikey", field_values.get("apiKey"))
+        raw_cookie = field_values.get("cookie")
+        masked_count += sum(isinstance(value, str) and bool(_MASKED_VALUE.fullmatch(value.strip())) for value in (raw_api_key, raw_cookie))
+        tracker = _definition_tracker(field_values.get("definitionFile"), supported)
+        if tracker is None:
+            unsupported_count += 1
+            continue
+        matched_count += 1
+
+        base_url = str(field_values.get("baseUrl") or "").strip()
+        api_key = _usable_secret(raw_api_key)
+        cookie = _usable_cookie(raw_cookie, base_url)
+        if not api_key and not cookie:
+            continue
+
+        # One Prowlarr definition should map to one UA tracker. If duplicates
+        # exist, retain the first enabled credential deterministically.
+        credentials.setdefault(tracker, ProwlarrCredential(api_key=api_key, cookie=cookie, base_url=base_url))
+
+    return ProwlarrCredentialReport(
+        credentials=credentials,
+        enabled_indexers=enabled_count,
+        matched_indexers=matched_count,
+        masked_credentials=masked_count,
+        unsupported_indexers=unsupported_count,
+    )
+
+
+def fetch_prowlarr_credentials(
+    base_url: str,
+    api_key: str,
+    supported_trackers: set[str],
+    *,
+    include_status: bool = False,
+) -> ProwlarrCredentialReport:
+    """Fetch Prowlarr credentials without logging or persisting secret values."""
+    key = _usable_secret(api_key)
+    if not key:
+        raise ProwlarrError("Prowlarr API key is required")
+
+    try:
+        with httpx.Client(headers={"X-Api-Key": key}, timeout=10.0) as client:
+            response = client.get(_api_url(base_url, "/api/v1/indexer"))
+            response.raise_for_status()
+            report = resolve_prowlarr_credentials(response.json(), supported_trackers)
+            version = ""
+            if include_status:
+                status_response = client.get(_api_url(base_url, "/api/v1/system/status"))
+                status_response.raise_for_status()
+                status_value: object = status_response.json()
+                if isinstance(status_value, dict):
+                    status = cast(dict[str, object], status_value)
+                    version = str(status.get("version") or "").strip()
+            return ProwlarrCredentialReport(
+                credentials=report.credentials,
+                enabled_indexers=report.enabled_indexers,
+                matched_indexers=report.matched_indexers,
+                masked_credentials=report.masked_credentials,
+                unsupported_indexers=report.unsupported_indexers,
+                version=version,
+            )
+    except ProwlarrError:
+        raise
+    except httpx.HTTPStatusError as error:
+        status_code = error.response.status_code
+        if status_code in {401, 403}:
+            raise ProwlarrError("Prowlarr rejected the API key") from error
+        raise ProwlarrError(f"Prowlarr returned HTTP {status_code}") from error
+    except httpx.TimeoutException as error:
+        raise ProwlarrError("Prowlarr connection timed out") from error
+    except httpx.RequestError as error:
+        raise ProwlarrError("Prowlarr could not be reached") from error
+    except ValueError as error:
+        raise ProwlarrError("Prowlarr returned invalid JSON") from error
+
+
+def apply_prowlarr_credentials(config: dict[str, Any], report: ProwlarrCredentialReport) -> set[str]:
+    """Apply missing credentials to a runtime config and return their sources."""
+    trackers_value: object = config.setdefault("TRACKERS", {})
+    if not isinstance(trackers_value, dict):
+        return set()
+    trackers = cast(dict[str, object], trackers_value)
+
+    applied: set[str] = set()
+    for tracker, credential in report.credentials.items():
+        tracker_config_value = trackers.setdefault(tracker, {})
+        if not isinstance(tracker_config_value, dict):
+            continue
+        tracker_config = cast(dict[str, object], tracker_config_value)
+
+        used = False
+        if credential.api_key and not str(tracker_config.get("api_key") or "").strip():
+            tracker_config["api_key"] = credential.api_key
+            used = True
+        if credential.cookie:
+            tracker_config["_prowlarr_cookie"] = {
+                "header": credential.cookie,
+                "base_url": credential.base_url,
+            }
+            used = True
+        if used:
+            tracker_config["_prowlarr_credential_source"] = True
+            applied.add(tracker)
+    return applied
+
+
+def configured_prowlarr(config: dict[str, Any]) -> tuple[str, str] | None:
+    default_value: object = config.get("DEFAULT", {})
+    if not isinstance(default_value, dict):
+        return None
+    default = cast(dict[str, object], default_value)
+    base_url = str(default.get("prowlarr_url") or "").strip()
+    api_key = str(default.get("prowlarr_api_key") or "").strip()
+    return (base_url, api_key) if base_url and api_key else None
+
+
+def prowlarr_cookie_jar(tracker_config: dict[str, Any]) -> http.cookiejar.CookieJar | None:
+    """Build a process-local cookie jar from a hydrated Prowlarr credential."""
+    value_raw: object = tracker_config.get("_prowlarr_cookie")
+    if not isinstance(value_raw, dict):
+        return None
+    value = cast(dict[str, object], value_raw)
+    base_url = str(value.get("base_url") or "").strip()
+    header = _usable_cookie(value.get("header"), base_url)
+    parsed = urlsplit(base_url)
+    if not header or parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return None
+
+    cookies = SimpleCookie()
+    try:
+        cookies.load(header)
+    except CookieError:
+        return None
+    if not cookies:
+        return None
+
+    jar = http.cookiejar.CookieJar()
+    for name, morsel in cookies.items():
+        jar.set_cookie(
+            http.cookiejar.Cookie(
+                version=0,
+                name=name,
+                value=morsel.value,
+                port=None,
+                port_specified=False,
+                domain=parsed.hostname,
+                domain_specified=True,
+                domain_initial_dot=False,
+                path="/",
+                path_specified=True,
+                secure=parsed.scheme == "https",
+                expires=None,
+                discard=True,
+                comment=None,
+                comment_url=None,
+                rest={"HttpOnly": ""},
+                rfc2109=False,
+            )
+        )
+    return jar

--- a/tests/test_prowlarr.py
+++ b/tests/test_prowlarr.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+import src.prowlarr as prowlarr
+import web_ui.server as server
+from src.cookie_auth import CookieValidator
+from src.meta import Meta
+
+
+def _indexer(definition: str | None, *, api_key: str = "", cookie: str = "", enabled: bool = True, base_url: str = "https://tracker.example/") -> dict[str, Any]:
+    fields: list[dict[str, Any]] = [
+        {"name": "definitionFile", "value": definition},
+        {"name": "baseUrl", "value": base_url},
+    ]
+    if api_key:
+        fields.append({"name": "apikey", "value": api_key})
+    if cookie:
+        fields.append({"name": "cookie", "value": cookie})
+    return {"enable": enabled, "fields": fields}
+
+
+def test_resolve_prowlarr_credentials_maps_supported_api_keys_and_cookies() -> None:
+    report = prowlarr.resolve_prowlarr_credentials(
+        [
+            _indexer("aither-api", api_key="aither-key"),
+            _indexer("bjshare", cookie="session=abc; clearance=xyz", base_url="https://bj-share.info/"),
+            _indexer("uploadcx", api_key="upload-key"),
+            _indexer("xingyung", cookie="session=xyz", base_url="https://pt.xingyungept.org/"),
+            _indexer("disabled-api", api_key="ignored", enabled=False),
+        ],
+        {"AITHER", "BJSHARE", "ULCX", "XINGYUNGEPT"},
+    )
+
+    assert report.enabled_indexers == 4
+    assert report.matched_indexers == 4
+    assert report.credentials["AITHER"].api_key == "aither-key"
+    assert report.credentials["BJSHARE"].cookie == "session=abc; clearance=xyz"
+    assert report.credentials["ULCX"].api_key == "upload-key"
+    assert report.credentials["XINGYUNGEPT"].cookie == "session=xyz"
+
+
+def test_resolve_rejects_masked_and_malformed_credentials() -> None:
+    report = prowlarr.resolve_prowlarr_credentials(
+        [
+            _indexer("aither-api", api_key="********"),
+            _indexer("bjshare", cookie="not-a-cookie", base_url="https://bj-share.info/"),
+            _indexer(None, api_key="********"),
+            {"enable": True, "fields": "invalid"},
+        ],
+        {"AITHER", "BJSHARE"},
+    )
+
+    assert report.credentials == {}
+    assert report.masked_credentials == 2
+    assert report.unsupported_indexers == 2
+
+
+def test_apply_prowlarr_credentials_only_fills_missing_api_key() -> None:
+    config: dict[str, Any] = {
+        "TRACKERS": {
+            "AITHER": {"api_key": "local-key"},
+            "BJSHARE": {"announce_url": "https://announce.example/passkey"},
+        }
+    }
+    report = prowlarr.ProwlarrCredentialReport(
+        credentials={
+            "AITHER": prowlarr.ProwlarrCredential(api_key="remote-key"),
+            "BLUTOPIA": prowlarr.ProwlarrCredential(api_key="remote-blu"),
+            "BJSHARE": prowlarr.ProwlarrCredential(cookie="session=remote", base_url="https://bj-share.info/"),
+        }
+    )
+
+    applied = prowlarr.apply_prowlarr_credentials(config, report)
+
+    assert config["TRACKERS"]["AITHER"]["api_key"] == "local-key"
+    assert config["TRACKERS"]["BLUTOPIA"]["api_key"] == "remote-blu"
+    assert config["TRACKERS"]["BJSHARE"]["announce_url"] == "https://announce.example/passkey"
+    assert "AITHER" not in applied
+    assert applied == {"BLUTOPIA", "BJSHARE"}
+
+
+def test_prowlarr_cookie_jar_scopes_cookies_to_indexer_host() -> None:
+    jar = prowlarr.prowlarr_cookie_jar(
+        {
+            "_prowlarr_cookie": {
+                "header": "session=abc; clearance=xyz",
+                "base_url": "https://bj-share.info/",
+            }
+        }
+    )
+
+    assert jar is not None
+    cookies = {cookie.name: cookie for cookie in jar}
+    assert {name: cookie.value for name, cookie in cookies.items()} == {"session": "abc", "clearance": "xyz"}
+    assert all(cookie.domain == "bj-share.info" for cookie in cookies.values())
+    assert all(cookie.secure for cookie in cookies.values())
+
+
+@pytest.mark.asyncio
+async def test_cookie_validator_prefers_local_file_over_prowlarr(tmp_path: Path) -> None:
+    cookies_dir = tmp_path / "data" / "cookies"
+    cookies_dir.mkdir(parents=True)
+    (cookies_dir / "BJSHARE.txt").write_text(
+        "# Netscape HTTP Cookie File\n.bj-share.info\tTRUE\t/\tTRUE\t0\tsession\tlocal\n",
+        encoding="utf-8",
+    )
+    config = {
+        "TRACKERS": {
+            "BJSHARE": {
+                "_prowlarr_cookie": {
+                    "header": "session=remote",
+                    "base_url": "https://bj-share.info/",
+                }
+            }
+        }
+    }
+    meta = Meta()
+    meta.base_dir = str(tmp_path)
+
+    jar = await CookieValidator(config).load_session_cookies(meta, "BJSHARE")
+
+    assert jar is not None
+    assert {cookie.name: cookie.value for cookie in jar} == {"session": "local"}
+
+
+@pytest.mark.asyncio
+async def test_cookie_validator_uses_prowlarr_when_file_is_missing(tmp_path: Path) -> None:
+    config = {
+        "TRACKERS": {
+            "BRASILTRACKER": {
+                "_prowlarr_cookie": {
+                    "header": "session=remote",
+                    "base_url": "https://brasiltracker.org/",
+                }
+            }
+        }
+    }
+    meta = Meta()
+    meta.base_dir = str(tmp_path)
+
+    jar = await CookieValidator(config).load_session_cookies(meta, "BRASILTRACKER")
+
+    assert jar is not None
+    assert {cookie.name: cookie.value for cookie in jar} == {"session": "remote"}
+    assert not (tmp_path / "data" / "cookies" / "BRASILTRACKER.txt").exists()
+
+
+class _FakeResponse:
+    def __init__(self, payload: Any, status_code: int = 200):
+        self.payload = payload
+        self.status_code = status_code
+        self.request = httpx.Request("GET", "http://prowlarr.test")
+
+    def json(self) -> Any:
+        return self.payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            response = httpx.Response(self.status_code, request=self.request)
+            raise httpx.HTTPStatusError("failure", request=self.request, response=response)
+
+
+class _FakeClient:
+    def __init__(self, responses: list[_FakeResponse]):
+        self.responses = responses
+        self.urls: list[str] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def get(self, url: str) -> _FakeResponse:
+        self.urls.append(url)
+        return self.responses.pop(0)
+
+
+def test_fetch_uses_indexer_and_status_endpoints(monkeypatch) -> None:
+    client = _FakeClient([_FakeResponse([_indexer("aither-api", api_key="key")]), _FakeResponse({"version": "2.5.2"})])
+    monkeypatch.setattr(prowlarr.httpx, "Client", lambda **_kwargs: client)
+
+    report = prowlarr.fetch_prowlarr_credentials("http://prowlarr.test/", "secret", {"AITHER"}, include_status=True)
+
+    assert client.urls == ["http://prowlarr.test/api/v1/indexer", "http://prowlarr.test/api/v1/system/status"]
+    assert report.version == "2.5.2"
+
+
+def test_fetch_reports_authentication_failure_without_response_body(monkeypatch) -> None:
+    client = _FakeClient([_FakeResponse({"secret": "must-not-leak"}, status_code=401)])
+    monkeypatch.setattr(prowlarr.httpx, "Client", lambda **_kwargs: client)
+
+    with pytest.raises(prowlarr.ProwlarrError, match="rejected the API key") as error:
+        prowlarr.fetch_prowlarr_credentials("http://prowlarr.test", "secret", {"AITHER"})
+
+    assert "must-not-leak" not in str(error.value)
+
+
+def test_fetch_reports_timeout(monkeypatch) -> None:
+    class TimeoutClient(_FakeClient):
+        def get(self, url: str) -> _FakeResponse:
+            raise httpx.ReadTimeout("slow", request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(prowlarr.httpx, "Client", lambda **_kwargs: TimeoutClient([]))
+
+    with pytest.raises(prowlarr.ProwlarrError, match="timed out"):
+        prowlarr.fetch_prowlarr_credentials("http://prowlarr.test", "secret", {"AITHER"})
+
+
+def test_tracker_catalog_marks_prowlarr_cookie_source(monkeypatch, tmp_path: Path) -> None:
+    user_config = {
+        "DEFAULT": {"prowlarr_url": "http://prowlarr.test", "prowlarr_api_key": "secret"},
+        "TRACKERS": {"BJSHARE": {"announce_url": "https://tracker.example/passkey/announce"}},
+    }
+    example_config = {"TRACKERS": {"BJSHARE": {"announce_url": ""}}}
+
+    monkeypatch.setattr(server, "_is_authenticated", lambda: True)
+    monkeypatch.setattr(server, "_verify_csrf_header", lambda: True)
+    monkeypatch.setattr(server, "_verify_same_origin", lambda: True)
+    monkeypatch.setattr(server, "STATE_DIR", tmp_path)
+    monkeypatch.setattr(
+        server,
+        "_load_config_from_file",
+        lambda path: example_config if path.name == "example_config.py" else user_config,
+    )
+    monkeypatch.setattr(
+        prowlarr,
+        "fetch_prowlarr_credentials",
+        lambda *_args, **_kwargs: prowlarr.ProwlarrCredentialReport(
+            credentials={"BJSHARE": prowlarr.ProwlarrCredential(cookie="session=remote", base_url="https://bj-share.info/")}
+        ),
+    )
+
+    response = server.app.test_client().get("/api/trackers")
+
+    tracker = next(item for item in response.get_json()["trackers"] if item["name"] == "BJSHARE")
+    assert tracker["configured"] is True
+    assert tracker["cookie_configured"] is True
+    assert tracker["credential_source"] == "prowlarr"
+
+    user_config["TRACKERS"]["BJSHARE"]["announce_url"] = ""
+    response = server.app.test_client().get("/api/trackers")
+    tracker = next(item for item in response.get_json()["trackers"] if item["name"] == "BJSHARE")
+    assert tracker["configured"] is False
+    assert tracker["cookie_configured"] is True
+
+
+def test_config_test_prowlarr_requires_session_and_csrf(monkeypatch) -> None:
+    monkeypatch.setattr(server, "_is_authenticated", lambda: False)
+    response = server.app.test_client().post("/api/config_test_prowlarr", json={})
+    assert response.status_code == 401
+
+    monkeypatch.setattr(server, "_is_authenticated", lambda: True)
+    monkeypatch.setattr(server, "_verify_csrf_header", lambda: False)
+    response = server.app.test_client().post("/api/config_test_prowlarr", json={})
+    assert response.status_code == 403
+
+
+def test_config_test_prowlarr_returns_no_secrets(monkeypatch) -> None:
+    monkeypatch.setattr(server, "_is_authenticated", lambda: True)
+    monkeypatch.setattr(server, "_verify_csrf_header", lambda: True)
+    monkeypatch.setattr(server, "_verify_same_origin", lambda: True)
+    monkeypatch.setattr(
+        prowlarr,
+        "fetch_prowlarr_credentials",
+        lambda *_args, **_kwargs: prowlarr.ProwlarrCredentialReport(
+            credentials={"BJSHARE": prowlarr.ProwlarrCredential(cookie="session=secret", base_url="https://bj-share.info/")},
+            enabled_indexers=2,
+            matched_indexers=1,
+            masked_credentials=1,
+            unsupported_indexers=1,
+            version="2.5.2",
+        ),
+    )
+
+    response = server.app.test_client().post(
+        "/api/config_test_prowlarr",
+        json={"url": "http://prowlarr.test", "api_key": "top-secret"},
+    )
+
+    payload = response.get_json()
+    assert response.status_code == 200
+    assert payload["credential_trackers"] == ["BJSHARE"]
+    assert payload["cookie_trackers"] == ["BJSHARE"]
+    assert "top-secret" not in response.text
+    assert "session=secret" not in response.text

--- a/upload.py
+++ b/upload.py
@@ -2277,6 +2277,21 @@ async def do_the_thing(base_dir: str) -> None:
     except Exception as exc:
         logger.warning(f"[yellow]Warning: could not reload config from disk: {exc}[/yellow]")
 
+    from src.prowlarr import ProwlarrError, apply_prowlarr_credentials, configured_prowlarr, fetch_prowlarr_credentials
+
+    if prowlarr_connection := configured_prowlarr(config):
+        try:
+            report = await asyncio.to_thread(
+                fetch_prowlarr_credentials,
+                prowlarr_connection[0],
+                prowlarr_connection[1],
+                set(tracker_class_map),
+            )
+            applied = apply_prowlarr_credentials(config, report)
+            logger.debug(f"[green]Prowlarr supplied fallback credentials for {len(applied)} tracker(s).[/green]")
+        except ProwlarrError as exc:
+            logger.warning(f"[yellow]Prowlarr credential fallback unavailable: {exc}[/yellow]")
+
     await asyncio.sleep(0.1)  # Ensure it's not racing
 
     tmp_dir = Path(base_dir) / "tmp"

--- a/web_ui/server.py
+++ b/web_ui/server.py
@@ -4647,15 +4647,6 @@ def get_trackers():
     config_path = base_dir / "data" / "config.py"
     user_config = _load_config_from_file(config_path) or {}
 
-    trackers_section_raw = user_config.get("TRACKERS", {})
-    trackers_section = cast(dict[str, Any], trackers_section_raw) if isinstance(trackers_section_raw, Mapping) else {}
-    default_trackers_val = trackers_section.get("default_trackers", "")
-    default_trackers_list = []
-    if isinstance(default_trackers_val, str):
-        default_trackers_list = [t.strip().upper() for t in default_trackers_val.split(",") if t.strip()]
-    elif isinstance(default_trackers_val, list):
-        default_trackers_list = [str(t).strip().upper() for t in default_trackers_val if str(t).strip()]
-
     # Load tracker_class_map from src.trackersetup
     try:
         from src.trackersetup import tracker_class_map
@@ -4666,6 +4657,34 @@ def get_trackers():
     example_trackers_raw = example_config.get("TRACKERS", {})
     example_trackers = cast(dict[str, Any], example_trackers_raw) if isinstance(example_trackers_raw, Mapping) else {}
 
+    from src.prowlarr import ProwlarrError, apply_prowlarr_credentials, configured_prowlarr, fetch_prowlarr_credentials
+
+    prowlarr_sources: set[str] = set()
+    prowlarr_cookie_trackers: set[str] = set()
+    try:
+        if prowlarr_connection := configured_prowlarr(user_config):
+            prowlarr_report = fetch_prowlarr_credentials(
+                prowlarr_connection[0],
+                prowlarr_connection[1],
+                set(tracker_class_map),
+            )
+            prowlarr_sources = apply_prowlarr_credentials(user_config, prowlarr_report)
+            prowlarr_cookie_trackers = {name for name, credential in prowlarr_report.credentials.items() if credential.cookie}
+    except ProwlarrError:
+        # The tracker catalogue remains usable with local configuration when
+        # the optional Prowlarr instance is unavailable.
+        prowlarr_sources = set()
+        prowlarr_cookie_trackers = set()
+
+    trackers_section_raw = user_config.get("TRACKERS", {})
+    trackers_section = cast(dict[str, Any], trackers_section_raw) if isinstance(trackers_section_raw, Mapping) else {}
+    default_trackers_val = trackers_section.get("default_trackers", "")
+    default_trackers_list = []
+    if isinstance(default_trackers_val, str):
+        default_trackers_list = [t.strip().upper() for t in default_trackers_val.split(",") if t.strip()]
+    elif isinstance(default_trackers_val, list):
+        default_trackers_list = [str(t).strip().upper() for t in default_trackers_val if str(t).strip()]
+
     cookie_trackers: set[str] = set()
     try:
         from src.cookie_auth import find_cookie_file
@@ -4675,6 +4694,9 @@ def get_trackers():
         cookie_trackers = set()
     else:
         cookie_trackers = _configured_cookie_tracker_names(tracker_class_map, user_config, STATE_DIR, find_cookie_file)
+
+    prowlarr_sources -= cookie_trackers
+    cookie_trackers |= prowlarr_cookie_trackers
 
     configured_trackers = _configured_tracker_names(
         trackers_section,
@@ -4707,6 +4729,7 @@ def get_trackers():
                 "base_url": base_url,
                 "favicon": favicon_url,
                 "configured": tracker_name.upper() in configured_trackers,
+                "credential_source": ("prowlarr" if tracker_name.upper() in prowlarr_sources else "local" if tracker_name.upper() in configured_trackers else None),
                 "auth_type": auth_type,
                 "optional_setup_keys": optional_setup_keys,
                 "cookie_configured": tracker_name.upper() in cookie_trackers,
@@ -4718,6 +4741,49 @@ def get_trackers():
     trackers_data.sort(key=lambda x: x["display_name"].lower())
 
     return jsonify({"success": True, "default_trackers": default_trackers_list, "trackers": trackers_data})
+
+
+@app.route("/api/config_test_prowlarr", methods=["POST"])
+@limiter.limit("30 per hour", key_func=_rate_limit_key_func)
+def config_test_prowlarr():
+    """Test draft Prowlarr settings and return credential-free metadata."""
+    if not _is_authenticated():
+        return jsonify({"success": False, "error": "Authentication required (web session)"}), 401
+    if not _verify_csrf_header() or not _verify_same_origin():
+        return jsonify({"success": False, "error": "CSRF/Origin validation failed"}), 403
+
+    data = _request_json_dict()
+    base_url = str(data.get("url") or "").strip()
+    api_key = str(data.get("api_key") or "").strip()
+    if not base_url or not api_key:
+        return jsonify({"success": False, "error": "Prowlarr URL and API key are required"}), 400
+
+    from src.prowlarr import ProwlarrError, fetch_prowlarr_credentials
+    from src.trackersetup import tracker_class_map
+
+    try:
+        report = fetch_prowlarr_credentials(base_url, api_key, set(tracker_class_map), include_status=True)
+    except ProwlarrError as error:
+        return jsonify({"success": False, "error": str(error)}), 400
+    except Exception:
+        return jsonify({"success": False, "error": "Unable to test the Prowlarr connection"}), 500
+
+    api_key_trackers = sorted(name for name, credential in report.credentials.items() if credential.api_key)
+    cookie_trackers = sorted(name for name, credential in report.credentials.items() if credential.cookie)
+    return jsonify(
+        {
+            "success": True,
+            "message": f"Connected to Prowlarr {report.version or '(version unavailable)'}. Found credentials for {len(report.credentials)} supported tracker(s).",
+            "version": report.version,
+            "enabled_indexers": report.enabled_indexers,
+            "matched_indexers": report.matched_indexers,
+            "credential_trackers": sorted(report.credentials),
+            "api_key_trackers": api_key_trackers,
+            "cookie_trackers": cookie_trackers,
+            "masked_credentials": report.masked_credentials,
+            "unsupported_indexers": report.unsupported_indexers,
+        }
+    )
 
 
 @app.route("/api/config_set_tracker_overrides", methods=["POST"])

--- a/web_ui/static/js/config_app.js
+++ b/web_ui/static/js/config_app.js
@@ -640,6 +640,7 @@ const DEFAULT_WORKFLOW_GROUPS = [
     label: "Upload Workflow",
     headings: [
       "TRACKER SEARCH AND IMPORT",
+      "PROWLARR CREDENTIAL FALLBACK",
       "TRACKER CHECKS AND UPLOAD",
       "TORRENT CREATION",
       "POST-UPLOAD",
@@ -775,6 +776,7 @@ const CONFIG_HEADING_LABELS = {
   "METADATA CACHING": "Metadata Caching",
   "MUSIC METADATA": "Music Metadata",
   "TRACKER SEARCH AND IMPORT": "Tracker Search and Import",
+  "PROWLARR CREDENTIAL FALLBACK": "Prowlarr Credential Fallback",
   "IMAGE HOSTING": "Image Hosting",
   "SCREENSHOT CAPTURE AND PROCESSING": "Screenshot Capture and Processing",
   "SCREENSHOT ENHANCEMENTS": "Screenshot Enhancements",
@@ -802,6 +804,8 @@ const CONFIG_HEADING_LABELS = {
 const CONFIG_HEADING_DESCRIPTIONS = {
   "EXTERNAL TOOL PATHS":
     "Optional executable overrides. Leave fields blank to use automatically managed tools or executables on the system PATH. Check Tools detects their availability without downloading or installing anything.",
+  "PROWLARR CREDENTIAL FALLBACK":
+    "Use enabled Prowlarr indexers as a live fallback for missing tracker API keys and cookies. Values remain in memory and local credentials take precedence.",
 };
 
 const EXTERNAL_TOOL_KEYS = [
@@ -831,6 +835,7 @@ const getConfigHeadingDescription = (value) =>
 
 const UPLOAD_WORKFLOW_HEADING_ORDER = [
   "TRACKER SEARCH AND IMPORT",
+  "PROWLARR CREDENTIAL FALLBACK",
   "TRACKER CHECKS",
   "TORRENT CREATION",
   "UPLOAD BEHAVIOUR",
@@ -1269,6 +1274,14 @@ const INLINE_FIELD_HELP = {
   btn_api: {
     description:
       "Enter the BTN API key used to retrieve metadata from BroadcasTheNet.",
+  },
+  prowlarr_url: {
+    description:
+      "Enter the Prowlarr base URL. The connection is used only when both fields are set.",
+  },
+  prowlarr_api_key: {
+    description:
+      "Used to read enabled indexer credentials at the start of each run. Retrieved values are never saved by UA.",
   },
 };
 
@@ -5513,6 +5526,11 @@ function TrackerManager({
     const trackerStatusText = window.getUATrackerStatusText
       ? window.getUATrackerStatusText(trackerStatus)
       : "Not checked";
+    const visibleStatuses =
+      tracker.credential_source === "prowlarr" &&
+      !statuses.some((status) => status.label === "Prowlarr")
+        ? [...statuses, { label: "Prowlarr", tone: "accent" }]
+        : statuses;
     return (
       <span className="flex min-w-0 items-center gap-3">
         <span className="ua-config-tracker-icon flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-lg border">
@@ -5544,9 +5562,9 @@ function TrackerManager({
                 title={trackerStatusText}
               />
             )}
-            {statuses.length > 0 && (
+            {visibleStatuses.length > 0 && (
               <span className="flex flex-wrap gap-1.5">
-                {statuses.map((status) =>
+                {visibleStatuses.map((status) =>
                   trackerStatusBadge(status.label, status.tone),
                 )}
               </span>
@@ -6618,6 +6636,8 @@ function ItemList({
   externalToolStatusError,
   isCheckingExternalTools,
   onCheckExternalTools,
+  onTestProwlarr,
+  prowlarrTestState,
   onBrowseFolder,
   onValueChange,
 }) {
@@ -7055,6 +7075,11 @@ function ItemList({
           depth === 0 &&
           item.subsection === true &&
           normalizeConfigHeading(item.key) === "EXTERNAL TOOL PATHS";
+        const isProwlarrSubsection =
+          pathParts[0] === "DEFAULT" &&
+          depth === 0 &&
+          item.subsection === true &&
+          normalizeConfigHeading(item.key) === "PROWLARR CREDENTIAL FALLBACK";
         const isImageHostingSubsection =
           pathParts[0] === "DEFAULT" &&
           depth === 0 &&
@@ -7346,6 +7371,18 @@ function ItemList({
                       {isCheckingExternalTools ? "Checking…" : "Check tools"}
                     </button>
                   )}
+                  {isProwlarrSubsection && (
+                    <button
+                      type="button"
+                      className="ua-config-service-action shrink-0 rounded-lg border px-3 py-2 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-50"
+                      disabled={prowlarrTestState?.status === "loading"}
+                      onClick={onTestProwlarr}
+                    >
+                      {prowlarrTestState?.status === "loading"
+                        ? "Testing…"
+                        : "Test Connection"}
+                    </button>
+                  )}
                 </div>
                 {isExternalToolsSubsection && externalToolStatusError && (
                   <div
@@ -7376,6 +7413,19 @@ function ItemList({
                       </span>
                     </div>
                   )}
+                {isProwlarrSubsection && prowlarrTestState?.message && (
+                  <div
+                    className={
+                      "mt-3 rounded-lg border px-3 py-2 text-xs " +
+                      (prowlarrTestState.status === "success"
+                        ? "border-green-500/40 text-green-500"
+                        : "border-red-500/40 text-red-500")
+                    }
+                    role="status"
+                  >
+                    {prowlarrTestState.message}
+                  </div>
+                )}
               </div>
               <div className="ua-config-section-panel p-4">{nested}</div>
             </section>
@@ -9105,6 +9155,7 @@ function ConfigApp() {
   const [folderPicker, setFolderPicker] = useState(null);
   const [renameClientSource, setRenameClientSource] = useState("");
   const [clientTestStates, setClientTestStates] = useState(new Map());
+  const [prowlarrTestState, setProwlarrTestState] = useState(null);
   const [externalToolStatuses, setExternalToolStatuses] = useState({});
   const [externalToolStatusError, setExternalToolStatusError] = useState("");
   const [isCheckingExternalTools, setIsCheckingExternalTools] = useState(false);
@@ -9404,6 +9455,7 @@ function ConfigApp() {
       setPendingTrackerOverrideModes(new Map());
       setTrackerOverrideEditors(new Set());
       setClientTestStates(new Map());
+      setProwlarrTestState(null);
       setRenameClientSource("");
       setConfigWarning(data.config_warning || "");
       setStatus({ text: "", type: "info" });
@@ -10119,6 +10171,43 @@ function ConfigApp() {
           message: error.message || "Connection failed",
         });
         return next;
+      });
+    }
+  };
+
+  const testProwlarr = async () => {
+    const url = String(getEffectiveDefaultValue("prowlarr_url") || "").trim();
+    const apiKey = String(
+      getEffectiveDefaultValue("prowlarr_api_key") || "",
+    ).trim();
+    if (!url || !apiKey) {
+      setProwlarrTestState({
+        status: "error",
+        message: "Enter both the Prowlarr URL and API key.",
+      });
+      return;
+    }
+    setProwlarrTestState({
+      status: "loading",
+      message: "Testing connection…",
+    });
+    try {
+      const response = await apiFetch(`${API_BASE}/config_test_prowlarr`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url, api_key: apiKey }),
+      });
+      const data = await response.json();
+      setProwlarrTestState({
+        status: data.success ? "success" : "error",
+        message: data.success
+          ? data.message || "Connection successful"
+          : data.error || "Connection failed",
+      });
+    } catch (error) {
+      setProwlarrTestState({
+        status: "error",
+        message: error.message || "Connection failed",
       });
     }
   };
@@ -11652,6 +11741,8 @@ function ConfigApp() {
                           externalToolStatusError={externalToolStatusError}
                           isCheckingExternalTools={isCheckingExternalTools}
                           onCheckExternalTools={checkExternalTools}
+                          onTestProwlarr={testProwlarr}
+                          prowlarrTestState={prowlarrTestState}
                           onBrowseFolder={browseForFolder}
                           onValueChange={onValueChange}
                         />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Prowlarr integration to provide tracker credentials when local credentials are unavailable.
  * Added Prowlarr configuration fields and a **Test Connection** action in the Web UI.
  * Tracker listings now indicate whether credentials come from Prowlarr or local configuration.
  * Prowlarr-provided cookies can be used without replacing locally saved cookies.
* **Documentation**
  * Documented Prowlarr setup, supported credentials, credential precedence, and handling of masked secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->