### PR TITLE
fix(hawkeuno): respect configured screenshot rows

### DIFF
--- a/src/get_desc.py
+++ b/src/get_desc.py
@@ -2145,11 +2145,6 @@ class DescriptionBuilder:
 
             # If screens_per_row is set, use that to determine how many screenshots should be on each row. Otherwise, use 2 as default
             screens_per_row = self._get_int_config("screens_per_row", 2)
-            if self.tracker == "HAWKEUNO":
-                width = self._get_int_config("thumbnail_size", 350)
-                # Adjust screens_per_row to keep total width below 1100
-                while screens_per_row * width > 1100 and screens_per_row > 1:
-                    screens_per_row -= 1
         except Exception:
             screens_per_row = 2
         return screens_per_row

--- a/tests/test_hawkeuno.py
+++ b/tests/test_hawkeuno.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from src.get_desc import DescriptionBuilder
 from src.meta import Meta
 from src.rehostimages import check_tracker_image_hosts
 from src.trackers.UNIT3D.hawkeuno import HawkeUno
@@ -31,6 +32,25 @@ async def test_hawkeuno_image_host_policy_does_not_require_legacy_method():
     await check_tracker_image_hosts(meta, tracker)
 
     tracker.rehost_images_manager.check_policy.assert_awaited_once_with(meta, "HAWKEUNO", tracker.image_host_policy)
+
+
+@pytest.mark.asyncio
+async def test_hawkeuno_respects_configured_screenshot_rows():
+    config = {
+        "DEFAULT": {"screens_per_row": "1000", "thumbnail_size": "350"},
+        "TRACKERS": {"HAWKEUNO": {}},
+    }
+    builder = DescriptionBuilder("HAWKEUNO", config)
+
+    screens_per_row = await builder.get_screens_per_row()
+
+    assert screens_per_row == 1000
+    parts = []
+    for index in range(9):
+        parts.append(builder.format_screenshot(f"https://example.com/{index}", f"https://example.com/{index}.png"))
+        builder._append_screenshot_row_separator(parts, index, screens_per_row)
+
+    assert "\n" not in "".join(parts)
 
 
 async def _noop():


### PR DESCRIPTION
Actual description block width is smaller not, which causes screens to be weirdly divided into rows: 2-1-2-1. The code seems unnecessary anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - HAWKEUNO now respects the configured screenshots-per-row setting instead of applying a separate layout limit.

- **Tests**
  - Added coverage to verify configured screenshot rows are honored when formatting screenshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->