### PR TITLE
fix: capture full DVD title screenshots

### DIFF
--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -893,40 +893,25 @@ async def dvd_screenshots(
             frame_rate = float(track.frame_rate)
     w_sar, h_sar = screenshot_par_scale_factors(width, height, par, dar)
 
-    async def _is_vob_good(n: int, loops: int, _num_screens: int) -> tuple[float, int]:
-        max_loops = 6
-        fallback_duration = 300
-        valid_tracks: list[dict[str, Any]] = []
-
-        while loops < max_loops:
-            try:
-                vob_mi = MediaInfo.parse(f"{meta.discs[disc_num]['path']}/VTS_{main_set[n]}", output="JSON")
-                vob_mi = json.loads(vob_mi)
-
-                for track in vob_mi.get("media", {}).get("track", []):
-                    duration = float(track.get("Duration", 0))
-                    width = track.get("Width")
-                    height = track.get("Height")
-
-                    if duration > 1 and width and height:  # Minimum 1-second track
-                        valid_tracks.append({"duration": duration, "track_index": n})
-
-                if valid_tracks:
-                    # Sort by duration, take longest track
-                    longest_track: dict[str, Any] = max(valid_tracks, key=lambda x: x["duration"])
-                    return longest_track["duration"], longest_track["track_index"]
-
-            except Exception as e:
-                logger.error(f"[red]Error parsing VOB {n}: {e}")
-
-            n = (n + 1) % len(main_set)
-            loops += 1
-
-        return fallback_duration, 0
-
-    main_set = meta.discs[disc_num]["main_set"][1:] if len(meta.discs[disc_num]["main_set"]) > 1 else meta.discs[disc_num]["main_set"]
-    voblength, vob_index = await _is_vob_good(0, 0, num_screens)
-    capture_vob = main_set[vob_index]
+    main_set = meta.discs[disc_num]["main_set"]
+    content_vobs = [vob for vob in main_set if not vob.upper().endswith("_0.VOB")] or main_set
+    title_vobs = [str(Path(meta.discs[disc_num]["path"]) / f"VTS_{vob}") for vob in content_vobs]
+    input_file = title_vobs[0] if len(title_vobs) == 1 else f"concat:{'|'.join(title_vobs)}"
+    voblength = 0.0
+    for title_vob in title_vobs:
+        try:
+            vob_mi = json.loads(MediaInfo.parse(title_vob, output="JSON"))
+            video_durations = [
+                float(track.get("Duration", 0))
+                for track in vob_mi.get("media", {}).get("track", [])
+                if track.get("Width") and track.get("Height") and float(track.get("Duration", 0)) > 1
+            ]
+            if video_durations:
+                voblength += max(video_durations)
+        except Exception as e:
+            logger.error(f"[red]Error parsing VOB {title_vob}: {e}")
+    if not voblength:
+        voblength = 300
     ss_times = await valid_ss_time([], num_screens, voblength, frame_rate, meta, retake=retry_cap)
     capture_tasks: list[Awaitable[tuple[int, str | None]]] = []
     existing_images_count = 0
@@ -934,7 +919,6 @@ async def dvd_screenshots(
 
     for i in range(num_screens + 1):
         image = str(screenshot_dir / f"{sanitized_disc_name}-{i}.png")
-        input_file = f"{meta.discs[disc_num]['path']}/VTS_{capture_vob}"
         if Path(image).exists() and not meta.retake:
             existing_images_count += 1
             existing_image_paths.append(image)
@@ -949,7 +933,6 @@ async def dvd_screenshots(
 
     for i in range(num_screens + 1):
         image = str(screenshot_dir / f"{sanitized_disc_name}-{i}.png")
-        input_file = f"{meta.discs[disc_num]['path']}/VTS_{capture_vob}"
         image_paths.append(image)
         input_files.append(input_file)
 
@@ -1013,7 +996,6 @@ async def dvd_screenshots(
                 logger.info(f"[yellow]Retaking screenshot for: {image} (Attempt {attempt}/{retry_attempts})[/yellow]")
 
                 index = int(image.rsplit("-", 1)[-1].split(".")[0])
-                input_file = f"{meta.discs[disc_num]['path']}/VTS_{capture_vob}"
                 adjusted_time = random.uniform(0, voblength)  # nosec B311 - Random screenshot timing, not cryptographic  # noqa: S311
 
                 if Path(image).exists():  # Prevent unnecessary deletion error
@@ -1073,18 +1055,19 @@ async def capture_dvd_screenshot(task: tuple[int, str, str, str, Meta, float, fl
 
     try:
         loglevel = "verbose" if meta.ffdebug else "quiet"
-        media_info = MediaInfo.parse(input_file)
         video_duration: float | None = None
-        tracks: list[Any] = []
-        tracks.extend(cast(list[Any], getattr(media_info, "tracks", [])))
-        for track in tracks:
-            if track.track_type == "Video":
-                try:
-                    if track.duration is not None:
-                        video_duration = float(track.duration)
-                except TypeError, ValueError:
-                    video_duration = None
-                break
+        if not input_file.startswith("concat:"):
+            media_info = MediaInfo.parse(input_file)
+            tracks: list[Any] = []
+            tracks.extend(cast(list[Any], getattr(media_info, "tracks", [])))
+            for track in tracks:
+                if track.track_type == "Video":
+                    try:
+                        if track.duration is not None:
+                            video_duration = float(track.duration) / 1000
+                    except TypeError, ValueError:
+                        video_duration = None
+                    break
 
         if video_duration and seek_time > video_duration:
             seek_time = max(0, video_duration - 1)

--- a/tests/test_takescreens_ffmpeg.py
+++ b/tests/test_takescreens_ffmpeg.py
@@ -2,6 +2,7 @@
 # ruff: noqa: S101
 
 import asyncio
+import json
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -183,3 +184,56 @@ async def test_capture_screenshot_applies_selected_libplacebo_tonemapping(monkey
 
     assert result == (0, str(output))
     assert any("libplacebo=tonemapping=hable" in argument for argument in commands[0])
+
+
+@pytest.mark.asyncio
+async def test_dvd_screenshots_uses_complete_title_set(monkeypatch, tmp_path):
+    disc_path = tmp_path / "VIDEO_TS"
+    disc_path.mkdir()
+    main_set = ["01_0.VOB", "01_1.VOB", "01_2.VOB", "01_3.VOB"]
+    durations = {"01_1.VOB": 1200.0, "01_2.VOB": 1200.0, "01_3.VOB": 600.0}
+    captured: list[tuple[int, str, str]] = []
+
+    def parse_stub(path, output=None, **_kwargs):
+        if output == "JSON":
+            duration = durations[Path(path).name.removeprefix("VTS_")]
+            return json.dumps({"media": {"track": [{"Duration": duration, "Width": 720, "Height": 480}]}})
+        return SimpleNamespace(
+            tracks=[SimpleNamespace(track_type="Video", duration="3000000", pixel_aspect_ratio="1", display_aspect_ratio="1.5", width="720", height="480", frame_rate="24")]
+        )
+
+    async def valid_times_stub(_times, num_screens, length, _frame_rate, _meta, retake=False):
+        assert num_screens == 2
+        assert length == 3000.0
+        assert retake is False
+        return ["100", "1500", "2700"]
+
+    async def capture_stub(task):
+        index, source, image, seek_time, *_rest = task
+        Path(image).write_bytes(b"x" * 120001)
+        captured.append((index, source, seek_time))
+        return index, image
+
+    monkeypatch.setattr(takescreens.MediaInfo, "parse", parse_stub)
+    monkeypatch.setattr(takescreens, "valid_ss_time", valid_times_stub)
+    monkeypatch.setattr(takescreens, "capture_dvd_screenshot", capture_stub)
+    monkeypatch.setattr(takescreens, "register_screenshots", lambda *_args: [])
+    monkeypatch.setattr(takescreens, "screenshot_par_scale_factors", lambda *_args: (1.0, 1.0))
+
+    meta = Meta(
+        base_dir=str(tmp_path),
+        uuid="dvd-test",
+        screens=2,
+        discs=[{"name": "DVD", "path": str(disc_path), "main_set": main_set}],
+        image_list=[],
+        retake=False,
+        frame_overlay=False,
+        tv_pack=False,
+        debug=False,
+        ffdebug=False,
+    )
+    await takescreens.dvd_screenshots(meta, 0, cleanup_after_capture=False)
+
+    expected_source = "concat:" + "|".join(str(disc_path / f"VTS_{vob}") for vob in main_set[1:])
+    assert [source for _index, source, _time in captured] == [expected_source] * 3
+    assert [time for _index, _source, time in captured] == ["100", "1500", "2700"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved DVD screenshot capture to include the complete main title content, producing more representative screenshots.
  - Improved screenshot timing by calculating duration across all relevant video content.
  - Added a fallback duration when video duration cannot be determined, helping capture continue reliably.
  - Improved retry behavior for DVD screenshot captures.

- **Tests**
  - Added coverage verifying complete-title DVD processing, timing, and screenshot capture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->