### PR TITLE
fix(books): avoid duplicate audiobook volume

### DIFF
--- a/src/book_prep.py
+++ b/src/book_prep.py
@@ -696,19 +696,28 @@ async def gather_book_prep(
             meta.keywords = map_audiobook_keywords(meta.keywords)
 
     if meta.audiobook:
-        meta.title = normalize_audiobook_title(meta.title, meta.book_series)
+        meta.title = normalize_audiobook_title(meta.title, meta.book_series, meta.book_series_index)
 
     detect_newspaper(meta)
     sanitize_book_language(meta)
     sanitize_book_author(meta)
 
 
-def normalize_audiobook_title(title: str, series: str) -> str:
-    """Remove a repeated series name from the beginning or end of an audiobook title."""
+def normalize_audiobook_title(title: str, series: str, series_index: str = "") -> str:
+    """Remove repeated series metadata from an audiobook title."""
     title = title.strip()
     series = series.strip()
     if not series:
         return title
+    series_index = series_index.strip()
+    if series_index:
+        repeated_volume = re.search(
+            rf"\s*:\s*{re.escape(series)}\s*[-\u2013\u2014]\s*vol(?:ume)?\.?\s*{re.escape(series_index)}\s*$",
+            title,
+            re.IGNORECASE,
+        )
+        if repeated_volume:
+            return title[: repeated_volume.start()].rstrip()
     if len(title) > len(series):
         if title.casefold().endswith(series.casefold()):
             return title[: -len(series)].rstrip(" :-\u2013\u2014")

--- a/tests/test_audiobook_series_titles.py
+++ b/tests/test_audiobook_series_titles.py
@@ -18,6 +18,17 @@ def test_normalize_audiobook_title_removes_repeated_series_prefix():
     assert normalize_audiobook_title("Os Contos de Hans Christian Andersen: O bobo", "Os Contos de Hans Christian Andersen") == "O bobo"  # noqa: S101
 
 
+def test_normalize_audiobook_title_removes_repeated_series_volume_suffix():
+    assert (  # noqa: S101
+        normalize_audiobook_title(
+            "3. Fato Típico, Dolo e Culpa - Conceito de Crime: Direito Penal - Vol. 7",
+            "Direito Penal",
+            "7",
+        )
+        == "3. Fato Típico, Dolo e Culpa - Conceito de Crime"
+    )
+
+
 def test_extract_audiobook_series_without_comma():
     assert extract_audiobook_series_from_title("Crescendo: Hush, hush Livro 2") == ("Crescendo", "Hush, hush", "2")  # noqa: S101
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audiobook title cleanup by removing repeated series names and volume suffixes from titles.
  * Titles such as those ending in a repeated “Vol. 7” suffix now display only the chapter title.

* **Tests**
  * Added coverage to verify correct handling of repeated series-volume suffixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->