### PR TITLE
feat(webui): preserve file browser scroll position

### DIFF
--- a/web_ui/static/js/app.js
+++ b/web_ui/static/js/app.js
@@ -2400,6 +2400,10 @@ function AudionutsUAGUI() {
   const fileBrowserSearchTimer = useRef(null);
   const fileBrowserSearchQuery = useRef("");
 
+  // Preserve the desktop file browser scroll position while the
+  // browser is temporarily unmounted or rerendered.
+  const fileBrowserScrollTopRef = useRef(0);
+
   // Folder loading states
   const [loadingFolders, setLoadingFolders] = useState(new Set());
 
@@ -7128,6 +7132,16 @@ function AudionutsUAGUI() {
                 </div>
                 {renderSelectAllBar()}
                 <div
+                  ref={(node) => {
+                    if (!node) return;
+                    requestAnimationFrame(() => {
+                      node.scrollTop = fileBrowserScrollTopRef.current;
+                    });
+                  }}
+                  onScroll={(event) => {
+                    fileBrowserScrollTopRef.current =
+                      event.currentTarget.scrollTop;
+                  }}
                   className={`${hasDescFile && !descBrowserCollapsed ? "flex-1 max-h-[50%]" : "flex-1"} overflow-y-auto`}
                 >
                   {fileBrowserSearch ? (


### PR DESCRIPTION
## Preserve file browser scroll position

### What changed

Preserves the desktop file browser's vertical scroll position when the file browser is temporarily unmounted or rerendered.

The scroll position is stored in a React `useRef` whenever the user scrolls. When the file browser container is mounted again, its previous `scrollTop` value is restored on the next animation frame.

### Why

When working with large directory trees, the file browser can jump back to the top after Upload Assistant starts or finishes processing and the sidebar rerenders.

This can be inconvenient when browsing deeply nested folders or large media libraries because the user has to find their previous position again.

### Implementation

* Adds `fileBrowserScrollTopRef` to store the current scroll position.
* Updates the ref from the file browser container's `onScroll` handler.
* Restores the saved `scrollTop` when the container mounts.
* Uses `requestAnimationFrame()` so restoration occurs after the DOM has been rendered.

### Testing

Tested with the Upload Assistant WebUI using a large directory tree.

Verified that:

* Scrolling normally still works.
* Selecting files/folders does not reset the position.
* The sidebar retains its previous position after the file browser is temporarily replaced during execution.
* No backend changes are required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The desktop file browser now preserves its scroll position when the view is rerendered or temporarily unmounted, preventing users from being returned to the top unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->