### PR TITLE
fix(ulcx): check minimum encode resolution against 1280x720

### DIFF
--- a/src/trackers/UNIT3D/ulcx.py
+++ b/src/trackers/UNIT3D/ulcx.py
@@ -129,8 +129,9 @@ class ULCX(UNIT3D):
         # Section 4.3.1.1: Encodes min resolution 720p
         if meta.type == "ENCODE":
             height = meta.video_height or 0
-            if height > 0 and height < 720:
-                logger.info(f"{self.tracker}: [bold red]Encodes must be at least 720p resolution. Standard definition encodes are forbidden.[/bold red]")
+            width = meta.video_width or 0
+            if height and width and not (height >= 720 and width >= 1280):
+                logger.info(f"{self.tracker}: [bold red]Encodes resolution must be at least 1280x720. Standard definition encodes are forbidden.[/bold red]")
                 return False
 
         # Section 4.3.1.6 & 4.3.1.7: Codec Restrictions for Encodes

--- a/src/trackers/UNIT3D/ulcx.py
+++ b/src/trackers/UNIT3D/ulcx.py
@@ -130,7 +130,7 @@ class ULCX(UNIT3D):
         if meta.type == "ENCODE":
             height = meta.video_height or 0
             width = meta.video_width or 0
-            if height and width and not (height >= 720 and width >= 1280):
+            if (height and height < 720) or (width and width < 1280):
                 logger.info(f"{self.tracker}: [bold red]Encodes resolution must be at least 1280x720. Standard definition encodes are forbidden.[/bold red]")
                 return False
 

--- a/tests/test_ulcx_rules.py
+++ b/tests/test_ulcx_rules.py
@@ -108,9 +108,15 @@ async def test_ulcx_dvdrip_rejection():
 async def test_ulcx_encode_rules():
     tracker = make_ulcx()
 
-    # SD encode (height < 720) rejected
+    # SD encode (height < 720 or width < 1280) rejected
     meta_sd = make_ulcx_meta(type="ENCODE", resolution="480p", video_height=480)
     assert await tracker.get_additional_checks(meta_sd) is False
+
+    meta_sd_width = make_ulcx_meta(type="ENCODE", resolution="720p", video_height=720, video_width=960)
+    assert await tracker.get_additional_checks(meta_sd_width) is False
+
+    meta_720p_valid = make_ulcx_meta(type="ENCODE", resolution="720p", video_height=720, video_width=1280)
+    assert await tracker.get_additional_checks(meta_720p_valid) is True
 
     # Live-action HEVC encode from 1080p source rejected
     meta_hevc_hd = make_ulcx_meta(type="ENCODE", video_codec="HEVC", resolution="1080p", video_height=1080, anime=False)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated ULCX encode validation to consider both video height and width.
  - Encodes are now rejected only when both dimensions are known and fall below the minimum requirements of 720p height and 1280px width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->