### PR TITLE
fix(hdbits): respect piece number limits, rehash if needed

### DIFF
--- a/src/clients.py
+++ b/src/clients.py
@@ -627,7 +627,10 @@ class Clients(QbittorrentClientMixin, RtorrentClientMixin, DelugeClientMixin, Tr
                         valid = not wrong_file and hdbits_pieces_allowed(piece_size, reuse_torrent.pieces, reuse_torrent.size)
                         if not valid:
                             logger.debug("[bold red]Torrent does not meet HDBits piece limits or file requirements")
-                    elif reuse_torrent.pieces >= 5000 and reuse_torrent.piece_size < 4294304 and (max_piece_size is None or max_piece_size >= 4):
+                        trackers = meta.trackers.split(",") if isinstance(meta.trackers, str) else meta.trackers
+                        if not valid or all(tracker == "HDBITS" for tracker in trackers):
+                            return valid, torrent_path
+                    if reuse_torrent.pieces >= 5000 and reuse_torrent.piece_size < 4294304 and (max_piece_size is None or max_piece_size >= 4):
                         logger.debug("[bold red]Torrent needs to have less than 5000 pieces with a 4 MiB piece size")
                         valid = False
                     elif (

--- a/src/clients.py
+++ b/src/clients.py
@@ -16,7 +16,7 @@ from src.console import logger
 from src.meta import Meta
 from src.torrent_clients import DelugeClientMixin, QbittorrentClientMixin, RtorrentClientMixin, TransmissionClientMixin
 from src.torrent_clients.path_utils import coerce_str_list, is_path_under
-from src.torrentcreate import SUBTITLE_EXTENSIONS
+from src.torrentcreate import SUBTITLE_EXTENSIONS, hdbits_pieces_allowed
 
 # Secure XML-RPC client using defusedxml to prevent XML attacks
 defusedxml.xmlrpc.monkey_patch()
@@ -623,7 +623,11 @@ class Clients(QbittorrentClientMixin, RtorrentClientMixin, DelugeClientMixin, Tr
 
                     # Piece size and count validations
                     max_piece_size = meta.max_piece_size
-                    if reuse_torrent.pieces >= 5000 and reuse_torrent.piece_size < 4294304 and (max_piece_size is None or max_piece_size >= 4):
+                    if "HDBITS" in meta.trackers:
+                        valid = not wrong_file and hdbits_pieces_allowed(piece_size, reuse_torrent.pieces, reuse_torrent.size)
+                        if not valid:
+                            logger.debug("[bold red]Torrent does not meet HDBits piece limits or file requirements")
+                    elif reuse_torrent.pieces >= 5000 and reuse_torrent.piece_size < 4294304 and (max_piece_size is None or max_piece_size >= 4):
                         logger.debug("[bold red]Torrent needs to have less than 5000 pieces with a 4 MiB piece size")
                         valid = False
                     elif (

--- a/src/torrentcreate.py
+++ b/src/torrentcreate.py
@@ -32,6 +32,26 @@ PIECE_SIZE_MAX = 134_217_728  # 128 MiB
 SUBTITLE_EXTENSIONS = (".srt", ".sub", ".vtt", ".ssa", ".ass", ".idx")
 
 
+def hdbits_pieces_allowed(piece_size: int, pieces: int, total_size: int) -> bool:
+    if piece_size <= 0 or piece_size & (piece_size - 1) or pieces <= 0:
+        return False
+    if piece_size <= 2 * 1024**2:
+        return pieces <= 4000
+    if piece_size in (4 * 1024**2, 8 * 1024**2):
+        return pieces <= 30000
+    return piece_size == 16 * 1024**2 or (piece_size == 32 * 1024**2 and total_size > 1024**4)
+
+
+def hdbits_piece_size(total_size: int) -> int:
+    """Choose a compliant size for new hashes; never use this to reject reuse."""
+    if total_size > 8 * 1024**3:
+        return 16 * 1024**2
+    piece_size = 32768
+    while not hdbits_pieces_allowed(piece_size, max(1, (total_size + piece_size - 1) // piece_size), total_size):
+        piece_size *= 2
+    return piece_size
+
+
 def calculate_piece_size(
     total_size: int,
     min_size: int,
@@ -114,6 +134,9 @@ class TorrentCreator:
         meta: Meta,
         piece_size: int | None = None,
     ) -> int:
+        if "HDBITS" in meta.trackers:
+            return hdbits_piece_size(total_size)
+
         # Set max_size
         if piece_size:
             try:
@@ -280,6 +303,18 @@ class TorrentCreator:
                     exclude = ["*.*", "*sample.mkv", "!sample*.*"] if not meta.is_disc else []
                     include = ["*.mkv", "*.mp4", "*.ts"] if not meta.is_disc else []
 
+                # Calculate initial size
+                def calculate_size() -> int:
+                    size = 0
+                    if Path(path).is_file():
+                        size = Path(path).stat().st_size
+                    elif Path(path).is_dir():
+                        for root, _dirs, files in os.walk(path):
+                            size += sum((Path(root) / f).stat().st_size for f in files if (Path(root) / f).is_file())
+                    return size
+
+                initial_size = await asyncio.to_thread(calculate_size)
+
                 # If using mkbrr, run the external application
                 if meta.mkbrr:
                     try:
@@ -305,7 +340,10 @@ class TorrentCreator:
                         if meta.randomized >= 1:
                             cmd.extend(["-e"])
 
-                        if piece_size and not tracker_url:
+                        if "HDBITS" in meta.trackers:
+                            power = max(16, hdbits_piece_size(initial_size).bit_length() - 1)
+                            cmd.extend(["-l", str(power)])
+                        elif piece_size and not tracker_url:
                             try:
                                 max_size_bytes = piece_size * 1024 * 1024
 
@@ -427,18 +465,6 @@ class TorrentCreator:
                         logger.info("[yellow]Falling back to CustomTorrent method")
                         meta.mkbrr = False
                 overall_start_time = time.time()
-
-                # Calculate initial size
-                def calculate_size() -> int:
-                    size = 0
-                    if Path(path).is_file():
-                        size = Path(path).stat().st_size
-                    elif Path(path).is_dir():
-                        for root, _dirs, files in os.walk(path):
-                            size += sum((Path(root) / f).stat().st_size for f in files if (Path(root) / f).is_file())
-                    return size
-
-                initial_size = await asyncio.to_thread(calculate_size)
 
                 piece_size = cls.calculate_piece_size(initial_size, 32768, 134217728, meta, piece_size=piece_size)
 

--- a/src/trackers/hdbits.py
+++ b/src/trackers/hdbits.py
@@ -2,6 +2,7 @@
 import asyncio
 import json
 import re
+import shutil
 from pathlib import Path
 from typing import Any, cast
 from urllib.parse import quote, urlparse
@@ -9,16 +10,18 @@ from urllib.parse import quote, urlparse
 import aiofiles
 import httpx
 from rich.markup import escape
+from torf import Torrent
 from unidecode import unidecode
 
 from src.bbcode import BBCODE
+from src.clients import Clients
 from src.cogs.redaction import Redaction
 from src.console import console, logger
 from src.description_review import get_base_description
 from src.exceptions import *  # noqa F403
 from src.meta import Meta
 from src.temp_paths import screenshots_dir
-from src.torrentcreate import TorrentCreator
+from src.torrentcreate import TorrentCreator, hdbits_pieces_allowed
 from src.trackers.common import Common
 
 Config = dict[str, Any]
@@ -255,28 +258,39 @@ class HDBits:
         async with aiofiles.open(f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/[{self.tracker}]DESCRIPTION.txt", encoding="utf-8") as desc_file:
             hdb_desc = await desc_file.read()
 
-        base_piece_mb = meta.base_torrent_piece_mb or 0
         torrent_file_path = f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/[{self.tracker}].torrent"
+        tracker_config = self.config.get("TRACKERS", {}).get(self.tracker, {})
+        torrent_dir = Path(meta.base_dir) / "tmp" / meta.uuid
+        base_name = await common.get_torrent_filename(meta, tracker_config)
+        base_torrent = Torrent.read(torrent_dir / f"{base_name}.torrent")
+        torrent_name = base_name
+        if not hdbits_pieces_allowed(base_torrent.piece_size, base_torrent.pieces, base_torrent.size):
+            search_meta = meta.copy()
+            search_meta.trackers = [self.tracker]
+            if base_name != "BASE_SUBS":
+                search_meta.subtitle_files = []
+            clients = Clients(self.config)
+            candidate_path = await clients.find_existing_torrent(search_meta)
+            if candidate_path and search_meta.subtitle_files and not clients._torrent_includes_all_local_subtitles(candidate_path, search_meta):
+                candidate_path = None
 
-        # Check if the piece size exceeds 16 MiB and regenerate the torrent if needed
-        if base_piece_mb > 16 and not meta.nohash:
-            logger.info(f"{self.tracker}: [red]Piece size is OVER 16M and does not work on {self.tracker}. Generating a new .torrent")
-            hdb_config = self.config.get("TRACKERS", {}).get("HDBITS", {})
-            hdb_config_dict = cast(dict[str, Any], hdb_config) if isinstance(hdb_config, dict) else {}
-            tracker_url = str(hdb_config_dict.get("announce_url", "https://fake.tracker")).strip()
-            piece_size = 16
-            torrent_create = f"[{self.tracker}]"
-            try:
-                cooldown = int(self.config.get("DEFAULT", {}).get("rehash_cooldown", 0) or 0)
-            except ValueError, TypeError:
-                cooldown = 0
-            if cooldown > 0:
-                await asyncio.sleep(cooldown)  # Small cooldown before rehashing
+            torrent_name = f"[{self.tracker}]"
+            if candidate_path:
+                await asyncio.to_thread(shutil.copyfile, candidate_path, torrent_dir / f"{torrent_name}.torrent")
+            else:
+                logger.info("HDBITS: [yellow]No torrent meeting the piece limits found. Generating a new .torrent")
+                try:
+                    cooldown = int(self.config.get("DEFAULT", {}).get("rehash_cooldown", 0) or 0)
+                except ValueError, TypeError:
+                    cooldown = 0
+                if cooldown > 0:
+                    await asyncio.sleep(cooldown)
+                if base_name == "BASE_SUBS":
+                    torrent_name += "_BASE_SUBS"
+                tracker_url = str(tracker_config.get("announce_url") or "https://fake.tracker").strip()
+                await TorrentCreator.create_torrent(search_meta, str(meta.path), torrent_name, tracker_url=tracker_url)
 
-            await TorrentCreator.create_torrent(meta, str(meta.path), torrent_create, tracker_url=tracker_url, piece_size=piece_size)
-            await common.create_torrent_for_upload(meta, self.tracker, self.source_flag, torrent_filename=torrent_create)
-        else:
-            await common.create_torrent_for_upload(meta, self.tracker, self.source_flag)
+        await common.create_torrent_for_upload(meta, self.tracker, self.source_flag, torrent_filename=torrent_name)
 
         # Proceed with the upload process
         async with aiofiles.open(torrent_file_path, "rb") as torrent_file:

--- a/tests/test_hdbits_pieces.py
+++ b/tests/test_hdbits_pieces.py
@@ -1,0 +1,160 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from torf import Torrent
+
+from src.clients import Clients
+from src.meta import Meta
+from src.torrentcreate import TorrentCreator, hdbits_pieces_allowed
+from src.trackers.hdbits import HDBits
+
+MIB = 1024**2
+GIB = 1024**3
+TIB = 1024**4
+
+
+def write_torrent(path, piece_size, size, name="release.mkv"):
+    torrent = Torrent()
+    count = (size + piece_size - 1) // piece_size
+    torrent.metainfo["info"] = {"name": name, "length": size, "piece length": piece_size, "pieces": b"x" * (20 * count)}
+    torrent.write(path, overwrite=True)
+    return torrent
+
+
+@pytest.mark.parametrize(
+    ("piece_size", "count", "size", "allowed"),
+    [
+        (32768, 4000, 4000 * 32768, True),
+        (32768, 4001, 4001 * 32768, False),
+        (2 * MIB, 4000, 8000 * MIB, True),
+        (2 * MIB, 4001, 8002 * MIB, False),
+        (4 * MIB, 30000, 120000 * MIB, True),
+        (4 * MIB, 30001, 120004 * MIB, False),
+        (8 * MIB, 30000, 240000 * MIB, True),
+        (8 * MIB, 30001, 240008 * MIB, False),
+        (16 * MIB, 65536, TIB, True),
+        (32 * MIB, 32768, TIB, False),
+        (32 * MIB, 32769, TIB + 1, True),
+        (64 * MIB, 32768, 2 * TIB, False),
+    ],
+)
+def test_hdbits_piece_limits(piece_size, count, size, allowed):
+    assert hdbits_pieces_allowed(piece_size, count, size) is allowed
+
+
+@pytest.mark.parametrize("size", [1, 4000 * 32768, 4000 * 32768 + 1, 8 * GIB, 8 * GIB + 1, TIB + 1])
+def test_hashing_uses_compliant_recommendation_even_with_small_configured_max(size):
+    chosen = TorrentCreator.calculate_piece_size(size, 32768, 128 * MIB, Meta(trackers=["HDBITS"]), piece_size=1)
+    assert hdbits_pieces_allowed(chosen, (size + chosen - 1) // chosen, size)
+    if size > 8 * GIB:
+        assert chosen == 16 * MIB
+
+
+@pytest.fixture
+def setup_release(tmp_path, monkeypatch):
+    directory = tmp_path / "tmp" / "release"
+    directory.mkdir(parents=True)
+    media = tmp_path / "release.mkv"
+    media.touch()
+    meta = Meta(base_dir=str(tmp_path), uuid="release", path=str(media), filelist=[str(media)], trackers=["HDBITS"], category="MOVIE")
+    meta.debug = True
+    meta.video = str(media)
+    meta.tracker_status = {"HDBITS": {}}
+    for filename in ("[HDBITS]DESCRIPTION.txt", "MEDIAINFO_CLEANPATH.txt"):
+        (directory / filename).write_text("")
+    for method in ("edit_desc", "get_name", "get_type_category_id", "get_type_codec_id", "get_type_medium_id", "get_tags"):
+        monkeypatch.setattr(HDBits, method, AsyncMock(return_value=1))
+    config = {"DEFAULT": {"default_torrent_client": "none"}, "TORRENT_CLIENTS": {}, "TRACKERS": {"HDBITS": {}}}
+    return directory, meta, config
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("piece_size", "size"), [(2 * MIB, 4000 * 2 * MIB), (4 * MIB, 30000 * 4 * MIB), (8 * MIB, 30000 * 8 * MIB), (32 * MIB, TIB + 1)])
+async def test_upload_reuses_allowed_base_without_search_or_hash(setup_release, monkeypatch, piece_size, size):
+    directory, meta, config = setup_release
+    original = write_torrent(directory / "BASE.torrent", piece_size, size)
+    search = AsyncMock(side_effect=AssertionError("must not search"))
+    create = AsyncMock(side_effect=AssertionError("must not rehash"))
+    monkeypatch.setattr(Clients, "find_existing_torrent", search)
+    monkeypatch.setattr(TorrentCreator, "create_torrent", create)
+    assert await HDBits(config).upload(meta) is True
+    result = Torrent.read(directory / "[HDBITS].torrent")
+    assert result.piece_size == piece_size
+    assert result.metainfo["info"]["pieces"] == original.metainfo["info"]["pieces"]
+
+
+@pytest.mark.asyncio
+async def test_upload_finds_alternative_before_rehash(setup_release, tmp_path, monkeypatch):
+    directory, meta, config = setup_release
+    size = 10 * GIB
+    write_torrent(directory / "BASE.torrent", 2 * MIB, size)
+    alternative = tmp_path / "alternative.torrent"
+    write_torrent(alternative, 4 * MIB, size)
+    search = AsyncMock(return_value=str(alternative))
+    monkeypatch.setattr(Clients, "find_existing_torrent", search)
+    monkeypatch.setattr(TorrentCreator, "create_torrent", AsyncMock(side_effect=AssertionError("must not rehash")))
+    assert await HDBits(config).upload(meta) is True
+    assert Torrent.read(directory / "[HDBITS].torrent").piece_size == 4 * MIB
+    search.assert_awaited_once()
+    assert Torrent.read(directory / "BASE.torrent").piece_size == 2 * MIB
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("nohash", [False, True])
+async def test_upload_forces_rehash_only_after_failed_search(setup_release, monkeypatch, nohash):
+    directory, meta, config = setup_release
+    meta.nohash = nohash
+    size = 10 * GIB
+    write_torrent(directory / "BASE.torrent", 2 * MIB, size)
+    search = AsyncMock(return_value=None)
+    monkeypatch.setattr(Clients, "find_existing_torrent", search)
+
+    async def create(hash_meta, path, output, **kwargs):
+        search.assert_awaited_once()
+        assert hash_meta.trackers == ["HDBITS"]
+        write_torrent(directory / f"{output}.torrent", 16 * MIB, size)
+
+    hashing = AsyncMock(side_effect=create)
+    monkeypatch.setattr(TorrentCreator, "create_torrent", hashing)
+    assert await HDBits(config).upload(meta) is True
+    hashing.assert_awaited_once()
+    assert Torrent.read(directory / "[HDBITS].torrent").piece_size == 16 * MIB
+
+
+@pytest.mark.asyncio
+async def test_client_search_skips_invalid_hash_and_uses_next_client(setup_release, tmp_path):
+    directory, meta, config = setup_release
+    meta.torrenthash = "abc"
+    size = 120000 * MIB
+    first, second = tmp_path / "first", tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    write_torrent(first / "abc.torrent", 2 * MIB, size)
+    write_torrent(second / "abc.torrent", 4 * MIB, size)
+    config["DEFAULT"].update(default_torrent_client="first", searching_client_list=["first", "second"])
+    config["TORRENT_CLIENTS"] = {name: {"torrent_client": "qbit", "torrent_storage_dir": str(path)} for name, path in [("first", first), ("second", second)]}
+    assert await Clients(config).find_existing_torrent(meta) == str(second / "abc.torrent")
+    assert meta.reuse_torrent_client == "second"
+    assert (first / "abc.torrent").exists()
+
+
+@pytest.mark.asyncio
+async def test_mkbrr_gets_recommended_size_even_with_tracker_url(setup_release, monkeypatch):
+    directory, meta, config = setup_release
+    with Path(meta.path).open("wb") as media:
+        media.truncate(8 * GIB + 1)
+    meta.mkbrr = True
+    monkeypatch.setattr(TorrentCreator, "get_mkbrr_path", lambda _: meta.path)
+    commands = []
+
+    def process(command, **kwargs):
+        commands.append(command)
+        write_torrent(directory / "BASE.torrent", 16 * MIB, 8 * GIB + 1)
+        return SimpleNamespace(stdout=[], wait=lambda: 0)
+
+    monkeypatch.setattr("src.torrentcreate.subprocess.Popen", process)
+    await TorrentCreator.create_torrent(meta, meta.path, "BASE", tracker_url="https://fake.tracker", piece_size=1)
+    assert commands[0][commands[0].index("-l") + 1] == "24"
+    assert meta.mkbrr

--- a/tests/test_hdbits_pieces.py
+++ b/tests/test_hdbits_pieces.py
@@ -141,6 +141,32 @@ async def test_client_search_skips_invalid_hash_and_uses_next_client(setup_relea
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("trackers", "piece_size", "pieces", "max_piece_size", "expected"),
+    [
+        (["HDBITS"], 16 * MIB, 12001, None, True),
+        (["OTHER"], 16 * MIB, 12001, None, False),
+        (["HDBITS", "OTHER"], 16 * MIB, 12001, None, False),
+        (["OTHER", "HDBITS"], 16 * MIB, 12000, None, False),
+        (["HDBITS", "OTHER"], 16 * MIB, 11999, None, True),
+        (["HDBITS", "OTHER"], 16 * MIB, 12001, 0, True),
+        (["OTHER"], 2 * MIB, 4001, None, True),
+        (["HDBITS", "OTHER"], 2 * MIB, 4001, None, False),
+        ("HDBITS", 16 * MIB, 12001, None, True),
+        ("HDBITS,OTHER", 16 * MIB, 12001, None, False),
+    ],
+)
+async def test_mixed_tracker_reuse_preserves_generic_and_hdbits_limits(setup_release, trackers, piece_size, pieces, max_piece_size, expected):
+    directory, meta, config = setup_release
+    path = directory / "candidate.torrent"
+    torrent = write_torrent(path, piece_size, pieces * piece_size)
+    meta.trackers = trackers
+    meta.max_piece_size = max_piece_size
+    valid, _ = await Clients(config).is_valid_torrent(meta, str(path), torrent.infohash, "qbit", {})
+    assert valid is expected
+
+
+@pytest.mark.asyncio
 async def test_mkbrr_gets_recommended_size_even_with_tracker_url(setup_release, monkeypatch):
     directory, meta, config = setup_release
     with Path(meta.path).open("wb") as media:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enforces HDBits-specific piece-size, piece-count, and total-size requirements.
  - Applies HDBits-compliant piece sizing during torrent creation and upload.
  - Reuses compatible existing torrents when available, avoiding unnecessary rehashing.
  - Searches for alternative compatible torrents before generating a new one.

- **Bug Fixes**
  - Prevents uploads with torrents that do not meet HDBits validation requirements.
  - Ensures uploads use the correctly resolved torrent.
  - Preserves standard validation for torrents shared across HDBits and other trackers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->