### PR TITLE
fix(metadata): allow long release group tags

### DIFF
--- a/src/tags.py
+++ b/src/tags.py
@@ -112,11 +112,8 @@ async def get_tag(video: str, meta: Meta, season_pack_check: bool = False) -> st
                             if merged and (merged in title_norm or merged in author_norm):
                                 release_group = None
 
-            if release_group:
-                if "Z0N3" in release_group:
-                    release_group = release_group.replace("Z0N3", "D-Z0N3")
-                if not meta.scene and len(release_group) > 12:
-                    release_group = None
+            if release_group and "Z0N3" in release_group:
+                release_group = release_group.replace("Z0N3", "D-Z0N3")
             logger.debug(f"Non-anime regex match: {release_group}")
 
     # If regex patterns didn't work, fall back to guessit

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -52,3 +52,12 @@ async def test_release_group_after_dts_hd_audio_is_preserved():
     tag = await get_tag(filename, Meta(category="MOVIE", uuid=filename))
 
     assert tag == "-GROUP"
+
+
+@pytest.mark.asyncio
+async def test_long_release_group_is_preserved_without_scene_detection():
+    filename = "The.Movie.2011.1080p.WEB-DL.DD2.0.H.264-10GaugeSlugBlaster.mkv"
+
+    tag = await get_tag(filename, Meta(category="MOVIE", uuid=filename))
+
+    assert tag == "-10GaugeSlugBlaster"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release-group tag extraction for non-anime files.
  - Preserved longer release-group names instead of clearing them.
  - Applied the `Z0N3` to `D-Z0N3` normalization consistently when a release group is present.

- **Tests**
  - Added regression coverage to verify that long release-group names are retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->