### PR TITLE
fix: remove image resize tags for NexusPHP

### DIFF
--- a/src/get_desc.py
+++ b/src/get_desc.py
@@ -32,6 +32,20 @@ from src.tracker_images import get_tracker_image_collection, has_tracker_image_c
 from src.trackers.common import Common
 from src.uploadscreens import UploadScreensManager
 
+NEXUSPHP_TRACKERS = {
+    "1PTBA",
+    "LAJIDUI",
+    "LEMONHD",
+    "LONGPT",
+    "PTCAFE",
+    "PTFANS",
+    "PTGTK",
+    "PTZONE",
+    "RAILGUNPT",
+    "XINGYUNGEPT",
+    "NEXUSPHP",
+}
+
 
 def html_to_bbcode(text: str) -> str:
     """Convert HTML tags to BBCode format."""
@@ -2190,20 +2204,7 @@ class DescriptionBuilder:
         if not thumb_size:
             thumb_size = self._get_int_config("thumbnail_size", 350)
 
-        nexusphp_trackers = {
-            "1PTBA",
-            "LAJIDUI",
-            "LEMONHD",
-            "LONGPT",
-            "PTCAFE",
-            "PTFANS",
-            "PTGTK",
-            "PTZONE",
-            "RAILGUNPT",
-            "XINGYUNGEPT",
-            "NEXUSPHP",
-        }
-        if self.tracker in nexusphp_trackers:
+        if self.tracker in NEXUSPHP_TRACKERS:
             return f"[img]{raw_url}[/img]"
         if self.tracker == "HDTORRENTS":
             return f"<a href='{raw_url}'><img src='{img_url}' height=137></a> "
@@ -2221,6 +2222,9 @@ class DescriptionBuilder:
 
     def tracker_specific_formats(self, tracker: str, description: str) -> str:
         bbcode = BBCODE()
+        if tracker in NEXUSPHP_TRACKERS:
+            description = bbcode.remove_img_resize(description)
+
         if tracker in {"ANTHELION", "BJSHARE", "BRASILTRACKER", "GREATPOSTERWALL"}:
             description = bbcode.clamp_size_tags(description)
 

--- a/tests/test_bbcode.py
+++ b/tests/test_bbcode.py
@@ -28,6 +28,25 @@ def test_tracker_specific_formats_only_clamps_gazelle_descriptions() -> None:
     assert builder.tracker_specific_formats("HDTORRENTS", "[size=16]Text[/size]") == "[size=16]Text[/size]"
 
 
+def test_tracker_specific_formats_removes_image_resize_for_nexusphp_trackers() -> None:
+    builder = object.__new__(DescriptionBuilder)
+    description = "[img=450]https://example.test/image.jpg[/img]"
+
+    for tracker in (
+        "1PTBA",
+        "LAJIDUI",
+        "LEMONHD",
+        "LONGPT",
+        "PTCAFE",
+        "PTFANS",
+        "PTGTK",
+        "PTZONE",
+        "RAILGUNPT",
+        "XINGYUNGEPT",
+    ):
+        assert builder.tracker_specific_formats(tracker, description) == "[img]https://example.test/image.jpg[/img]"
+
+
 def test_clean_unit3d_description_removes_line_wrapped_align_center_signature() -> None:
     description = """Release notes
 [align=center]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved description formatting for NexusPHP trackers by removing image width settings while preserving image links.

* **Bug Fixes**
  * Corrected tracker-specific formatting so resized image tags are handled consistently across supported NexusPHP trackers.

* **Tests**
  * Added coverage verifying that image width arguments are removed without changing the underlying image URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->