### PR TITLE
fix(images): isolate hosts and reuse cache

### DIFF
--- a/src/rehostimages.py
+++ b/src/rehostimages.py
@@ -450,7 +450,7 @@ async def _check_hosts(
     if tracker == "covers":
         reuploaded_images_path = Path(meta.base_dir) / "tmp" / meta.uuid / "covers.json"
     else:
-        reuploaded_images_path = Path(meta.base_dir) / "tmp" / meta.uuid / "reuploaded_images.json"
+        reuploaded_images_path = screenshots_dir(meta.base_dir, meta.uuid) / "reuploaded_images.json"
     reuploaded_images: list[dict[str, str]] = []
 
     if Path(reuploaded_images_path).exists():

--- a/src/trackers/GAZELLE/greatposterwall.py
+++ b/src/trackers/GAZELLE/greatposterwall.py
@@ -18,6 +18,7 @@ from src.languages import languages_manager
 from src.meta import Meta
 from src.rehostimages import RehostImagesManager
 from src.tmdb import TmdbManager
+from src.tracker_images import get_tracker_image_collection, set_tracker_image_collection
 from src.trackers.common import Common
 
 
@@ -245,7 +246,7 @@ class GreatPosterWall:
 
     async def rehost_unapproved_images(self, meta: Meta) -> None:
         """Import public image URLs to GPW's KShare host before the normal host check."""
-        image_list = meta.image_list
+        image_list = get_tracker_image_collection(meta, self.tracker, "screenshots")
         if not isinstance(image_list, list) or not image_list:
             return
         if not self.api_key:
@@ -284,7 +285,7 @@ class GreatPosterWall:
                 rehosted_image.update({"img_url": hosted_url, "raw_url": hosted_url, "web_url": hosted_url})
                 rehosted_images.append(rehosted_image)
 
-        meta.image_list = rehosted_images
+        set_tracker_image_collection(meta, self.tracker, "screenshots", rehosted_images)
 
     async def check_image_hosts(self, meta: Meta) -> None:
         # Rule: 2.2.1. Screenshots: They have to be saved at kshare.club, pixhost.to, img.pterclub.com, yes.ilikeshots.club, imgbox.com, s3.pterclub.com

--- a/tests/test_greatposterwall_image_host.py
+++ b/tests/test_greatposterwall_image_host.py
@@ -7,6 +7,7 @@ import asyncio
 import httpx
 
 from src.meta import Meta
+from src.tracker_images import get_tracker_image_collection
 from src.trackers.GAZELLE.greatposterwall import GreatPosterWall
 
 
@@ -54,6 +55,14 @@ def test_greatposterwall_rehosts_only_unapproved_urls(monkeypatch):
     asyncio.run(tracker.rehost_unapproved_images(meta))
 
     assert meta.image_list == [
+        {"img_url": "https://lostimg.cc/example.png", "raw_url": "https://lostimg.cc/example.png", "web_url": "https://lostimg.cc/example.png"},
+        {
+            "img_url": "https://img2.kshare.club/gpw/user/1/kept.png",
+            "raw_url": "https://img2.kshare.club/gpw/user/1/kept.png",
+            "web_url": "https://img2.kshare.club/gpw/user/1/kept.png",
+        },
+    ]
+    assert get_tracker_image_collection(meta, tracker.tracker, "screenshots") == [
         {
             "img_url": "https://img2.kshare.club/gpw/user/1/test.png",
             "raw_url": "https://img2.kshare.club/gpw/user/1/test.png",
@@ -76,6 +85,7 @@ def test_greatposterwall_leaves_images_unchanged_without_api_key():
     asyncio.run(tracker.rehost_unapproved_images(meta))
 
     assert meta.image_list == [{"raw_url": "https://lostimg.cc/example.png"}]
+    assert tracker.tracker not in meta.tracker_image_collections
 
 
 def test_greatposterwall_accepts_pterclub_s3_host():

--- a/tests/test_rehostimages.py
+++ b/tests/test_rehostimages.py
@@ -3,6 +3,7 @@
 # ruff: noqa: S101
 
 import asyncio
+import json
 from pathlib import Path
 from typing import ClassVar
 from unittest.mock import AsyncMock
@@ -94,6 +95,43 @@ def test_music_does_not_rehost_missing_screenshots() -> None:
     asyncio.run(check_tracker_image_hosts(Meta(category="MUSIC"), tracker))
 
     tracker.rehost_images_manager.check_policy.assert_not_awaited()
+
+
+def test_reuses_rehosted_images_from_screenshot_cache(tmp_path: Path) -> None:
+    screenshots_path = tmp_path / "tmp" / "release" / "screenshots"
+    screenshots_path.mkdir(parents=True)
+    cached_images = [
+        {
+            "img_url": "https://i.ibb.co/cached.png",
+            "raw_url": "https://i.ibb.co/cached.png",
+            "web_url": "https://ibb.co/cached",
+        }
+    ]
+    (screenshots_path / "reuploaded_images.json").write_text(json.dumps(cached_images), encoding="utf-8")
+
+    manager = RehostImagesManager({"DEFAULT": {"img_host_1": "imgbb"}})
+    manager.uploadscreens_manager.upload_screens = AsyncMock()
+    meta = Meta(
+        base_dir=str(tmp_path),
+        uuid="release",
+        imghost="lostimg",
+        image_list=[{"raw_url": "https://lostimg.cc/original.png"}],
+    )
+
+    result, retry_mode, images_reuploaded = asyncio.run(
+        manager.check_hosts(
+            meta,
+            "TEST",
+            {"i.ibb.co": "imgbb", "lostimg.cc": "lostimg"},
+            approved_image_hosts=["imgbb"],
+        )
+    )
+
+    assert result == cached_images
+    assert not retry_mode
+    assert not images_reuploaded
+    assert meta.image_list == [{"raw_url": "https://lostimg.cc/original.png"}]
+    manager.uploadscreens_manager.upload_screens.assert_not_awaited()
 
 
 def test_rehosts_menu_and_spectrogram_images_without_touching_main_screens(tmp_path: Path):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Rehosted images are now correctly reused from the screenshots collection, preventing unnecessary repeat uploads.
  - GreatPosterWall image rehosting now preserves results in the appropriate tracker-specific screenshot collection.
  - Cached rehosted images no longer alter the original image list or trigger additional processing.
  - Image-hosting behavior is more consistent when no API key is configured.

- **Tests**
  - Added regression coverage for cached image reuse and tracker-specific image registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->