### PR TITLE
fix(description): wrap Blu-ray description links in BBCode URL tags

### DIFF
--- a/src/get_desc.py
+++ b/src/get_desc.py
@@ -1405,6 +1405,8 @@ class DescriptionBuilder:
         if bluray:
             release_url, cover_images = await self.get_bluray_section(meta)
             if release_url:
+                if self.tracker not in ("TORRENTLEECH", "IMMORTALSEED"):
+                    release_url = f"[url]{release_url}[/url]"
                 desc_parts.append(f"[center]{release_url}[/center]")
             if cover_images:
                 desc_parts.append(f"[center]{cover_images}[/center]\n")


### PR DESCRIPTION
ATH stopped making links clickable automatically

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Blu-ray descriptions now format release links appropriately for supported trackers, while preserving the existing plain-text format for TorrentLeech and ImmortalSeed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->