### PR TITLE
fix(nexusphp): update audio codec checks from `ddp` to `dd+`

### DIFF
--- a/src/trackers/NEXUSPHP/lajidui.py
+++ b/src/trackers/NEXUSPHP/lajidui.py
@@ -315,7 +315,7 @@ class Lajidui(NEXUSPHP):
             return 10
         if "lpcm" in audio_codec:
             return 11
-        if "ddp" in audio_codec:
+        if "dd+" in audio_codec:
             return 12
         if "dd" in audio_codec:
             return 13

--- a/src/trackers/NEXUSPHP/lemonhd.py
+++ b/src/trackers/NEXUSPHP/lemonhd.py
@@ -148,7 +148,7 @@ class LemonHD(NEXUSPHP):
             return 3
         if "dts" in audio_codec:
             return 5
-        if "ddp" in audio_codec or "eac3" in audio_codec or "e-ac-3" in audio_codec:
+        if "dd+" in audio_codec or "eac3" in audio_codec or "e-ac-3" in audio_codec:
             return 7
         if "dd" in audio_codec or "ac3" in audio_codec or "ac-3" in audio_codec:
             return 6

--- a/src/trackers/NEXUSPHP/longpt.py
+++ b/src/trackers/NEXUSPHP/longpt.py
@@ -156,6 +156,8 @@ class LongPT(NEXUSPHP):
             return 13
         if "lpcm" in audio_codec:
             return 14
+        if "dd+" in audio_codec:
+            return 10
         if "dd" in audio_codec:
             return 15
         if "alac" in audio_codec:
@@ -178,9 +180,6 @@ class LongPT(NEXUSPHP):
             return 8
         if "atmos" in audio_codec:
             return 9
-        if "dd+" in audio_codec:
-            return 10
-
         return 11
 
     def get_group_tag(self, meta: Meta) -> int:

--- a/src/trackers/NEXUSPHP/longpt.py
+++ b/src/trackers/NEXUSPHP/longpt.py
@@ -178,7 +178,7 @@ class LongPT(NEXUSPHP):
             return 8
         if "atmos" in audio_codec:
             return 9
-        if "ddp" in audio_codec:
+        if "dd+" in audio_codec:
             return 10
 
         return 11
@@ -201,7 +201,7 @@ class LongPT(NEXUSPHP):
         chinese_audio = 5
         chinese_subtitle = 6
         diy = 4
-        english_audio = 9
+        english_subs = 9
         hdr = 7
         reposting_prohibited = 1
 
@@ -209,7 +209,7 @@ class LongPT(NEXUSPHP):
         subtitle_tracks = meta.subtitle_languages or []
         mhdr = meta.hdr
 
-        checkboxes = []
+        checkboxes: list[str] = []
 
         if meta.exclusive:
             checkboxes.append(str(reposting_prohibited))
@@ -217,8 +217,8 @@ class LongPT(NEXUSPHP):
         if "Chinese" in audio_tracks or "Mandarin" in audio_tracks:
             checkboxes.append(str(chinese_audio))
 
-        if "English" in audio_tracks:
-            checkboxes.append(str(english_audio))
+        if "English" in subtitle_tracks:
+            checkboxes.append(str(english_subs))
 
         if "Chinese" in subtitle_tracks or "Mandarin" in subtitle_tracks:
             checkboxes.append(str(chinese_subtitle))

--- a/src/trackers/NEXUSPHP/ptzone.py
+++ b/src/trackers/NEXUSPHP/ptzone.py
@@ -161,7 +161,7 @@ class PTZone(NEXUSPHP):
             return 5
         if "aac" in audio_codec:
             return 6
-        if "ddp" in audio_codec or "eac3" in audio_codec or "e-ac-3" in audio_codec:
+        if "dd+" in audio_codec or "eac3" in audio_codec or "e-ac-3" in audio_codec:
             return 12
         if "dd" in audio_codec or "ac3" in audio_codec or "ac-3" in audio_codec:
             return 11

--- a/src/trackers/NEXUSPHP/xingyungept.py
+++ b/src/trackers/NEXUSPHP/xingyungept.py
@@ -161,7 +161,7 @@ class XingyungePT(NEXUSPHP):
             return 8
         if "lpcm" in audio_codec or "pcm" in audio_codec:
             return 9
-        if "ddp" in audio_codec or "eac3" in audio_codec or "e-ac-3" in audio_codec:
+        if "dd+" in audio_codec or "eac3" in audio_codec or "e-ac-3" in audio_codec:
             return 11
         if "dd" in audio_codec or "ac3" in audio_codec or "ac-3" in audio_codec:
             return 10


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Dolby Digital Plus detection across multiple trackers by supporting the standard `dd+` audio label alongside existing recognized formats.
  - Preserved accurate classification of other Dolby Digital audio formats while assigning `dd+` labels to the appropriate codec categories.
  - Corrected subtitle checkbox handling on one tracker so English subtitles are identified instead of English audio.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->