### PR TITLE
feat(webui): display tracker codebase in expanded tracker details

### DIFF
--- a/tests/test_webui_trackers.py
+++ b/tests/test_webui_trackers.py
@@ -4,6 +4,20 @@ import web_ui.server as server
 from src.trackers.retroflix import RetroFlix
 
 
+def test_tracker_codebase_uses_known_module_families_only() -> None:
+    for module, expected in (
+        ("src.trackers.UNIT3D.blutopia", "UNIT3D"),
+        ("src.trackers.GAZELLE.orpheus", "Gazelle"),
+        ("src.trackers.NEXUSPHP.oneptba", "NexusPHP"),
+        ("src.trackers.AVISTAZ.avistaz", "AvistaZ"),
+        ("src.trackers.USENET.nzbgeek", None),
+        ("src.trackers.broadcasthenet", None),
+        ("unrelated.trackers.GAZELLE.example", None),
+    ):
+        tracker_class = type("Tracker", (), {"__module__": module})
+        assert server._tracker_codebase(tracker_class) == expected
+
+
 def test_tracker_destination_type_uses_existing_usenet_marker() -> None:
     class TorrentTracker:
         pass

--- a/web_ui/server.py
+++ b/web_ui/server.py
@@ -4750,6 +4750,14 @@ def _configured_cookie_tracker_names(
     return configured
 
 
+def _tracker_codebase(tracker_class: Any) -> str | None:
+    """Expose known tracker families without guessing from ungrouped modules."""
+    module_parts = str(getattr(tracker_class, "__module__", "")).split(".")
+    if len(module_parts) < 4 or module_parts[:2] != ["src", "trackers"]:
+        return None
+    return {"UNIT3D": "UNIT3D", "GAZELLE": "Gazelle", "NEXUSPHP": "NexusPHP", "AVISTAZ": "AvistaZ"}.get(module_parts[2])
+
+
 def _tracker_destination_type(tracker_class: Any) -> str:
     """Return the WebUI destination category without changing tracker IDs."""
     return "usenet" if bool(getattr(tracker_class, "is_usenet", False)) else "torrent"
@@ -5024,6 +5032,7 @@ def get_trackers():
             {
                 "name": tracker_name,
                 "display_name": display_name,
+                "codebase": _tracker_codebase(tracker_class),
                 "base_url": base_url,
                 "favicon": favicon_url,
                 "configured": tracker_name.upper() in configured_trackers,

--- a/web_ui/static/js/config_app.js
+++ b/web_ui/static/js/config_app.js
@@ -6916,9 +6916,22 @@ function TrackerManager({
             </div>
             {isOpen && (
               <div className="ua-config-accordion-panel border-t p-4">
-                <p className="ua-config-service-description mb-4 text-xs">
-                  Tracker code: <code className="font-semibold">{name}</code>
-                </p>
+                <div className="ua-config-service-description mb-4 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs">
+                  <span>
+                    Tracker code: <code className="font-semibold">{name}</code>
+                  </span>
+                  {tracker.codebase && (
+                    <span className="inline-flex items-center gap-2">
+                      <span aria-hidden="true">·</span>
+                      <span>
+                        Codebase:{" "}
+                        <span className="font-semibold">
+                          {tracker.codebase}
+                        </span>
+                      </span>
+                    </span>
+                  )}
+                </div>
                 {trackerView === "available" && (
                   <div className="ua-config-state-panel mb-4 rounded-lg border p-4 text-sm">
                     Enter the required authentication details and choose Save


### PR DESCRIPTION
## Summary

Show a read-only Codebase label alongside Tracker code when a tracker is expanded. The details wrap on smaller screens.

Identify UNIT3D, Gazelle, NexusPHP and AvistaZ from the registered tracker class. Don't show any label for unrecognised tracker codebases or Usenet indexers; instead of guessing.

<img width="330" height="152" alt="image" src="https://github.com/user-attachments/assets/eb460f53-ff2c-4e12-949a-0fe389e298f1" />

## Validation

- Tracker catalogue regression tests pass, including recognized and unknown codebases.
- Verified the label appears only inside expanded tracker details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tracker settings now display the tracker’s codebase when available.
  * Tracker API responses now include codebase information for supported tracker families.

* **Bug Fixes**
  * Improved tracker codebase detection to recognize only supported module patterns and ignore unrelated modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->