### PR TITLE
fix(btn): normalize release names

### DIFF
--- a/src/trackers/broadcasthenet.py
+++ b/src/trackers/broadcasthenet.py
@@ -456,6 +456,21 @@ class BroadcasTheNet:
         name = str(meta.get("scene_name") or meta.name or meta.basename_no_ext or "")
         name = re.sub(r"(?i)\.(avi|mkv|mp4|ts|m4v|m2ts|wmv|mpeg|mpg|vob)$", "", name)
         name = self._clean_name(name)
+        if not meta.scene_name:
+            aka = self._clean_name(str(meta.aka or ""))
+            if aka:
+                name = re.sub(rf"(?i)(?:^|\.){re.escape(aka)}(?=\.|$)", ".", name, count=1)
+
+            hdr = self._clean_name(str(meta.hdr or ""))
+            resolution = self._clean_name(str(meta.resolution or ""))
+            if hdr and resolution:
+                hdr_pattern = rf"(?i)(?:^|\.){re.escape(hdr)}(?=\.|$)"
+                resolution_pattern = rf"(?i)(?:^|\.){re.escape(resolution)}(?=\.|$)"
+                if re.search(hdr_pattern, name) and re.search(resolution_pattern, name):
+                    name = re.sub(hdr_pattern, ".", name, count=1)
+                    name = re.sub(resolution_pattern, f".{hdr}.{resolution}", name, count=1)
+
+            name = re.sub(r"\.{2,}", ".", name).strip(".")
         if str(meta.resolution).lower() in {"sd", "480i", "480p", "576i", "576p"}:
             name = re.sub(r"(?i)(?:^|\.)(?:sd|\d{3,4}[pi])(?=\.|$)", ".", name)
             name = re.sub(r"\.{2,}", ".", name).strip(".")

--- a/tests/test_broadcasthenet.py
+++ b/tests/test_broadcasthenet.py
@@ -21,6 +21,23 @@ def test_btn_name_normalizes_audio_and_no_group_suffix() -> None:
     assert asyncio.run(tracker().get_name(meta)) == "Le.Serie.S01E01.1080p.WEB-DL.DDPA5.1.x265-NOGRP"  # noqa: S101
 
 
+def test_btn_name_puts_hdr_formats_before_resolution() -> None:
+    meta = Meta(name="Example Show S01E01 2160p WEB-DL DDP 5.1 Atmos DV HDR H.265-GRP", hdr="DV HDR", resolution="2160p", tag="-GRP")
+
+    assert asyncio.run(tracker().get_name(meta)) == "Example.Show.S01E01.DV.HDR.2160p.WEB-DL.DDPA5.1.H.265-GRP"  # noqa: S101
+
+
+def test_btn_name_removes_foreign_aka_title() -> None:
+    meta = Meta(
+        name="English Title AKA Foreign Title S01E01 1080p WEB-DL AAC 2.0 H.264-GRP",
+        aka="AKA Foreign Title",
+        resolution="1080p",
+        tag="-GRP",
+    )
+
+    assert asyncio.run(tracker().get_name(meta)) == "English.Title.S01E01.1080p.WEB-DL.AAC2.0.H.264-GRP"  # noqa: S101
+
+
 def test_btn_form_fields_keeps_autofilled_values() -> None:
     fields = tracker()._form_fields(
         '<input name="seriesid" value="42"><input name="artist" value="Example Show">'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BroadcasTheNet release-name formatting when metadata names are unavailable.
  * Removed foreign AKA titles from formatted release names.
  * Standardized HDR and resolution token ordering and formatting.
  * Reduced duplicate separators in generated names.

* **Tests**
  * Added coverage for HDR ordering and foreign AKA title removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->