### PR TITLE
feat(torrent): centralize base torrent storage

### DIFF
--- a/docs/cli-args.md
+++ b/docs/cli-args.md
@@ -218,6 +218,13 @@ Thise will use the specified hash to get tracker ids from qBitTorrent or rTorren
 - `-rh`, `--rehash`: Rehash `.torrent` even if it was not needed.
 - `-mkbrr`, `--mkbrr`: Use mkbrr for torrent hashing.
 - `-entropy`, `--entropy N`: Use entropy in created torrents (32 or 64 bits).
+
+Reusable base torrents are recorded in `tmp/<release-id>/torrent_manifest.json`
+and stored by piece size under `tmp/<release-id>/torrents/<piece-size-bytes>/`.
+Tracker-ready `[TRACKER].torrent` files remain in the release directory. When
+`--nohash` is used, a tracker is skipped if no stored base satisfies its torrent
+policy.
+
 - `-rt`, `--randomized N`: Create N extra torrents with random infohash (default `0`).
 - `--infohash HASH`: V1 info hash to use as the base.
 - `-frc`, `--force-recheck`: (qBittorrent only with auto torrent searching) Force recheck torrent before uploading. NOTE: will find the best seeded torrent file from a supported site, for the related content, and force a recheck before uploading.

--- a/src/clients.py
+++ b/src/clients.py
@@ -264,20 +264,26 @@ class Clients(QbittorrentClientMixin, RtorrentClientMixin, DelugeClientMixin, Tr
         original_client = meta.client
         try:
             for client_name in client_names:
-                meta.client = client_name
-                candidate = await self._find_existing_torrent(meta)
-                if candidate is None:
+                if client_name not in self.config["TORRENT_CLIENTS"]:
+                    logger.info(f"[yellow]Client '{client_name}' not found in TORRENT_CLIENTS config, skipping...")
                     continue
-                torrent = Torrent.read(candidate)
-                has_subs = any(Path(str(file)).suffix.casefold() in SUBTITLE_EXTENSIONS for file in torrent.files)
-                entry = manifest.register(candidate, "base_subs" if has_subs else "base", f"client:{client_name}")
-                managed = str(manifest.entry_path(entry))
-                if managed not in paths:
-                    paths.append(managed)
-                candidate_path = Path(candidate)
-                client_staging = Path(meta.base_dir) / "tmp" / meta.uuid / "torrents" / ".client"
-                if client_staging.resolve() in candidate_path.resolve().parents:
-                    candidate_path.unlink(missing_ok=True)
+                meta.client = client_name
+                result = await self._search_single_client_for_torrent(meta, client_name, False, False, None, True)
+                candidates = result if isinstance(result, list) else [result] if isinstance(result, str) else []
+                for candidate in candidates:
+                    if meta.subtitle_files and not self._torrent_includes_all_local_subtitles(candidate, meta) and not self._torrent_has_no_subtitles(candidate):
+                        continue
+                    torrent = Torrent.read(candidate)
+                    has_subs = any(Path(str(file)).suffix.casefold() in SUBTITLE_EXTENSIONS for file in torrent.files)
+                    entry = manifest.register(candidate, "base_subs" if has_subs else "base", f"client:{client_name}")
+                    managed = str(manifest.entry_path(entry))
+                    if managed not in paths:
+                        paths.append(managed)
+                    meta.reuse_torrent_client = client_name
+                    candidate_path = Path(candidate)
+                    client_staging = Path(meta.base_dir) / "tmp" / meta.uuid / "torrents" / ".client"
+                    if client_staging.resolve() in candidate_path.resolve().parents:
+                        candidate_path.unlink(missing_ok=True)
         finally:
             meta.client = original_client
         return paths
@@ -383,8 +389,14 @@ class Clients(QbittorrentClientMixin, RtorrentClientMixin, DelugeClientMixin, Tr
         return None
 
     async def _search_single_client_for_torrent(
-        self, meta: Meta, client_name: str, prefer_small_pieces: bool, piece_limit: bool, best_match: dict[str, Any] | None
-    ) -> dict[str, Any] | str | None:
+        self,
+        meta: Meta,
+        client_name: str,
+        prefer_small_pieces: bool,
+        piece_limit: bool,
+        best_match: dict[str, Any] | None,
+        collect_all: bool = False,
+    ) -> list[str] | dict[str, Any] | str | None:
         """Search a single client for an existing torrent by hash or via API search (qbit only)."""
 
         client = self.config["TORRENT_CLIENTS"][client_name]
@@ -392,6 +404,7 @@ class Clients(QbittorrentClientMixin, RtorrentClientMixin, DelugeClientMixin, Tr
         torrent_storage_dir = client.get("torrent_storage_dir")
         qbt_client: qbittorrentapi.Client | None = None
         proxy_url: str | None = None
+        candidates: list[str] = []
 
         # Iterate through pre-specified hashes
         for hash_key in ["torrenthash", "ext_torrenthash"]:
@@ -459,7 +472,10 @@ class Clients(QbittorrentClientMixin, RtorrentClientMixin, DelugeClientMixin, Tr
                 valid, resolved_path = await self.is_valid_torrent(meta, torrent_path, hash_value_str, torrent_client, client)
 
                 if valid:
-                    return resolved_path
+                    if not collect_all:
+                        return resolved_path
+                    if resolved_path not in candidates:
+                        candidates.append(resolved_path)
 
         # Search the client if no pre-specified hash matches
         if torrent_client == "qbit" and client.get("enable_search"):
@@ -473,7 +489,7 @@ class Clients(QbittorrentClientMixin, RtorrentClientMixin, DelugeClientMixin, Tr
                 else:
                     qbt_client = await self.init_qbittorrent_client(client)
 
-                found_hash = await self.search_qbit_for_torrent(meta, client, qbt_client, qbt_session, proxy_url)
+                found = await self.search_qbit_for_torrent(meta, client, qbt_client, qbt_session, proxy_url, collect_all=collect_all)
 
                 # Clean up session if we created one
                 if qbt_session:
@@ -481,7 +497,7 @@ class Clients(QbittorrentClientMixin, RtorrentClientMixin, DelugeClientMixin, Tr
 
             except KeyboardInterrupt:
                 logger.info("[bold red]Search cancelled by user")
-                found_hash = None
+                found = [] if collect_all else None
                 if qbt_session:
                     await qbt_session.aclose()
             except TimeoutError:
@@ -490,10 +506,11 @@ class Clients(QbittorrentClientMixin, RtorrentClientMixin, DelugeClientMixin, Tr
                 raise
             except Exception as e:
                 logger.info(f"[bold red]Error searching qBittorrent: {e}")
-                found_hash = None
+                found = [] if collect_all else None
                 if qbt_session:
                     await qbt_session.aclose()
-            if found_hash:
+            found_hashes = found if isinstance(found, list) else [found] if isinstance(found, str) else []
+            for found_hash in found_hashes:
                 extracted_torrent_dir = Path(meta.base_dir) / "tmp" / meta.uuid / "torrents" / ".client"
 
                 if torrent_storage_dir:
@@ -562,6 +579,10 @@ class Clients(QbittorrentClientMixin, RtorrentClientMixin, DelugeClientMixin, Tr
                     logger.info("[cyan]DEBUG: Skipping validation because found_hash is None[/cyan]")
 
                 if valid:
+                    if collect_all:
+                        if resolved_path not in candidates:
+                            candidates.append(resolved_path)
+                        continue
                     torrent = Torrent.read(resolved_path)
                     piece_size = torrent.piece_size
                     piece_in_mib = piece_size / 1024 / 1024
@@ -579,6 +600,8 @@ class Clients(QbittorrentClientMixin, RtorrentClientMixin, DelugeClientMixin, Tr
                         best_match = {"torrenthash": found_hash, "torrent_path": resolved_path, "piece_size": piece_size}
                         logger.info(f"[yellow]Storing valid torrent from client search as best match: [bold yellow]{found_hash}")
 
+        if collect_all:
+            return candidates
         return best_match
 
     async def is_valid_torrent(self, meta: Meta, torrent_path: str, torrenthash: str, torrent_client: str, _client: dict[str, Any]) -> tuple[bool, str]:

--- a/src/clients.py
+++ b/src/clients.py
@@ -16,7 +16,9 @@ from src.console import logger
 from src.meta import Meta
 from src.torrent_clients import DelugeClientMixin, QbittorrentClientMixin, RtorrentClientMixin, TransmissionClientMixin
 from src.torrent_clients.path_utils import coerce_str_list, is_path_under
-from src.torrentcreate import SUBTITLE_EXTENSIONS, hdbits_pieces_allowed
+from src.torrent_manifest import TorrentManifest
+from src.torrent_policy import HDBITS_POLICY, TorrentStats, generic_reuse_allowed
+from src.torrentcreate import SUBTITLE_EXTENSIONS
 
 # Secure XML-RPC client using defusedxml to prevent XML attacks
 defusedxml.xmlrpc.monkey_patch()
@@ -243,7 +245,60 @@ class Clients(QbittorrentClientMixin, RtorrentClientMixin, DelugeClientMixin, Tr
                     logger.info(f"[cyan]Waiting {inject_delay} seconds before adding to client '{client_name}'[/cyan]")
             await asyncio.sleep(inject_delay)
 
+    async def find_existing_torrents(self, meta: Meta) -> list[str]:
+        """Collect and register reusable variants from every configured search client."""
+        if meta.get("skip_auto_torrent", False):
+            return []
+        requested = meta.client
+        if isinstance(requested, str) and requested != "none":
+            client_names = [requested]
+        else:
+            configured = self.config["DEFAULT"].get("searching_client_list", [])
+            client_names = [str(name) for name in configured if str(name) and str(name) != "none"] if isinstance(configured, list) else []
+            default = str(self.config["DEFAULT"].get("default_torrent_client", "none"))
+            if not client_names and default != "none":
+                client_names = [default]
+
+        manifest = TorrentManifest(meta.base_dir, meta.uuid)
+        paths: list[str] = []
+        original_client = meta.client
+        try:
+            for client_name in client_names:
+                meta.client = client_name
+                candidate = await self._find_existing_torrent(meta)
+                if candidate is None:
+                    continue
+                torrent = Torrent.read(candidate)
+                has_subs = any(Path(str(file)).suffix.casefold() in SUBTITLE_EXTENSIONS for file in torrent.files)
+                entry = manifest.register(candidate, "base_subs" if has_subs else "base", f"client:{client_name}")
+                managed = str(manifest.entry_path(entry))
+                if managed not in paths:
+                    paths.append(managed)
+                candidate_path = Path(candidate)
+                client_staging = Path(meta.base_dir) / "tmp" / meta.uuid / "torrents" / ".client"
+                if client_staging.resolve() in candidate_path.resolve().parents:
+                    candidate_path.unlink(missing_ok=True)
+        finally:
+            meta.client = original_client
+        return paths
+
     async def find_existing_torrent(self, meta: Meta) -> str | None:
+        """Return the preferred registered variant for compatibility with callers."""
+        paths = await self.find_existing_torrents(meta)
+        if not paths:
+            return None
+        manifest = TorrentManifest(meta.base_dir, meta.uuid)
+        entries = [entry for path in paths if (entry := manifest.entry_for_path(path)) is not None]
+        if meta.subtitle_files and any(entry.layout == "base_subs" for entry in entries):
+            entries = [entry for entry in entries if entry.layout == "base_subs"]
+        if self.config["DEFAULT"].get("prefer_max_16_torrent", False):
+            entries.sort(key=lambda entry: entry.piece_size)
+        chosen = entries[0]
+        if chosen.origin.startswith("client:"):
+            meta.reuse_torrent_client = chosen.origin.removeprefix("client:")
+        return str(manifest.entry_path(chosen))
+
+    async def _find_existing_torrent(self, meta: Meta) -> str | None:
         """Find a reusable torrent matching the prepared metadata."""
         if meta.get("skip_auto_torrent", False):
             return None
@@ -344,7 +399,7 @@ class Clients(QbittorrentClientMixin, RtorrentClientMixin, DelugeClientMixin, Tr
             if hash_value:
                 hash_value_str = str(hash_value)
                 # If no torrent_storage_dir defined, use saved torrent from qbit
-                extracted_torrent_dir = Path(meta.base_dir) / "tmp" / meta.uuid
+                extracted_torrent_dir = Path(meta.base_dir) / "tmp" / meta.uuid / "torrents" / ".client"
 
                 if torrent_storage_dir:
                     torrent_path = Path(torrent_storage_dir) / f"{hash_value_str}.torrent"
@@ -439,7 +494,7 @@ class Clients(QbittorrentClientMixin, RtorrentClientMixin, DelugeClientMixin, Tr
                 if qbt_session:
                     await qbt_session.aclose()
             if found_hash:
-                extracted_torrent_dir = Path(meta.base_dir) / "tmp" / meta.uuid
+                extracted_torrent_dir = Path(meta.base_dir) / "tmp" / meta.uuid / "torrents" / ".client"
 
                 if torrent_storage_dir:
                     found_torrent_path = Path(torrent_storage_dir) / f"{found_hash}.torrent"
@@ -621,31 +676,17 @@ class Clients(QbittorrentClientMixin, RtorrentClientMixin, DelugeClientMixin, Tr
                         f"Checking piece size, count and size: pieces={reuse_torrent.pieces}, piece_size={piece_in_mib} MiB, .torrent size={torrent_file_size_kib} KiB"
                     )
 
-                    # Piece size and count validations
-                    max_piece_size = meta.max_piece_size
+                    # Centralized piece-count, piece-size and metainfo-size validation.
+                    stats = TorrentStats(piece_size, reuse_torrent.pieces, reuse_torrent.size, Path(torrent_path).stat().st_size)
                     if "HDBITS" in meta.trackers:
-                        valid = not wrong_file and hdbits_pieces_allowed(piece_size, reuse_torrent.pieces, reuse_torrent.size)
+                        valid = not wrong_file and HDBITS_POLICY.accepts(stats)
                         if not valid:
                             logger.debug("[bold red]Torrent does not meet HDBits piece limits or file requirements")
                         trackers = meta.trackers.split(",") if isinstance(meta.trackers, str) else meta.trackers
                         if not valid or all(tracker == "HDBITS" for tracker in trackers):
                             return valid, torrent_path
-                    if reuse_torrent.pieces >= 5000 and reuse_torrent.piece_size < 4294304 and (max_piece_size is None or max_piece_size >= 4):
-                        logger.debug("[bold red]Torrent needs to have less than 5000 pieces with a 4 MiB piece size")
-                        valid = False
-                    elif (
-                        reuse_torrent.pieces >= 8000 and reuse_torrent.piece_size < 8488608 and (max_piece_size is None or max_piece_size >= 8) and not meta.prefer_small_pieces
-                    ):
-                        logger.debug("[bold red]Torrent needs to have less than 8000 pieces with a 8 MiB piece size")
-                        valid = False
-                    elif "max_piece_size" not in meta and reuse_torrent.pieces >= 12000:
-                        logger.debug("[bold red]Torrent needs to have less than 12000 pieces to be valid")
-                        valid = False
-                    elif reuse_torrent.piece_size < 32768:
-                        logger.debug("[bold red]Piece size too small to reuse")
-                        valid = False
-                    elif "max_piece_size" not in meta and torrent_file_size_kib > 250:
-                        logger.debug("[bold red]Torrent file size exceeds 250 KiB")
+                    if not generic_reuse_allowed(stats, meta):
+                        logger.debug("[bold red]Torrent does not meet the generic reuse policy")
                         valid = False
                     elif wrong_file:
                         logger.debug("[bold red]Provided .torrent has files that were not expected")

--- a/src/early_tasks.py
+++ b/src/early_tasks.py
@@ -10,6 +10,7 @@ from typing import Any, cast
 from src.clients import Clients
 from src.console import CliProgressGate, logger, suppress_cli_progress
 from src.meta import Meta
+from src.torrent_manifest import TorrentManifest
 from src.torrentcreate import TorrentCreator
 from src.trackersetup import tracker_class_map
 from src.webui_progress import has_progress_callback
@@ -85,10 +86,11 @@ async def create_base_torrents_early(meta: Meta, client: Clients) -> None:
         logger.debug("[cyan]Skipping early torrent creation due to hashing or tracker settings.[/cyan]")
         return
 
-    torrent_path = Path(meta.base_dir) / "tmp" / meta.uuid / "BASE.torrent"
-    subs_torrent_path = Path(meta.base_dir) / "tmp" / meta.uuid / "BASE_SUBS.torrent"
-    if torrent_path.exists():
-        logger.debug(f"[cyan]Skipping early torrent creation; BASE already exists at {torrent_path}[/cyan]")
+    manifest = TorrentManifest(meta.base_dir, meta.uuid)
+    torrent_path = manifest.default_path("base")
+    subs_torrent_path = manifest.default_path("base_subs")
+    if torrent_path is not None:
+        logger.debug(f"[cyan]Skipping early torrent creation; a base is already registered at {torrent_path}[/cyan]")
         return
 
     try:
@@ -107,7 +109,7 @@ async def create_base_torrents_early(meta: Meta, client: Clients) -> None:
         else:
             logger.debug("[cyan]No reusable client torrent found; creating BASE torrent while metadata and screenshots are processed.[/cyan]")
             await TorrentCreator.create_torrent(meta, Path(cast(str, meta.path)), "BASE")
-        if meta.subtitle_files and not subs_torrent_path.exists():
+        if meta.subtitle_files and subs_torrent_path is None:
             await TorrentCreator.create_torrent(meta, Path(cast(str, meta.path)), "BASE_SUBS")
         logger.debug(f"[cyan]Early torrent task completed in {time.perf_counter() - task_started:.2f}s[/cyan]")
     except asyncio.CancelledError:

--- a/src/early_tasks.py
+++ b/src/early_tasks.py
@@ -89,27 +89,29 @@ async def create_base_torrents_early(meta: Meta, client: Clients) -> None:
     manifest = TorrentManifest(meta.base_dir, meta.uuid)
     torrent_path = manifest.default_path("base")
     subs_torrent_path = manifest.default_path("base_subs")
-    if torrent_path is not None:
+    needs_subs = bool(meta.subtitle_files) and subs_torrent_path is None
+    if torrent_path is not None and not needs_subs:
         logger.debug(f"[cyan]Skipping early torrent creation; a base is already registered at {torrent_path}[/cyan]")
         return
 
     try:
-        reuse_torrent = meta.reuse_torrent_path
-        if not reuse_torrent or not Path(reuse_torrent).exists():
-            logger.debug("[cyan]Early torrent creation has no cached reusable torrent; searching client.[/cyan]")
-            search_started = time.perf_counter()
-            reuse_torrent = await client.find_existing_torrent(meta)
-            logger.debug(f"[cyan]Early client torrent search completed in {time.perf_counter() - search_started:.2f}s[/cyan]")
-        if reuse_torrent and Path(reuse_torrent).exists():
-            meta.reuse_torrent_path = reuse_torrent
-            logger.debug("[cyan]Creating torrent from the client copy while metadata and screenshots are processed.[/cyan]")
-            base_creation_started = time.perf_counter()
-            created_path = await TorrentCreator.create_base_from_existing_torrent(reuse_torrent, meta.base_dir, meta.uuid)
-            logger.debug(f"[cyan]Early base torrent creation completed in {time.perf_counter() - base_creation_started:.2f}s: {created_path or 'no file created'}[/cyan]")
-        else:
-            logger.debug("[cyan]No reusable client torrent found; creating BASE torrent while metadata and screenshots are processed.[/cyan]")
-            await TorrentCreator.create_torrent(meta, Path(cast(str, meta.path)), "BASE")
-        if meta.subtitle_files and subs_torrent_path is None:
+        if torrent_path is None:
+            reuse_torrent = meta.reuse_torrent_path
+            if not reuse_torrent or not Path(reuse_torrent).exists():
+                logger.debug("[cyan]Early torrent creation has no cached reusable torrent; searching client.[/cyan]")
+                search_started = time.perf_counter()
+                reuse_torrent = await client.find_existing_torrent(meta)
+                logger.debug(f"[cyan]Early client torrent search completed in {time.perf_counter() - search_started:.2f}s[/cyan]")
+            if reuse_torrent and Path(reuse_torrent).exists():
+                meta.reuse_torrent_path = reuse_torrent
+                logger.debug("[cyan]Creating torrent from the client copy while metadata and screenshots are processed.[/cyan]")
+                base_creation_started = time.perf_counter()
+                created_path = await TorrentCreator.create_base_from_existing_torrent(reuse_torrent, meta.base_dir, meta.uuid)
+                logger.debug(f"[cyan]Early base torrent creation completed in {time.perf_counter() - base_creation_started:.2f}s: {created_path or 'no file created'}[/cyan]")
+            else:
+                logger.debug("[cyan]No reusable client torrent found; creating BASE torrent while metadata and screenshots are processed.[/cyan]")
+                await TorrentCreator.create_torrent(meta, Path(cast(str, meta.path)), "BASE")
+        if needs_subs:
             await TorrentCreator.create_torrent(meta, Path(cast(str, meta.path)), "BASE_SUBS")
         logger.debug(f"[cyan]Early torrent task completed in {time.perf_counter() - task_started:.2f}s[/cyan]")
     except asyncio.CancelledError:

--- a/src/early_tasks.py
+++ b/src/early_tasks.py
@@ -108,10 +108,10 @@ async def create_base_torrents_early(meta: Meta, client: Clients) -> None:
                 base_creation_started = time.perf_counter()
                 created_path = await TorrentCreator.create_base_from_existing_torrent(reuse_torrent, meta.base_dir, meta.uuid)
                 logger.debug(f"[cyan]Early base torrent creation completed in {time.perf_counter() - base_creation_started:.2f}s: {created_path or 'no file created'}[/cyan]")
-            else:
-                logger.debug("[cyan]No reusable client torrent found; creating BASE torrent while metadata and screenshots are processed.[/cyan]")
-                await TorrentCreator.create_torrent(meta, Path(cast(str, meta.path)), "BASE")
-        if needs_subs:
+        if manifest.default_path("base") is None:
+            logger.debug("[cyan]No reusable base torrent found; creating BASE while metadata and screenshots are processed.[/cyan]")
+            await TorrentCreator.create_torrent(meta, Path(cast(str, meta.path)), "BASE")
+        if meta.subtitle_files and manifest.default_path("base_subs") is None:
             await TorrentCreator.create_torrent(meta, Path(cast(str, meta.path)), "BASE_SUBS")
         logger.debug(f"[cyan]Early torrent task completed in {time.perf_counter() - task_started:.2f}s[/cyan]")
     except asyncio.CancelledError:

--- a/src/manualpackage.py
+++ b/src/manualpackage.py
@@ -15,6 +15,7 @@ from torf import Torrent
 from src.console import logger
 from src.meta import Meta
 from src.temp_paths import artwork_dir
+from src.torrent_manifest import TorrentManifest
 from src.uploadscreens import UploadScreensManager
 
 
@@ -83,11 +84,11 @@ class ManualPackageManager:
                 if not each.startswith(("BASE", "[RAND")):
                     Path(f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/{each}").resolve().unlink()
         try:
-            if Path(f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/BASE.torrent").exists():
-                base_torrent = Torrent.read(f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/BASE.torrent")
+            base_path = TorrentManifest(meta.base_dir, meta.uuid).default_path()
+            if base_path is not None:
+                base_torrent = Torrent.read(base_path)
                 manual_name = re.sub(r"[^0-9a-zA-Z\[\]\'\-]+", ".", Path(meta.path or "").name)
                 Torrent.copy(base_torrent).write(f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/{manual_name}.torrent", overwrite=True)
-                # shutil.copy(os.path.abspath(f"{meta.base_dir}/tmp/{meta.uuid}/BASE.torrent"), os.path.abspath(f"{meta.base_dir}/tmp/{meta.uuid}/{meta.name.replace(' ', '.')}.torrent").replace(' ', '.'))
             manual_tracker_raw = self.tracker_config.get("MANUAL")
             manual_tracker_cfg: dict[str, Any] = cast(dict[str, Any], manual_tracker_raw) if isinstance(manual_tracker_raw, dict) else {}
             manual_filebrowser = manual_tracker_cfg.get("filebrowser")

--- a/src/torrent_clients/qbittorrent.py
+++ b/src/torrent_clients/qbittorrent.py
@@ -401,7 +401,9 @@ class QbittorrentClientMixin:
         qbt_client: qbittorrentapi.Client | None = None,
         qbt_session: httpx.AsyncClient | None = None,
         proxy_url: str | None = None,
-    ) -> str | None:
+        *,
+        collect_all: bool = False,
+    ) -> list[str] | str | None:
         logger.debug("[green]Searching qBittorrent for an existing .torrent")
 
         torrent_storage_dir = client.get("torrent_storage_dir")
@@ -583,6 +585,7 @@ class QbittorrentClientMixin:
             # **Step 2: Extract and Save .torrent Files**
             processed_hashes: set[str] = set()
             video_only_fallback: str | None = None
+            valid_hashes: list[str] = []
             torrent_hash: str | None = None
             for matching_torrent in matching_torrents:
                 try:
@@ -658,18 +661,26 @@ class QbittorrentClientMixin:
                 if valid:
                     if meta.subtitle_files and not self._torrent_includes_all_local_subtitles(str(torrent_file_path), meta):
                         if self._torrent_has_no_subtitles(str(torrent_file_path)):
-                            video_only_fallback = torrent_hash
-                            meta.base_reuse_torrent_path = str(torrent_path or torrent_file_path)
-                            logger.debug(f"[yellow]Keeping video-only torrent as fallback: {torrent_hash}")
+                            if collect_all:
+                                valid_hashes.append(torrent_hash)
+                            else:
+                                video_only_fallback = torrent_hash
+                                meta.base_reuse_torrent_path = str(torrent_path or torrent_file_path)
+                                logger.debug(f"[yellow]Keeping video-only torrent as fallback: {torrent_hash}")
                         else:
                             logger.debug(f"[yellow]Skipping partial-subtitle torrent as fallback: {torrent_hash}")
+                        continue
+                    if collect_all:
+                        valid_hashes.append(torrent_hash)
                         continue
                     logger.debug(f"[green]Returning first valid torrent: {torrent_hash}")
                     return torrent_hash
                 logger.debug(f"[bold red]{torrent_hash} failed validation")
                 torrent_file_path.unlink()
 
-            if video_only_fallback:
+            if collect_all:
+                result = valid_hashes
+            elif video_only_fallback:
                 logger.info(f"[yellow]No matching torrent with all local subtitles found; using video-only fallback: {video_only_fallback}")
                 result = video_only_fallback
             else:

--- a/src/torrent_clients/qbittorrent.py
+++ b/src/torrent_clients/qbittorrent.py
@@ -133,7 +133,7 @@ class QbittorrentClientMixin:
 
                     torrents = [TorrentInfo(torrent_properties)]
                 except Exception as e:
-                    logger.info(f"[yellow]Failed to get properties: {e}")
+                    logger.debug(f"[yellow]Failed to get properties: {e}")
                     return meta
         except TimeoutError:
             logger.info("[bold red]Getting torrents list timed out after retries")

--- a/src/torrent_clients/qbittorrent.py
+++ b/src/torrent_clients/qbittorrent.py
@@ -151,7 +151,7 @@ class QbittorrentClientMixin:
         if not meta.uuid:
             meta.uuid = folder_id
 
-        extracted_torrent_dir = str(Path(meta.base_dir) / "tmp" / meta.uuid)
+        extracted_torrent_dir = str(Path(meta.base_dir) / "tmp" / meta.uuid / "torrents" / ".client")
         Path(extracted_torrent_dir).mkdir(parents=True, exist_ok=True)
 
         for torrent in torrents:
@@ -405,7 +405,7 @@ class QbittorrentClientMixin:
         logger.debug("[green]Searching qBittorrent for an existing .torrent")
 
         torrent_storage_dir = client.get("torrent_storage_dir")
-        extracted_torrent_dir = str(Path(meta.base_dir) / "tmp" / meta.uuid)
+        extracted_torrent_dir = str(Path(meta.base_dir) / "tmp" / meta.uuid / "torrents" / ".client")
 
         if not extracted_torrent_dir or extracted_torrent_dir.strip() == "tmp/":
             logger.info("[bold red]Invalid extracted torrent directory path. Check `meta.base_dir` and `meta.uuid`.")
@@ -1624,7 +1624,7 @@ class QbittorrentClientMixin:
         if not meta.base_torrent_created:
             torrent_storage_dir = client_config.get("torrent_storage_dir")
 
-            extracted_torrent_dir = str(Path(meta.base_dir) / "tmp" / meta.uuid)
+            extracted_torrent_dir = str(Path(meta.base_dir) / "tmp" / meta.uuid / "torrents" / ".client")
             Path(extracted_torrent_dir).mkdir(parents=True, exist_ok=True)
 
             # Set up piece size preference logic

--- a/src/torrent_clients/rtorrent.py
+++ b/src/torrent_clients/rtorrent.py
@@ -361,7 +361,7 @@ class RtorrentClientMixin:
         if not meta.uuid:
             meta.uuid = folder_id
 
-        extracted_torrent_dir = Path(meta.base_dir) / "tmp" / meta.uuid
+        extracted_torrent_dir = Path(meta.base_dir) / "tmp" / meta.uuid / "torrents" / ".client"
         Path(extracted_torrent_dir).mkdir(parents=True, exist_ok=True)
 
         # Check if the torrent file exists directly
@@ -424,18 +424,11 @@ class RtorrentClientMixin:
                 valid, resolved_path = await self.is_valid_torrent(meta, str(torrent_path), info_hash_v1, "rtorrent", client)
 
                 if valid:
-                    base_torrent_path = Path(extracted_torrent_dir) / "BASE.torrent"
-
                     try:
                         await TorrentCreator.create_base_from_existing_torrent(resolved_path, meta.base_dir, meta.uuid)
                         logger.debug("[green]Created BASE.torrent from existing torrent")
                     except Exception as e:
                         logger.info(f"[bold red]Error creating BASE.torrent: {e}")
-                        try:
-                            shutil.copy2(resolved_path, base_torrent_path)
-                            logger.info(f"[yellow]Created simple torrent copy as fallback: {base_torrent_path}")
-                        except Exception as copy_err:
-                            logger.info(f"[bold red]Failed to create backup copy: {copy_err}")
 
         except Exception as e:
             logger.info(f"[bold red]Error reading torrent file: {e}")

--- a/src/torrent_manifest.py
+++ b/src/torrent_manifest.py
@@ -1,0 +1,215 @@
+"""Manifest-backed storage for reusable per-release torrent hashes."""
+
+from __future__ import annotations
+
+import json
+import threading
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Literal, cast
+
+from torf import TorfError, Torrent
+
+from src.temp_paths import release_temp_dir
+from src.torrent_policy import TorrentPolicy, TorrentStats
+
+TorrentLayout = Literal["base", "base_subs"]
+
+
+@dataclass(frozen=True)
+class TorrentEntry:
+    id: str
+    file: str
+    layout: TorrentLayout
+    origin: str
+    infohash: str
+    piece_size: int
+    piece_count: int
+    content_size: int
+    metainfo_size: int
+
+    @property
+    def stats(self) -> TorrentStats:
+        return TorrentStats(self.piece_size, self.piece_count, self.content_size, self.metainfo_size)
+
+
+_locks: dict[str, threading.RLock] = {}
+_locks_guard = threading.Lock()
+
+
+class TorrentManifest:
+    VERSION = 1
+
+    def __init__(self, base_dir: str | Path | None, release_id: str) -> None:
+        self.root = release_temp_dir(base_dir, release_id)
+        self.path = self.root / "torrent_manifest.json"
+        key = str(self.path.resolve()).casefold()
+        with _locks_guard:
+            self._lock = _locks.setdefault(key, threading.RLock())
+
+    def _empty(self) -> dict[str, Any]:
+        return {"version": self.VERSION, "torrents": {}, "defaults": {}, "selections": {}}
+
+    def _load(self) -> dict[str, Any]:
+        try:
+            value = json.loads(self.path.read_text(encoding="utf-8"))
+        except OSError, json.JSONDecodeError:
+            return self._empty()
+        if not isinstance(value, dict) or value.get("version") != self.VERSION:
+            return self._empty()
+        for key in ("torrents", "defaults", "selections"):
+            if not isinstance(value.get(key), dict):
+                value[key] = {}
+        return value
+
+    def _save(self, value: dict[str, Any]) -> None:
+        self.root.mkdir(parents=True, exist_ok=True)
+        temporary = self.path.with_suffix(".tmp")
+        temporary.write_text(json.dumps(value, indent=2, sort_keys=True), encoding="utf-8")
+        temporary.replace(self.path)
+
+    def _resolve(self, relative: str) -> Path:
+        path = (self.root / relative).resolve()
+        if self.root.resolve() not in path.parents:
+            raise ValueError(f"Torrent manifest path escapes release directory: {relative}")
+        return path
+
+    @staticmethod
+    def _normalize(source: str | Path) -> Torrent:
+        torrent = Torrent.read(source)
+        torrent.trackers = ["https://fake.tracker"]
+        torrent.comment = "Upload-Assistant (fork)"
+        torrent.created_by = "Upload-Assistant (fork)"
+        info = torrent.metainfo["info"]
+        valid_info = {"name", "piece length", "pieces", "private", "source", "files", "length"}
+        for key in list(info):
+            if key not in valid_info:
+                info.pop(key, None)
+        valid_root = {
+            "announce",
+            "comment",
+            "creation date",
+            "created by",
+            "encoding",
+            "info",
+            "imdb",
+            "tmdb",
+            "tvdb",
+            "tvmaze",
+            "mal",
+            "douban",
+            "igdb",
+            "asin",
+            "isbn",
+        }
+        for key in list(torrent.metainfo):
+            if key not in valid_root:
+                torrent.metainfo.pop(key, None)
+        torrent.source = "L4G"
+        torrent.private = True
+        return torrent
+
+    def register(self, source: str | Path, layout: TorrentLayout, origin: str, *, make_default: bool = False) -> TorrentEntry:
+        with self._lock:
+            torrent = self._normalize(source)
+            infohash = str(torrent.infohash)
+            entry_id = f"{layout}:{infohash}"
+            relative = Path("torrents") / str(int(torrent.piece_size)) / f"{infohash}.torrent"
+            output = self._resolve(relative.as_posix())
+            output.parent.mkdir(parents=True, exist_ok=True)
+            temporary = output.with_suffix(".tmp")
+            Torrent.copy(torrent).write(temporary, overwrite=True)
+            temporary.replace(output)
+            stats = TorrentStats.from_path(output)
+            entry = TorrentEntry(
+                id=entry_id,
+                file=relative.as_posix(),
+                layout=layout,
+                origin=origin,
+                infohash=infohash,
+                piece_size=stats.piece_size,
+                piece_count=stats.piece_count,
+                content_size=stats.content_size,
+                metainfo_size=stats.metainfo_size,
+            )
+            manifest = self._load()
+            torrents = cast(dict[str, Any], manifest["torrents"])
+            torrents[entry_id] = asdict(entry)
+            defaults = cast(dict[str, Any], manifest["defaults"])
+            if make_default or layout not in defaults:
+                defaults[layout] = entry_id
+            self._save(manifest)
+            return entry
+
+    def entries(self, layout: TorrentLayout | None = None) -> list[TorrentEntry]:
+        manifest = self._load()
+        result: list[TorrentEntry] = []
+        for value in cast(dict[str, Any], manifest["torrents"]).values():
+            if not isinstance(value, dict):
+                continue
+            try:
+                entry = TorrentEntry(**value)
+                path = self._resolve(entry.file)
+            except TypeError, ValueError:
+                continue
+            if not path.is_file():
+                continue
+            try:
+                torrent = Torrent.read(path)
+                current = TorrentStats(
+                    piece_size=int(torrent.piece_size or 0),
+                    piece_count=int(torrent.pieces or 0),
+                    content_size=int(torrent.size or 0),
+                    metainfo_size=path.stat().st_size,
+                )
+            except OSError, TorfError, TypeError, ValueError:
+                continue
+            if current != entry.stats or str(torrent.infohash) != entry.infohash:
+                continue
+            if layout is None or entry.layout == layout:
+                result.append(entry)
+        return result
+
+    def entry_path(self, entry: TorrentEntry) -> Path:
+        return self._resolve(entry.file)
+
+    def entry_for_path(self, path: str | Path) -> TorrentEntry | None:
+        resolved = Path(path).resolve()
+        return next((entry for entry in self.entries() if self.entry_path(entry).resolve() == resolved), None)
+
+    def select(self, tracker: str, layout: TorrentLayout, policy: TorrentPolicy | None = None) -> TorrentEntry | None:
+        candidates = [entry for entry in self.entries(layout) if policy is None or policy.accepts(entry.stats)]
+        if not candidates:
+            return None
+        candidates.sort(key=lambda entry: (entry.piece_size, entry.metainfo_size, entry.id))
+        entry = candidates[0]
+        with self._lock:
+            manifest = self._load()
+            cast(dict[str, Any], manifest["selections"])[tracker.upper()] = entry.id
+            self._save(manifest)
+        return entry
+
+    def selected_path(self, tracker: str) -> Path | None:
+        manifest = self._load()
+        entry_id = cast(dict[str, Any], manifest["selections"]).get(tracker.upper())
+        value = cast(dict[str, Any], manifest["torrents"]).get(entry_id)
+        if not isinstance(value, dict):
+            return None
+        try:
+            entry = TorrentEntry(**value)
+            path = self.entry_path(entry)
+        except TypeError, ValueError:
+            return None
+        return path if path.is_file() else None
+
+    def default_path(self, layout: TorrentLayout = "base") -> Path | None:
+        manifest = self._load()
+        entry_id = cast(dict[str, Any], manifest["defaults"]).get(layout)
+        value = cast(dict[str, Any], manifest["torrents"]).get(entry_id)
+        if not isinstance(value, dict):
+            return None
+        try:
+            path = self.entry_path(TorrentEntry(**value))
+        except TypeError, ValueError:
+            return None
+        return path if path.is_file() else None

--- a/src/torrent_policy.py
+++ b/src/torrent_policy.py
@@ -1,0 +1,113 @@
+"""Central torrent acceptance and piece-size policies."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from torf import Torrent
+
+if TYPE_CHECKING:
+    from src.meta import Meta
+
+KIB = 1024
+MIB = KIB**2
+GIB = KIB**3
+TIB = KIB**4
+PIECE_SIZE_MIN = 32 * KIB
+PIECE_SIZE_MAX = 128 * MIB
+
+
+@dataclass(frozen=True)
+class TorrentStats:
+    piece_size: int
+    piece_count: int
+    content_size: int
+    metainfo_size: int
+
+    @classmethod
+    def from_path(cls, path: str | Path) -> TorrentStats:
+        torrent = Torrent.read(path)
+        return cls(
+            piece_size=int(torrent.piece_size or 0),
+            piece_count=int(torrent.pieces or 0),
+            content_size=int(torrent.size or 0),
+            metainfo_size=Path(path).stat().st_size,
+        )
+
+
+Validator = Callable[[TorrentStats], bool]
+PieceSizeSelector = Callable[[int], int]
+
+
+@dataclass(frozen=True)
+class TorrentPolicy:
+    """Declarative tracker limits plus optional exceptional rule functions."""
+
+    max_piece_size: int | None = None
+    max_metainfo_size: int | None = None
+    required_piece_size: int | None = None
+    validator: Validator | None = None
+    piece_size_selector: PieceSizeSelector | None = None
+
+    def accepts(self, stats: TorrentStats) -> bool:
+        if stats.piece_size < PIECE_SIZE_MIN:
+            return False
+        if self.max_piece_size is not None and stats.piece_size > self.max_piece_size:
+            return False
+        if self.max_metainfo_size is not None and stats.metainfo_size > self.max_metainfo_size:
+            return False
+        return self.validator(stats) if self.validator is not None else True
+
+    def choose_piece_size(self, content_size: int, default_piece_size: int) -> int:
+        if self.piece_size_selector is not None:
+            return self.piece_size_selector(content_size)
+        if self.required_piece_size is not None:
+            return self.required_piece_size
+        if self.max_piece_size is not None:
+            return min(default_piece_size, self.max_piece_size)
+        return default_piece_size
+
+
+def hdbits_pieces_allowed(piece_size: int, pieces: int, total_size: int) -> bool:
+    if piece_size <= 0 or piece_size & (piece_size - 1) or pieces <= 0:
+        return False
+    if piece_size <= 2 * MIB:
+        return pieces <= 4000
+    if piece_size in (4 * MIB, 8 * MIB):
+        return pieces <= 30000
+    return piece_size == 16 * MIB or (piece_size == 32 * MIB and total_size > TIB)
+
+
+def hdbits_piece_size(total_size: int) -> int:
+    if total_size > 8 * GIB:
+        return 16 * MIB
+    piece_size = PIECE_SIZE_MIN
+    while not hdbits_pieces_allowed(piece_size, max(1, (total_size + piece_size - 1) // piece_size), total_size):
+        piece_size *= 2
+    return piece_size
+
+
+def _hdbits_validator(stats: TorrentStats) -> bool:
+    return hdbits_pieces_allowed(stats.piece_size, stats.piece_count, stats.content_size)
+
+
+HDBITS_POLICY = TorrentPolicy(validator=_hdbits_validator, piece_size_selector=hdbits_piece_size)
+PASSTHEPOPCORN_POLICY = TorrentPolicy(max_piece_size=16 * MIB)
+ANTHELION_POLICY = TorrentPolicy(max_metainfo_size=250 * KIB, required_piece_size=128 * MIB)
+
+
+def generic_reuse_allowed(stats: TorrentStats, meta: Meta) -> bool:
+    """Preserve the historical client-reuse thresholds in one responsible layer."""
+    max_piece_size = meta.max_piece_size
+    if stats.piece_count >= 5000 and stats.piece_size < 4_294_304 and (max_piece_size is None or max_piece_size >= 4):
+        return False
+    if stats.piece_count >= 8000 and stats.piece_size < 8_488_608 and (max_piece_size is None or max_piece_size >= 8) and not meta.prefer_small_pieces:
+        return False
+    if "max_piece_size" not in meta and stats.piece_count >= 12000:
+        return False
+    if stats.piece_size < PIECE_SIZE_MIN:
+        return False
+    return not ("max_piece_size" not in meta and stats.metainfo_size > 250 * KIB)

--- a/src/torrent_provision.py
+++ b/src/torrent_provision.py
@@ -40,59 +40,64 @@ async def provision_tracker_torrents(
 ) -> set[str]:
     """Prepare manifest selections and return trackers blocked by constraints."""
     manifest = TorrentManifest(meta.base_dir, meta.uuid)
-    blocked: set[str] = set()
+    blocked: dict[str, str] = {}
     tracker_configs = config.get("TRACKERS", {})
     tracker_configs = tracker_configs if isinstance(tracker_configs, Mapping) else {}
 
     for raw_tracker in trackers:
         tracker = str(raw_tracker).strip().upper()
-        factory = tracker_class_map.get(tracker)
-        if factory is None or getattr(factory, "is_usenet", False):
-            continue
-        tracker_settings = tracker_configs.get(tracker, {})
-        allow_subs = isinstance(tracker_settings, Mapping) and bool(tracker_settings.get("allow_ext_subtitles", False))
-        layout: TorrentLayout = "base_subs" if allow_subs and manifest.default_path("base_subs") is not None else "base"
-        policy = cast(TorrentPolicy | None, getattr(factory, "torrent_policy", None))
-        if manifest.select(tracker, layout, policy) is not None:
-            continue
-        if meta.nohash:
-            blocked.add(tracker)
-            continue
-        if policy is None:
-            continue
-
-        async with _variant_lock(meta, layout, policy):
+        try:
+            factory = tracker_class_map.get(tracker)
+            if factory is None or getattr(factory, "is_usenet", False):
+                continue
+            tracker_settings = tracker_configs.get(tracker, {})
+            allow_subs = isinstance(tracker_settings, Mapping) and bool(tracker_settings.get("allow_ext_subtitles", False))
+            layout: TorrentLayout = "base_subs" if allow_subs and manifest.default_path("base_subs") is not None else "base"
+            policy = cast(TorrentPolicy | None, getattr(factory, "torrent_policy", None))
             if manifest.select(tracker, layout, policy) is not None:
                 continue
-            if meta.path is None:
-                blocked.add(tracker)
+            if meta.nohash:
+                blocked[tracker] = "Skipped: no policy-compliant torrent is available and hashing is disabled"
                 continue
-            content_size = await asyncio.to_thread(_content_size, meta.path)
-            hash_meta = meta.copy()
-            hash_meta.trackers = [tracker]
-            default_piece_size = TorrentCreator.calculate_piece_size(
-                content_size,
-                PIECE_SIZE_MIN,
-                PIECE_SIZE_MAX,
-                hash_meta,
-                piece_size=meta.max_piece_size,
-            )
-            chosen = policy.choose_piece_size(content_size, default_piece_size)
-            output = "BASE_SUBS" if layout == "base_subs" else "BASE"
-            logger.info(f"{tracker}: [yellow]Creating a policy-compliant {chosen / MIB:g} MiB base torrent.[/yellow]")
-            try:
-                cooldown = int(cast(Mapping[str, Any], config.get("DEFAULT", {})).get("rehash_cooldown", 0) or 0)
-            except TypeError, ValueError:
-                cooldown = 0
-            if cooldown > 0:
-                await asyncio.sleep(cooldown)
-            await TorrentCreator.create_torrent(hash_meta, Path(meta.path), output, piece_size=max(1, chosen // MIB))
-            if manifest.select(tracker, layout, policy) is None:
-                blocked.add(tracker)
+            if policy is None:
+                continue
 
-    for tracker in blocked:
+            async with _variant_lock(meta, layout, policy):
+                if manifest.select(tracker, layout, policy) is not None:
+                    continue
+                if meta.path is None:
+                    blocked[tracker] = "Skipped: source path is unavailable for torrent creation"
+                    continue
+                content_size = await asyncio.to_thread(_content_size, meta.path)
+                hash_meta = meta.copy()
+                hash_meta.trackers = [tracker]
+                default_piece_size = TorrentCreator.calculate_piece_size(
+                    content_size,
+                    PIECE_SIZE_MIN,
+                    PIECE_SIZE_MAX,
+                    hash_meta,
+                    piece_size=meta.max_piece_size,
+                )
+                chosen = policy.choose_piece_size(content_size, default_piece_size)
+                output = "BASE_SUBS" if layout == "base_subs" else "BASE"
+                logger.info(f"{tracker}: [yellow]Creating a policy-compliant {chosen / MIB:g} MiB base torrent.[/yellow]")
+                try:
+                    cooldown = int(cast(Mapping[str, Any], config.get("DEFAULT", {})).get("rehash_cooldown", 0) or 0)
+                except TypeError, ValueError:
+                    cooldown = 0
+                if cooldown > 0:
+                    await asyncio.sleep(cooldown)
+                await TorrentCreator.create_torrent(hash_meta, Path(meta.path), output, piece_size=max(1, chosen // MIB))
+                if manifest.select(tracker, layout, policy) is None:
+                    blocked[tracker] = "Skipped: generated torrent does not satisfy the tracker policy"
+        except asyncio.CancelledError:
+            raise
+        except Exception as error:
+            blocked[tracker] = f"Skipped: torrent provisioning failed: {error}"
+
+    for tracker, reason in blocked.items():
         status = meta.tracker_status.setdefault(tracker, {})
         status["upload"] = False
-        status["status_message"] = "Skipped: no policy-compliant torrent is available and hashing is disabled"
+        status["status_message"] = reason
         logger.info(f"[yellow]{tracker}: {status['status_message']}[/yellow]")
-    return blocked
+    return set(blocked)

--- a/src/torrent_provision.py
+++ b/src/torrent_provision.py
@@ -1,0 +1,98 @@
+"""Select or create policy-compliant base torrents before tracker uploads."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, cast
+
+from src.console import logger
+from src.meta import Meta
+from src.torrent_manifest import TorrentLayout, TorrentManifest
+from src.torrent_policy import MIB, PIECE_SIZE_MAX, PIECE_SIZE_MIN, TorrentPolicy
+from src.torrentcreate import TorrentCreator
+
+_locks: dict[str, asyncio.Lock] = {}
+_locks_guard = threading.Lock()
+
+
+def _variant_lock(meta: Meta, layout: TorrentLayout, policy: TorrentPolicy) -> asyncio.Lock:
+    key = f"{Path(meta.base_dir).resolve()}:{meta.uuid}:{layout}:{policy!r}"
+    with _locks_guard:
+        return _locks.setdefault(key, asyncio.Lock())
+
+
+def _content_size(path: str | os.PathLike[str]) -> int:
+    source = Path(path)
+    if source.is_file():
+        return source.stat().st_size
+    return sum(item.stat().st_size for item in source.rglob("*") if item.is_file())
+
+
+async def provision_tracker_torrents(
+    meta: Meta,
+    config: Mapping[str, Any],
+    trackers: Sequence[str],
+    tracker_class_map: Mapping[str, Any],
+) -> set[str]:
+    """Prepare manifest selections and return trackers blocked by constraints."""
+    manifest = TorrentManifest(meta.base_dir, meta.uuid)
+    blocked: set[str] = set()
+    tracker_configs = config.get("TRACKERS", {})
+    tracker_configs = tracker_configs if isinstance(tracker_configs, Mapping) else {}
+
+    for raw_tracker in trackers:
+        tracker = str(raw_tracker).strip().upper()
+        factory = tracker_class_map.get(tracker)
+        if factory is None or getattr(factory, "is_usenet", False):
+            continue
+        tracker_settings = tracker_configs.get(tracker, {})
+        allow_subs = isinstance(tracker_settings, Mapping) and bool(tracker_settings.get("allow_ext_subtitles", False))
+        layout: TorrentLayout = "base_subs" if allow_subs and manifest.default_path("base_subs") is not None else "base"
+        policy = cast(TorrentPolicy | None, getattr(factory, "torrent_policy", None))
+        if manifest.select(tracker, layout, policy) is not None:
+            continue
+        if meta.nohash:
+            blocked.add(tracker)
+            continue
+        if policy is None:
+            continue
+
+        async with _variant_lock(meta, layout, policy):
+            if manifest.select(tracker, layout, policy) is not None:
+                continue
+            if meta.path is None:
+                blocked.add(tracker)
+                continue
+            content_size = await asyncio.to_thread(_content_size, meta.path)
+            hash_meta = meta.copy()
+            hash_meta.trackers = [tracker]
+            default_piece_size = TorrentCreator.calculate_piece_size(
+                content_size,
+                PIECE_SIZE_MIN,
+                PIECE_SIZE_MAX,
+                hash_meta,
+                piece_size=meta.max_piece_size,
+            )
+            chosen = policy.choose_piece_size(content_size, default_piece_size)
+            output = "BASE_SUBS" if layout == "base_subs" else "BASE"
+            logger.info(f"{tracker}: [yellow]Creating a policy-compliant {chosen / MIB:g} MiB base torrent.[/yellow]")
+            try:
+                cooldown = int(cast(Mapping[str, Any], config.get("DEFAULT", {})).get("rehash_cooldown", 0) or 0)
+            except TypeError, ValueError:
+                cooldown = 0
+            if cooldown > 0:
+                await asyncio.sleep(cooldown)
+            await TorrentCreator.create_torrent(hash_meta, Path(meta.path), output, piece_size=max(1, chosen // MIB))
+            if manifest.select(tracker, layout, policy) is None:
+                blocked.add(tracker)
+
+    for tracker in blocked:
+        status = meta.tracker_status.setdefault(tracker, {})
+        status["upload"] = False
+        status["status_message"] = "Skipped: no policy-compliant torrent is available and hashing is disabled"
+        logger.info(f"[yellow]{tracker}: {status['status_message']}[/yellow]")
+    return blocked

--- a/src/torrentcreate.py
+++ b/src/torrentcreate.py
@@ -25,31 +25,12 @@ from src.app_paths import CODE_DIR
 from src.binaries import configured_binary
 from src.console import console, is_cli_progress_suppressed, logger, progress_display
 from src.meta import Meta
+from src.torrent_manifest import TorrentManifest
+from src.torrent_policy import PIECE_SIZE_MAX, PIECE_SIZE_MIN, hdbits_piece_size
+from src.torrent_policy import hdbits_pieces_allowed as hdbits_pieces_allowed
 from src.webui_progress import complete_progress, has_progress_callback, publish_progress
 
-PIECE_SIZE_MIN = 32 * 1024  # 32 KiB
-PIECE_SIZE_MAX = 134_217_728  # 128 MiB
 SUBTITLE_EXTENSIONS = (".srt", ".sub", ".vtt", ".ssa", ".ass", ".idx")
-
-
-def hdbits_pieces_allowed(piece_size: int, pieces: int, total_size: int) -> bool:
-    if piece_size <= 0 or piece_size & (piece_size - 1) or pieces <= 0:
-        return False
-    if piece_size <= 2 * 1024**2:
-        return pieces <= 4000
-    if piece_size in (4 * 1024**2, 8 * 1024**2):
-        return pieces <= 30000
-    return piece_size == 16 * 1024**2 or (piece_size == 32 * 1024**2 and total_size > 1024**4)
-
-
-def hdbits_piece_size(total_size: int) -> int:
-    """Choose a compliant size for new hashes; never use this to reject reuse."""
-    if total_size > 8 * 1024**3:
-        return 16 * 1024**2
-    piece_size = 32768
-    while not hdbits_pieces_allowed(piece_size, max(1, (total_size + piece_size - 1) // piece_size), total_size):
-        piece_size *= 2
-    return piece_size
 
 
 def calculate_piece_size(
@@ -219,6 +200,7 @@ class TorrentCreator:
         output_filename: str,
         tracker_url: str | None = None,
         piece_size: int = 0,
+        make_default: bool = False,
     ) -> str | Torrent:
         # Ensure only one torrent creation runs at a time
         wait_started: float | None = None
@@ -243,6 +225,7 @@ class TorrentCreator:
                 exclude: list[str] = []
 
                 is_subs = "BASE_SUBS" in output_filename
+                is_base = output_filename in {"BASE", "BASE_SUBS"}
                 creation_filelist = list(meta.filelist)
                 if is_subs and meta.subtitle_files:
                     creation_filelist.extend(meta.subtitle_files)
@@ -325,7 +308,11 @@ class TorrentCreator:
                         # Validate mkbrr binary exists and is executable
                         if not Path(mkbrr_binary).exists():
                             raise FileNotFoundError(f"mkbrr binary not found: {mkbrr_binary}")
-                        output_path = Path(meta.base_dir) / "tmp" / meta.uuid / f"{output_filename}.torrent"
+                        if is_base:
+                            output_path = Path(meta.base_dir) / "tmp" / meta.uuid / "torrents" / ".staging" / f"{output_filename}.torrent"
+                            output_path.parent.mkdir(parents=True, exist_ok=True)
+                        else:
+                            output_path = Path(meta.base_dir) / "tmp" / meta.uuid / f"{output_filename}.torrent"
 
                         # Ensure executable permission for non-Windows systems
                         if not sys.platform.startswith("win"):
@@ -454,6 +441,11 @@ class TorrentCreator:
                         if not Path(output_path).exists():
                             logger.info("[bold red]mkbrr did not create a torrent file!")
                             raise FileNotFoundError(f"Expected torrent file {output_path} was not created")
+                        if is_base:
+                            manifest = TorrentManifest(meta.base_dir, meta.uuid)
+                            entry = manifest.register(output_path, "base_subs" if is_subs else "base", "generated", make_default=make_default)
+                            output_path.unlink(missing_ok=True)
+                            return str(manifest.entry_path(entry))
                         return output_path
 
                     except subprocess.CalledProcessError as e:
@@ -502,9 +494,16 @@ class TorrentCreator:
                 publish_progress(progress_id, progress_label, current=0, total=1, detail="Starting torrent hash", group="media", unit="pieces")
 
                 # Run torrent generation in thread to avoid blocking the event loop
+                staging_path = (
+                    Path(meta.base_dir) / "tmp" / meta.uuid / "torrents" / ".staging" / f"{output_filename}.torrent"
+                    if is_base
+                    else Path(meta.base_dir) / "tmp" / meta.uuid / f"{output_filename}.torrent"
+                )
+                staging_path.parent.mkdir(parents=True, exist_ok=True)
+
                 def generate_torrent() -> None:
                     torrent.generate(callback=cls.torf_cb, interval=5)
-                    torrent.write(f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/{output_filename}.torrent", overwrite=True)
+                    torrent.write(staging_path, overwrite=True)
                     torrent.verify_filesize(path)
 
                 try:
@@ -516,12 +515,16 @@ class TorrentCreator:
                 total_elapsed_time = time.time() - overall_start_time
                 formatted_time = time.strftime("%H:%M:%S", time.gmtime(total_elapsed_time))
 
-                torrent_file_path = f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/{output_filename}.torrent"
-                torrent_file_size = Path(torrent_file_path).stat().st_size / 1024
+                torrent_file_size = staging_path.stat().st_size / 1024
                 logger.debug("")
                 logger.debug(f"[bold green]torrent created in {formatted_time}")
                 logger.debug(f"[green]Torrent file size: {torrent_file_size:.2f} KB")
                 complete_progress(progress_id, progress_label, current=1, total=1, detail="Torrent created", group="media", unit="pieces")
+                if is_base:
+                    manifest = TorrentManifest(meta.base_dir, meta.uuid)
+                    entry = manifest.register(staging_path, "base_subs" if is_subs else "base", "generated", make_default=make_default)
+                    staging_path.unlink(missing_ok=True)
+                    return str(manifest.entry_path(entry))
                 return torrent
             finally:
                 cls._create_torrent_inflight -= 1
@@ -572,7 +575,10 @@ class TorrentCreator:
     @staticmethod
     def create_random_torrents(base_dir: str, uuid: str, num: int | str, path: str) -> None:
         manual_name = re.sub(r"[^0-9a-zA-Z\[\]\'\-]+", ".", Path(path).name)
-        base_torrent = Torrent.read(f"{base_dir}{'/' + 'tmp' + '/'}{uuid}/BASE.torrent")
+        base_path = TorrentManifest(base_dir, uuid).default_path()
+        if base_path is None:
+            raise FileNotFoundError("No base torrent is registered in the torrent manifest")
+        base_torrent = Torrent.read(base_path)
         for i in range(1, int(num) + 1):
             new_torrent = base_torrent
             new_torrent.metainfo["info"]["entropy"] = random.randint(1, 999999)  # type: ignore  # nosec B311  # noqa: S311
@@ -582,49 +588,10 @@ class TorrentCreator:
     async def create_base_from_existing_torrent(torrentpath: str, base_dir: str, uuid: str) -> str | None:
         if Path(torrentpath).exists():
             base_torrent = Torrent.read(torrentpath)
-            base_torrent.trackers = ["https://fake.tracker"]
-            base_torrent.comment = "Upload-Assistant (fork)"
-            base_torrent.created_by = "Upload-Assistant (fork)"
-            info_dict = base_torrent.metainfo["info"]
-            valid_keys = ["name", "piece length", "pieces", "private", "source"]
-
-            # Add the correct key based on single vs multi file torrent
-            if "files" in info_dict:
-                valid_keys.append("files")
-            elif "length" in info_dict:
-                valid_keys.append("length")
-
-            # Remove everything not in the whitelist
-            for each in list(info_dict):
-                if each not in valid_keys:
-                    info_dict.pop(each, None)  # type: ignore
-            for each in list(base_torrent.metainfo):
-                if each not in (
-                    "announce",
-                    "comment",
-                    "creation date",
-                    "created by",
-                    "encoding",
-                    "info",
-                    "imdb",
-                    "tmdb",
-                    "tvdb",
-                    "tvmaze",
-                    "mal",
-                    "douban",
-                    "igdb",
-                    "asin",
-                    "isbn",
-                ):
-                    base_torrent.metainfo.pop(each, None)  # type: ignore
-            base_torrent.source = "L4G"
-            base_torrent.private = True
             has_subs = any(Path(str(f)).suffix.lower() in SUBTITLE_EXTENSIONS for f in base_torrent.files)
-            out_name = "BASE_SUBS.torrent" if has_subs else "BASE.torrent"
-            output_path = Path(base_dir) / "tmp" / uuid / out_name
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-            Torrent.copy(base_torrent).write(output_path, overwrite=True)
-            return str(output_path)
+            manifest = TorrentManifest(base_dir, uuid)
+            entry = manifest.register(torrentpath, "base_subs" if has_subs else "base", "client")
+            return str(manifest.entry_path(entry))
         return None
 
     @staticmethod
@@ -680,6 +647,7 @@ async def create_torrent(
     output_filename: str,
     tracker_url: str | None = None,
     piece_size: int = 0,
+    make_default: bool = False,
 ) -> str | Torrent:
     return await TorrentCreator.create_torrent(
         meta=meta,
@@ -687,6 +655,7 @@ async def create_torrent(
         output_filename=output_filename,
         tracker_url=tracker_url,
         piece_size=piece_size,
+        make_default=make_default,
     )
 
 

--- a/src/trackerhandle.py
+++ b/src/trackerhandle.py
@@ -20,6 +20,7 @@ from src.manualpackage import ManualPackageManager
 from src.meta import Meta
 from src.qbitwait import Wait
 from src.rehostimages import check_tracker_image_hosts, has_restricted_image_hosts, select_common_image_host
+from src.torrent_provision import provision_tracker_torrents
 from src.trackers.GAZELLE.passthepopcorn import PassThePopcorn
 from src.trackersetup import TrackerSetup
 
@@ -75,8 +76,14 @@ async def process_trackers(
     tracker_setup = TrackerSetup(config=config)
     tracker_setup_any = cast(Any, tracker_setup)
     enabled_trackers = list(cast(Sequence[str], tracker_setup_any.trackers_enabled(meta)))
+    manual_targets = "MANUAL" in enabled_trackers
+    torrent_targets = [
+        tracker
+        for tracker in enabled_trackers
+        if tracker not in {"MANUAL", "USENET"} and (manual_targets or bool(cast(Mapping[str, Any], meta.tracker_status.get(tracker, {})).get("upload", False)))
+    ]
+    await provision_tracker_torrents(meta, config, torrent_targets, tracker_class_map)
     if config.get("DEFAULT", {}).get("smart_image_host_selection", True) and not meta.imghost_from_cli:
-        manual_targets = "MANUAL" in enabled_trackers
         target_trackers = [
             tracker
             for tracker in enabled_trackers

--- a/src/trackers/GAZELLE/anthelion.py
+++ b/src/trackers/GAZELLE/anthelion.py
@@ -15,7 +15,7 @@ from src.console import logger, prompt_in_thread
 from src.get_desc import DescriptionBuilder
 from src.mediainfo import strip_report_by_line
 from src.meta import Meta
-from src.torrentcreate import TorrentCreator
+from src.torrent_policy import ANTHELION_POLICY
 from src.trackers.common import Common
 
 Config = dict[str, Any]
@@ -111,6 +111,7 @@ class Anthelion:
     base_url = "https://anthelion.me"
     api_url = f"{base_url}/api.php"
     supported_categories = ("MOVIE",)
+    torrent_policy = ANTHELION_POLICY
     tracker_urls = ("tracker.anthelion.me",)
 
     def __init__(self, config: Config):
@@ -249,21 +250,7 @@ class Anthelion:
         return ant_type
 
     async def upload(self, meta: Meta) -> bool:
-        torrent_filename = "BASE"
-        torrent_path = f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/BASE.torrent"
-        torrent_file_size_kib = Path(torrent_path).stat().st_size / 1024
-        tracker_url: str = ""
-        if meta.mkbrr:
-            tracker_url = self.tracker_config.get("announce_url", "https://fake.tracker").strip()
-
-        # Trigger regeneration automatically if size constraints aren't met
-        if torrent_file_size_kib > 250:  # 250 KiB
-            logger.info(f"{self.tracker}: [yellow]Existing .torrent exceeds 250 KiB and will be regenerated to fit constraints.")
-            meta.max_piece_size = 128  # 128 MiB
-            await TorrentCreator.create_torrent(meta, str(Path(str(meta.path))), "ANTHELION", tracker_url=tracker_url)
-            torrent_filename = "ANTHELION"
-
-        await self.common.create_torrent_for_upload(meta, self.tracker, self.source_flag, torrent_filename=torrent_filename)
+        await self.common.create_torrent_for_upload(meta, self.tracker, self.source_flag)
         flags = await self.get_flags(meta)
         audioformat = await self.get_audio(meta)
         if not audioformat:

--- a/src/trackers/GAZELLE/passthepopcorn.py
+++ b/src/trackers/GAZELLE/passthepopcorn.py
@@ -28,7 +28,7 @@ from src.rehostimages import ImageHostPolicy, RehostImagesManager
 from src.screenshot_manifest import files as manifest_files
 from src.takescreens import TakeScreensManager
 from src.temp_paths import artwork_dir, screenshots_dir
-from src.torrentcreate import TorrentCreator
+from src.torrent_policy import PASSTHEPOPCORN_POLICY
 from src.tracker_images import get_tracker_image_collection
 from src.trackers.common import Common
 from src.uploadscreens import UploadScreensManager
@@ -135,6 +135,7 @@ class PassThePopcorn:
         ("Vietnamese", "vie", "vi"): 25,
     }
     supported_categories = ("MOVIE",)
+    torrent_policy = PASSTHEPOPCORN_POLICY
     tracker_urls = ("passthepopcorn.me",)
 
     def __init__(self, config: dict[str, Any]) -> None:
@@ -1628,26 +1629,8 @@ class PassThePopcorn:
 
     async def upload(self, meta: Meta, url: str, data: dict[str, Any]) -> bool:
         common = Common(config=self.config)
-        base_piece_mb = meta.base_torrent_piece_mb or 0
         torrent_file_path = f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/[{self.tracker}].torrent"
-
-        # Check if the piece size exceeds 16 MiB and regenerate the torrent if needed
-        if base_piece_mb > 16 and not meta.nohash:
-            logger.info(f"{self.tracker}: [red]Piece size is OVER 16M and does not work on PassThePopcorn. Generating a new .torrent")
-            tracker_url = self.announce_url.strip() if self.announce_url else "https://fake.tracker"
-            piece_size = 16
-            torrent_create = f"[{self.tracker}]"
-            try:
-                cooldown = int(self.config.get("DEFAULT", {}).get("rehash_cooldown", 0) or 0)
-            except ValueError, TypeError:
-                cooldown = 0
-            if cooldown > 0:
-                await asyncio.sleep(cooldown)  # Small cooldown before rehashing
-
-            await TorrentCreator.create_torrent(meta, str(meta.path), torrent_create, tracker_url=tracker_url, piece_size=piece_size)
-            await common.create_torrent_for_upload(meta, self.tracker, self.source_flag, torrent_filename=torrent_create)
-        else:
-            await common.create_torrent_for_upload(meta, self.tracker, self.source_flag)
+        await common.create_torrent_for_upload(meta, self.tracker, self.source_flag)
 
         # Proceed with the upload process
         async with aiofiles.open(torrent_file_path, "rb") as torrent_file_handle:

--- a/src/trackers/UNIT3D/__init__.py
+++ b/src/trackers/UNIT3D/__init__.py
@@ -513,8 +513,9 @@ class UNIT3D:
 
     async def upload(self, meta: Meta) -> bool:
         data = await self.get_data(meta)
-        torrent_filename = await self.common.get_torrent_filename(meta, self.tracker_config)
-        torrent_file_path = f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/{torrent_filename}.torrent"
+        torrent_file_path = await self.common.get_base_torrent_path(meta, self.tracker, self.tracker_config)
+        if torrent_file_path is None:
+            raise FileNotFoundError("No selected base torrent is available")
         async with aiofiles.open(torrent_file_path, "rb") as f:
             torrent_bytes = await f.read()
         files = {"torrent": ("torrent.torrent", torrent_bytes, "application/x-bittorrent")}

--- a/src/trackers/common.py
+++ b/src/trackers/common.py
@@ -29,6 +29,7 @@ from src.exportmi import export_info
 from src.genre_map import AUDIBLE_ENG_GENRE_MAP, AUDIBLE_PTBR_GENRE_MAP, ENG_TO_PTBR_GENRE_MAP
 from src.languages import languages_manager
 from src.meta import Meta
+from src.torrent_manifest import TorrentManifest
 from src.usenetcreate import verify_nzb_has_password
 
 
@@ -250,10 +251,20 @@ class Common:
         if isinstance(tracker_config, dict):
             allow_ext_subtitles = tracker_config.get("allow_ext_subtitles", False)
         if allow_ext_subtitles:
-            subs_path = f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/BASE_SUBS.torrent"
-            if await self.path_exists(subs_path):
+            subs_path = TorrentManifest(meta.base_dir, meta.uuid).default_path("base_subs")
+            if subs_path is not None:
                 torrent_filename = "BASE_SUBS"
         return torrent_filename
+
+    async def get_base_torrent_path(self, meta: Meta, tracker: str, tracker_config: Any) -> Path | None:
+        """Resolve a tracker's selected reusable base from the canonical manifest."""
+        manifest = TorrentManifest(meta.base_dir, meta.uuid)
+        selected = manifest.selected_path(tracker)
+        if selected is not None:
+            return selected
+        layout = "base_subs" if await self.get_torrent_filename(meta, tracker_config) == "BASE_SUBS" else "base"
+        entry = manifest.select(tracker, layout)
+        return manifest.entry_path(entry) if entry is not None else None
 
     async def create_torrent_for_upload(
         self,
@@ -267,9 +278,10 @@ class Common:
     ) -> None:
         tracker_cfg = self.config.get("TRACKERS", {}).get(tracker, {})
         if torrent_filename == "BASE":
-            torrent_filename = await self.get_torrent_filename(meta, tracker_cfg)
-
-        path = f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/{torrent_filename}.torrent"
+            base_path = await self.get_base_torrent_path(meta, tracker, tracker_cfg)
+            path = str(base_path) if base_path is not None else ""
+        else:
+            path = f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/{torrent_filename}.torrent"
         if await self.path_exists(path):
             loop = asyncio.get_running_loop()
             new_torrent = await loop.run_in_executor(None, lambda: Torrent.read(path))

--- a/src/trackers/common.py
+++ b/src/trackers/common.py
@@ -279,7 +279,9 @@ class Common:
         tracker_cfg = self.config.get("TRACKERS", {}).get(tracker, {})
         if torrent_filename == "BASE":
             base_path = await self.get_base_torrent_path(meta, tracker, tracker_cfg)
-            path = str(base_path) if base_path is not None else ""
+            if base_path is None:
+                raise FileNotFoundError(f"{tracker}: no selected base torrent is available in the manifest")
+            path = str(base_path)
         else:
             path = f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/{torrent_filename}.torrent"
         if await self.path_exists(path):

--- a/src/trackers/hdbits.py
+++ b/src/trackers/hdbits.py
@@ -2,7 +2,6 @@
 import asyncio
 import json
 import re
-import shutil
 from pathlib import Path
 from typing import Any, cast
 from urllib.parse import quote, urlparse
@@ -10,18 +9,16 @@ from urllib.parse import quote, urlparse
 import aiofiles
 import httpx
 from rich.markup import escape
-from torf import Torrent
 from unidecode import unidecode
 
 from src.bbcode import BBCODE
-from src.clients import Clients
 from src.cogs.redaction import Redaction
 from src.console import console, logger
 from src.description_review import get_base_description
 from src.exceptions import *  # noqa F403
 from src.meta import Meta
 from src.temp_paths import screenshots_dir
-from src.torrentcreate import TorrentCreator, hdbits_pieces_allowed
+from src.torrent_policy import HDBITS_POLICY
 from src.trackers.common import Common
 
 Config = dict[str, Any]
@@ -41,6 +38,7 @@ class HDBits:
     banned_groups: tuple[str, ...] = ("",)
     base_url = "https://hdbits.org"
     supported_categories = ("TV", "MOVIE")
+    torrent_policy = HDBITS_POLICY
     tracker_urls = ("https://tracker.hdbits.org",)
 
     def __init__(self, config: Config) -> None:
@@ -259,38 +257,7 @@ class HDBits:
             hdb_desc = await desc_file.read()
 
         torrent_file_path = f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/[{self.tracker}].torrent"
-        tracker_config = self.config.get("TRACKERS", {}).get(self.tracker, {})
-        torrent_dir = Path(meta.base_dir) / "tmp" / meta.uuid
-        base_name = await common.get_torrent_filename(meta, tracker_config)
-        base_torrent = Torrent.read(torrent_dir / f"{base_name}.torrent")
-        torrent_name = base_name
-        if not hdbits_pieces_allowed(base_torrent.piece_size, base_torrent.pieces, base_torrent.size):
-            search_meta = meta.copy()
-            search_meta.trackers = [self.tracker]
-            if base_name != "BASE_SUBS":
-                search_meta.subtitle_files = []
-            clients = Clients(self.config)
-            candidate_path = await clients.find_existing_torrent(search_meta)
-            if candidate_path and search_meta.subtitle_files and not clients._torrent_includes_all_local_subtitles(candidate_path, search_meta):
-                candidate_path = None
-
-            torrent_name = f"[{self.tracker}]"
-            if candidate_path:
-                await asyncio.to_thread(shutil.copyfile, candidate_path, torrent_dir / f"{torrent_name}.torrent")
-            else:
-                logger.info("HDBITS: [yellow]No torrent meeting the piece limits found. Generating a new .torrent")
-                try:
-                    cooldown = int(self.config.get("DEFAULT", {}).get("rehash_cooldown", 0) or 0)
-                except ValueError, TypeError:
-                    cooldown = 0
-                if cooldown > 0:
-                    await asyncio.sleep(cooldown)
-                if base_name == "BASE_SUBS":
-                    torrent_name += "_BASE_SUBS"
-                tracker_url = str(tracker_config.get("announce_url") or "https://fake.tracker").strip()
-                await TorrentCreator.create_torrent(search_meta, str(meta.path), torrent_name, tracker_url=tracker_url)
-
-        await common.create_torrent_for_upload(meta, self.tracker, self.source_flag, torrent_filename=torrent_name)
+        await common.create_torrent_for_upload(meta, self.tracker, self.source_flag)
 
         # Proceed with the upload process
         async with aiofiles.open(torrent_file_path, "rb") as torrent_file:

--- a/src/trackers/iptorrents.py
+++ b/src/trackers/iptorrents.py
@@ -1,6 +1,5 @@
 # Upload Assistant © 2025 Audionut & wastaken7 — Licensed under UAPL v1.0
 import re
-from pathlib import Path
 from typing import Any
 
 import aiofiles
@@ -12,6 +11,7 @@ from src.console import logger
 from src.cookie_auth import CookieAuthUploader, CookieValidator
 from src.get_desc import DescriptionBuilder
 from src.meta import Meta
+from src.torrent_manifest import TorrentManifest
 
 Config = dict[str, Any]
 
@@ -407,8 +407,8 @@ class IPTorrents:
         return re.sub(r"\s{2,}", " ", name)
 
     async def get_is_freeleech(self, meta: Meta):
-        torrent_path = f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/BASE.torrent"
-        if not Path(torrent_path).exists():
+        torrent_path = TorrentManifest(meta.base_dir, meta.uuid).default_path()
+        if torrent_path is None:
             return False
 
         try:

--- a/src/trackers/speedapp.py
+++ b/src/trackers/speedapp.py
@@ -289,8 +289,10 @@ class SpeedApp:
                 data["systemRequirements"] = requirements
 
         tracker_config = self.config.get("TRACKERS", {}).get(self.tracker, {})
-        torrent_filename = await self.common.get_torrent_filename(meta, tracker_config)
-        data["file"] = await self.encode_to_base64(f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/{torrent_filename}.torrent")
+        torrent_path = await self.common.get_base_torrent_path(meta, self.tracker, tracker_config)
+        if torrent_path is None:
+            raise FileNotFoundError("No selected base torrent is available")
+        data["file"] = await self.encode_to_base64(str(torrent_path))
         if meta.debug is True:
             data["file"] = data["file"][:50] + "...[DEBUG MODE]"
             if data.get("nfo"):

--- a/tests/test_early_tasks.py
+++ b/tests/test_early_tasks.py
@@ -130,3 +130,42 @@ def test_early_torrent_task_creates_missing_subtitle_variant(monkeypatch, tmp_pa
         assert outputs == ["BASE_SUBS"]
 
     asyncio.run(exercise())
+
+
+def test_early_torrent_task_refreshes_layouts_after_reuse(monkeypatch, tmp_path) -> None:
+    async def exercise() -> None:
+        layouts = {"base": None, "base_subs": None}
+        outputs = []
+        reusable = tmp_path / "reusable.torrent"
+        reusable.touch()
+
+        def default_path(_self, layout="base"):
+            return layouts[layout]
+
+        async def register_reuse(_path, _base_dir, _uuid):
+            layouts["base_subs"] = reusable
+            return str(reusable)
+
+        async def create_torrent(_meta, _path, output, **_kwargs):
+            outputs.append(output)
+
+        async def find_reuse(_meta):
+            return str(reusable)
+
+        monkeypatch.setattr(early_tasks.TorrentManifest, "default_path", default_path)
+        monkeypatch.setattr(early_tasks.TorrentCreator, "create_base_from_existing_torrent", register_reuse)
+        monkeypatch.setattr(early_tasks.TorrentCreator, "create_torrent", create_torrent)
+        meta = Meta(
+            base_dir=str(tmp_path),
+            uuid="release",
+            path=str(tmp_path / "release.mkv"),
+            subtitle_files=[str(tmp_path / "release.srt")],
+            trackers=["TEST"],
+        )
+        client = SimpleNamespace(find_existing_torrent=find_reuse)
+
+        await early_tasks.create_base_torrents_early(meta, client)
+
+        assert outputs == ["BASE"]
+
+    asyncio.run(exercise())

--- a/tests/test_early_tasks.py
+++ b/tests/test_early_tasks.py
@@ -1,9 +1,11 @@
 # ruff: noqa: S101
 
 import asyncio
+from types import SimpleNamespace
 
 from src import early_tasks
 from src.console import progress_display, suppress_cli_progress
+from src.meta import Meta
 from src.webui_progress import PROGRESS_STDOUT_PREFIX, clear_progress_callback, publish_progress, set_progress_callback
 
 
@@ -97,3 +99,34 @@ def test_webui_subprocess_progress_uses_structured_stdout(monkeypatch, capsys) -
     output = capsys.readouterr().out
     assert output.strip().startswith(PROGRESS_STDOUT_PREFIX)
     assert '"id":"hash"' in output
+
+
+def test_early_torrent_task_creates_missing_subtitle_variant(monkeypatch, tmp_path) -> None:
+    async def exercise() -> None:
+        outputs = []
+
+        def default_path(_self, layout="base"):
+            return tmp_path / "base.torrent" if layout == "base" else None
+
+        async def create_torrent(_meta, _path, output, **_kwargs):
+            outputs.append(output)
+
+        async def unexpected_search(_meta):
+            raise AssertionError("existing base must not trigger client search")
+
+        monkeypatch.setattr(early_tasks.TorrentManifest, "default_path", default_path)
+        monkeypatch.setattr(early_tasks.TorrentCreator, "create_torrent", create_torrent)
+        meta = Meta(
+            base_dir=str(tmp_path),
+            uuid="release",
+            path=str(tmp_path / "release.mkv"),
+            subtitle_files=[str(tmp_path / "release.srt")],
+            trackers=["TEST"],
+        )
+        client = SimpleNamespace(find_existing_torrent=unexpected_search)
+
+        await early_tasks.create_base_torrents_early(meta, client)
+
+        assert outputs == ["BASE_SUBS"]
+
+    asyncio.run(exercise())

--- a/tests/test_hdbits_pieces.py
+++ b/tests/test_hdbits_pieces.py
@@ -7,6 +7,9 @@ from torf import Torrent
 
 from src.clients import Clients
 from src.meta import Meta
+from src.torrent_manifest import TorrentManifest
+from src.torrent_policy import HDBITS_POLICY
+from src.torrent_provision import provision_tracker_torrents
 from src.torrentcreate import TorrentCreator, hdbits_pieces_allowed
 from src.trackers.hdbits import HDBits
 
@@ -74,11 +77,11 @@ def setup_release(tmp_path, monkeypatch):
 @pytest.mark.parametrize(("piece_size", "size"), [(2 * MIB, 4000 * 2 * MIB), (4 * MIB, 30000 * 4 * MIB), (8 * MIB, 30000 * 8 * MIB), (32 * MIB, TIB + 1)])
 async def test_upload_reuses_allowed_base_without_search_or_hash(setup_release, monkeypatch, piece_size, size):
     directory, meta, config = setup_release
-    original = write_torrent(directory / "BASE.torrent", piece_size, size)
-    search = AsyncMock(side_effect=AssertionError("must not search"))
-    create = AsyncMock(side_effect=AssertionError("must not rehash"))
-    monkeypatch.setattr(Clients, "find_existing_torrent", search)
-    monkeypatch.setattr(TorrentCreator, "create_torrent", create)
+    source = directory / "candidate.torrent"
+    original = write_torrent(source, piece_size, size)
+    manifest = TorrentManifest(meta.base_dir, meta.uuid)
+    manifest.register(source, "base", "client:test")
+    assert manifest.select("HDBITS", "base", HDBITS_POLICY) is not None
     assert await HDBits(config).upload(meta) is True
     result = Torrent.read(directory / "[HDBITS].torrent")
     assert result.piece_size == piece_size
@@ -86,41 +89,53 @@ async def test_upload_reuses_allowed_base_without_search_or_hash(setup_release, 
 
 
 @pytest.mark.asyncio
-async def test_upload_finds_alternative_before_rehash(setup_release, tmp_path, monkeypatch):
+async def test_provision_selects_registered_alternative_before_rehash(setup_release, tmp_path, monkeypatch):
     directory, meta, config = setup_release
     size = 10 * GIB
-    write_torrent(directory / "BASE.torrent", 2 * MIB, size)
+    invalid = directory / "invalid.torrent"
+    write_torrent(invalid, 2 * MIB, size)
     alternative = tmp_path / "alternative.torrent"
     write_torrent(alternative, 4 * MIB, size)
-    search = AsyncMock(return_value=str(alternative))
-    monkeypatch.setattr(Clients, "find_existing_torrent", search)
+    manifest = TorrentManifest(meta.base_dir, meta.uuid)
+    manifest.register(invalid, "base", "client:first")
+    manifest.register(alternative, "base", "client:second")
     monkeypatch.setattr(TorrentCreator, "create_torrent", AsyncMock(side_effect=AssertionError("must not rehash")))
-    assert await HDBits(config).upload(meta) is True
-    assert Torrent.read(directory / "[HDBITS].torrent").piece_size == 4 * MIB
-    search.assert_awaited_once()
-    assert Torrent.read(directory / "BASE.torrent").piece_size == 2 * MIB
+    assert await provision_tracker_torrents(meta, config, ["HDBITS"], {"HDBITS": HDBits}) == set()
+    assert Torrent.read(manifest.selected_path("HDBITS")).piece_size == 4 * MIB
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("nohash", [False, True])
-async def test_upload_forces_rehash_only_after_failed_search(setup_release, monkeypatch, nohash):
+async def test_provision_hashes_only_after_registered_variants_fail(setup_release, monkeypatch):
     directory, meta, config = setup_release
-    meta.nohash = nohash
     size = 10 * GIB
-    write_torrent(directory / "BASE.torrent", 2 * MIB, size)
-    search = AsyncMock(return_value=None)
-    monkeypatch.setattr(Clients, "find_existing_torrent", search)
+    invalid = directory / "invalid.torrent"
+    write_torrent(invalid, 2 * MIB, size)
+    manifest = TorrentManifest(meta.base_dir, meta.uuid)
+    manifest.register(invalid, "base", "client:first")
 
     async def create(hash_meta, path, output, **kwargs):
-        search.assert_awaited_once()
         assert hash_meta.trackers == ["HDBITS"]
-        write_torrent(directory / f"{output}.torrent", 16 * MIB, size)
+        generated = directory / "generated.torrent"
+        write_torrent(generated, 16 * MIB, size)
+        manifest.register(generated, "base", "generated")
 
     hashing = AsyncMock(side_effect=create)
     monkeypatch.setattr(TorrentCreator, "create_torrent", hashing)
-    assert await HDBits(config).upload(meta) is True
+    assert await provision_tracker_torrents(meta, config, ["HDBITS"], {"HDBITS": HDBits}) == set()
     hashing.assert_awaited_once()
-    assert Torrent.read(directory / "[HDBITS].torrent").piece_size == 16 * MIB
+    assert Torrent.read(manifest.selected_path("HDBITS")).piece_size == 16 * MIB
+
+
+@pytest.mark.asyncio
+async def test_nohash_blocks_tracker_when_no_compliant_variant_exists(setup_release, monkeypatch):
+    directory, meta, config = setup_release
+    meta.nohash = True
+    invalid = directory / "invalid.torrent"
+    write_torrent(invalid, 2 * MIB, 10 * GIB)
+    TorrentManifest(meta.base_dir, meta.uuid).register(invalid, "base", "client:first")
+    monkeypatch.setattr(TorrentCreator, "create_torrent", AsyncMock(side_effect=AssertionError("must not hash")))
+    assert await provision_tracker_torrents(meta, config, ["HDBITS"], {"HDBITS": HDBits}) == {"HDBITS"}
+    assert meta.tracker_status["HDBITS"]["upload"] is False
 
 
 @pytest.mark.asyncio
@@ -135,8 +150,9 @@ async def test_client_search_skips_invalid_hash_and_uses_next_client(setup_relea
     write_torrent(second / "abc.torrent", 4 * MIB, size)
     config["DEFAULT"].update(default_torrent_client="first", searching_client_list=["first", "second"])
     config["TORRENT_CLIENTS"] = {name: {"torrent_client": "qbit", "torrent_storage_dir": str(path)} for name, path in [("first", first), ("second", second)]}
-    assert await Clients(config).find_existing_torrent(meta) == str(second / "abc.torrent")
-    assert meta.reuse_torrent_client == "second"
+    paths = await Clients(config).find_existing_torrents(meta)
+    assert len(paths) == 1
+    assert Torrent.read(paths[0]).piece_size == 4 * MIB
     assert (first / "abc.torrent").exists()
 
 
@@ -177,7 +193,7 @@ async def test_mkbrr_gets_recommended_size_even_with_tracker_url(setup_release, 
 
     def process(command, **kwargs):
         commands.append(command)
-        write_torrent(directory / "BASE.torrent", 16 * MIB, 8 * GIB + 1)
+        write_torrent(Path(command[command.index("-o") + 1]), 16 * MIB, 8 * GIB + 1)
         return SimpleNamespace(stdout=[], wait=lambda: 0)
 
     monkeypatch.setattr("src.torrentcreate.subprocess.Popen", process)

--- a/tests/test_torrent_manifest.py
+++ b/tests/test_torrent_manifest.py
@@ -1,0 +1,161 @@
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+from torf import Torrent
+
+from src.torrent_manifest import TorrentEntry, TorrentManifest
+from src.torrent_policy import ANTHELION_POLICY, PASSTHEPOPCORN_POLICY, MIB, TorrentPolicy, TorrentStats
+from src.torrent_provision import provision_tracker_torrents
+from src.trackers.GAZELLE.anthelion import Anthelion
+from src.trackers.GAZELLE.passthepopcorn import PassThePopcorn
+from src.trackers.hdbits import HDBits
+
+
+def write_torrent(path: Path, piece_size: int = 4 * MIB, size: int = 8 * MIB, name: str = "release.mkv") -> Torrent:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    torrent = Torrent()
+    pieces = (size + piece_size - 1) // piece_size
+    torrent.metainfo["info"] = {"name": name, "length": size, "piece length": piece_size, "pieces": b"x" * (20 * pieces)}
+    torrent.trackers = ["https://private.example/passkey"]
+    torrent.comment = "private comment"
+    torrent.write(path, overwrite=True)
+    return torrent
+
+
+def test_register_sanitizes_and_places_torrent_under_piece_directory(tmp_path):
+    source = tmp_path / "client.torrent"
+    write_torrent(source)
+    manifest = TorrentManifest(tmp_path, "release")
+
+    entry = manifest.register(source, "base", "client:qbit")
+    path = manifest.entry_path(entry)
+
+    assert path.parent.name == str(4 * MIB)
+    assert path.name == f"{entry.infohash}.torrent"
+    assert Torrent.read(path).infohash == entry.infohash
+    assert Torrent.read(path).trackers == [["https://fake.tracker"]]
+    assert "private.example" not in path.read_bytes().decode("latin-1")
+    default = manifest.default_path("base")
+    assert default == path
+
+
+def test_manifest_keeps_layouts_separate_and_deduplicates(tmp_path):
+    base = tmp_path / "base.torrent"
+    subs = tmp_path / "subs.torrent"
+    write_torrent(base)
+    write_torrent(subs, name="release-with-subs.mkv")
+    manifest = TorrentManifest(tmp_path, "release")
+
+    first = manifest.register(base, "base", "generated")
+    again = manifest.register(base, "base", "client:qbit")
+    manifest.register(subs, "base_subs", "generated")
+
+    assert first.id == again.id
+    assert len(manifest.entries("base")) == 1
+    assert len(manifest.entries("base_subs")) == 1
+
+
+def test_explicit_default_replaces_the_previous_default(tmp_path):
+    first = tmp_path / "first.torrent"
+    second = tmp_path / "second.torrent"
+    write_torrent(first, MIB)
+    write_torrent(second, 2 * MIB)
+    manifest = TorrentManifest(tmp_path, "release")
+    manifest.register(first, "base", "client:first")
+    replacement = manifest.register(second, "base", "generated", make_default=True)
+    assert manifest.default_path() == manifest.entry_path(replacement)
+
+
+def test_corrupt_manifest_is_treated_as_empty(tmp_path):
+    manifest = TorrentManifest(tmp_path, "release")
+    manifest.path.parent.mkdir(parents=True)
+    manifest.path.write_text("not json", encoding="utf-8")
+    assert manifest.entries() == []
+
+
+def test_manifest_rejects_escaping_entry_path(tmp_path):
+    manifest = TorrentManifest(tmp_path, "release")
+    manifest.path.parent.mkdir(parents=True)
+    escaped = TorrentEntry("bad", "../outside.torrent", "base", "test", "bad", 1, 1, 1, 1)
+    manifest.path.write_text(
+        json.dumps({"version": 1, "torrents": {"bad": escaped.__dict__}, "defaults": {"base": "bad"}, "selections": {}}),
+        encoding="utf-8",
+    )
+    assert manifest.entries() == []
+    assert manifest.default_path() is None
+
+
+def test_manifest_rejects_a_managed_file_changed_after_registration(tmp_path):
+    source = tmp_path / "source.torrent"
+    replacement = tmp_path / "replacement.torrent"
+    write_torrent(source, MIB)
+    write_torrent(replacement, 2 * MIB)
+    manifest = TorrentManifest(tmp_path, "release")
+    entry = manifest.register(source, "base", "generated")
+    manifest.entry_path(entry).write_bytes(replacement.read_bytes())
+
+    assert manifest.entries() == []
+    assert manifest.select("TEST", "base") is None
+
+
+def test_policy_selection_records_tracker_choice(tmp_path):
+    large = tmp_path / "large.torrent"
+    small = tmp_path / "small.torrent"
+    write_torrent(large, 32 * MIB, 64 * MIB)
+    write_torrent(small, 16 * MIB, 64 * MIB)
+    manifest = TorrentManifest(tmp_path, "release")
+    manifest.register(large, "base", "client:first")
+    manifest.register(small, "base", "client:second")
+
+    selected = manifest.select("PASSTHEPOPCORN", "base", PASSTHEPOPCORN_POLICY)
+
+    assert selected is not None
+    assert selected.piece_size == 16 * MIB
+    assert manifest.selected_path("PASSTHEPOPCORN") == manifest.entry_path(selected)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_registration_keeps_manifest_valid(tmp_path):
+    sources = [tmp_path / f"source-{size}.torrent" for size in (MIB, 2 * MIB, 4 * MIB)]
+    for source, piece_size in zip(sources, (MIB, 2 * MIB, 4 * MIB), strict=True):
+        write_torrent(source, piece_size, 8 * MIB)
+    manifest = TorrentManifest(tmp_path, "release")
+
+    await asyncio.gather(*(asyncio.to_thread(manifest.register, source, "base", "client:test") for source in sources))
+
+    assert len(manifest.entries()) == 3
+
+
+def test_tracker_policy_boundaries():
+    assert PASSTHEPOPCORN_POLICY.accepts(TorrentStats(16 * MIB, 1, 16 * MIB, 100))
+    assert not PASSTHEPOPCORN_POLICY.accepts(TorrentStats(32 * MIB, 1, 32 * MIB, 100))
+    assert ANTHELION_POLICY.accepts(TorrentStats(4 * MIB, 1, 4 * MIB, 250 * 1024))
+    assert not ANTHELION_POLICY.accepts(TorrentStats(4 * MIB, 1, 4 * MIB, 250 * 1024 + 1))
+    assert TorrentPolicy(max_piece_size=8 * MIB).choose_piece_size(100, 16 * MIB) == 8 * MIB
+
+
+def test_trackers_expose_typed_torrent_policies():
+    assert HDBits.torrent_policy is not None
+    assert PassThePopcorn.torrent_policy is PASSTHEPOPCORN_POLICY
+    assert Anthelion.torrent_policy is ANTHELION_POLICY
+
+
+@pytest.mark.asyncio
+async def test_nohash_blocks_tracker_without_compliant_variant(tmp_path):
+    source = tmp_path / "large.torrent"
+    media = tmp_path / "release.mkv"
+    media.touch()
+    write_torrent(source, 32 * MIB, 64 * MIB)
+    manifest = TorrentManifest(tmp_path, "release")
+    manifest.register(source, "base", "client:qbit")
+    from src.meta import Meta
+
+    meta = Meta(base_dir=str(tmp_path), uuid="release", path=str(media), filelist=[str(media)], trackers=["PASSTHEPOPCORN"], nohash=True)
+    meta.tracker_status = {"PASSTHEPOPCORN": {"upload": True}}
+
+    blocked = await provision_tracker_torrents(meta, {"TRACKERS": {"PASSTHEPOPCORN": {}}}, ["PASSTHEPOPCORN"], {"PASSTHEPOPCORN": PassThePopcorn})
+
+    assert blocked == {"PASSTHEPOPCORN"}
+    assert meta.tracker_status["PASSTHEPOPCORN"]["upload"] is False

--- a/tests/test_torrent_manifest.py
+++ b/tests/test_torrent_manifest.py
@@ -8,6 +8,8 @@ from torf import Torrent
 from src.torrent_manifest import TorrentEntry, TorrentManifest
 from src.torrent_policy import ANTHELION_POLICY, PASSTHEPOPCORN_POLICY, MIB, TorrentPolicy, TorrentStats
 from src.torrent_provision import provision_tracker_torrents
+from src.torrentcreate import TorrentCreator
+from src.trackers.common import Common
 from src.trackers.GAZELLE.anthelion import Anthelion
 from src.trackers.GAZELLE.passthepopcorn import PassThePopcorn
 from src.trackers.hdbits import HDBits
@@ -159,3 +161,45 @@ async def test_nohash_blocks_tracker_without_compliant_variant(tmp_path):
 
     assert blocked == {"PASSTHEPOPCORN"}
     assert meta.tracker_status["PASSTHEPOPCORN"]["upload"] is False
+
+
+@pytest.mark.asyncio
+async def test_provision_contains_failures_and_reports_accurate_reasons(tmp_path, monkeypatch):
+    from src.meta import Meta
+
+    media = tmp_path / "release.mkv"
+    media.touch()
+    policy = TorrentPolicy(required_piece_size=4 * MIB)
+    tracker_class_map = {tracker: type(tracker, (), {"torrent_policy": policy}) for tracker in ("FAIL", "REJECT", "GOOD")}
+    meta = Meta(base_dir=str(tmp_path), uuid="release", path=str(media), filelist=[str(media)], trackers=list(tracker_class_map))
+    meta.tracker_status = {tracker: {"upload": True} for tracker in tracker_class_map}
+    manifest = TorrentManifest(meta.base_dir, meta.uuid)
+
+    async def create_torrent(hash_meta, _path, _output, **_kwargs):
+        tracker = hash_meta.trackers[0]
+        if tracker == "FAIL":
+            raise OSError("disk unavailable")
+        if tracker == "GOOD":
+            generated = tmp_path / "good.torrent"
+            write_torrent(generated)
+            manifest.register(generated, "base", "generated")
+
+    monkeypatch.setattr(TorrentCreator, "create_torrent", create_torrent)
+
+    blocked = await provision_tracker_torrents(meta, {"TRACKERS": {}}, list(tracker_class_map), tracker_class_map)
+
+    assert blocked == {"FAIL", "REJECT"}
+    assert meta.tracker_status["FAIL"]["status_message"] == "Skipped: torrent provisioning failed: disk unavailable"
+    assert meta.tracker_status["REJECT"]["status_message"] == "Skipped: generated torrent does not satisfy the tracker policy"
+    assert meta.tracker_status["GOOD"]["upload"] is True
+    assert manifest.selected_path("GOOD") is not None
+
+
+@pytest.mark.asyncio
+async def test_create_torrent_for_upload_rejects_missing_manifest_base(tmp_path):
+    from src.meta import Meta
+
+    meta = Meta(base_dir=str(tmp_path), uuid="release")
+
+    with pytest.raises(FileNotFoundError, match="TEST: no selected base torrent"):
+        await Common({"TRACKERS": {"TEST": {}}}).create_torrent_for_upload(meta, "TEST", "TEST")

--- a/tests/test_torrent_reuse.py
+++ b/tests/test_torrent_reuse.py
@@ -1,9 +1,11 @@
 from types import SimpleNamespace
 
 import pytest
+from torf import Torrent
 
 from src.clients import Clients
 from src.meta import Meta
+from src.torrent_manifest import TorrentManifest
 from src.torrentcreate import TorrentCreator
 
 
@@ -36,7 +38,7 @@ async def test_base_subs_contains_external_subtitle_with_custom_torrent(tmp_path
 
     from torf import Torrent
 
-    torrent = Torrent.read(tmp_path / "tmp" / meta.uuid / "BASE_SUBS.torrent")
+    torrent = Torrent.read(TorrentManifest(meta.base_dir, meta.uuid).default_path("base_subs"))
     assert sorted(path.name for path in torrent.files) == sorted([video.name, subtitle.name])  # noqa: S101
 
 
@@ -71,7 +73,7 @@ async def test_base_subs_excludes_unselected_subtitles(tmp_path):
 
     from torf import Torrent
 
-    torrent = Torrent.read(tmp_path / "tmp" / meta.uuid / "BASE_SUBS.torrent")
+    torrent = Torrent.read(TorrentManifest(meta.base_dir, meta.uuid).default_path("base_subs"))
     assert sorted(path.name for path in torrent.files) == sorted([video.name, selected_subtitle.name])  # noqa: S101
 
 
@@ -132,7 +134,7 @@ async def test_client_search_prefers_torrent_with_all_local_subtitles(tmp_path, 
     }
     meta = Meta({"client": "none", "subtitle_files": [str(subtitle)]})
 
-    found = await Clients(config).find_existing_torrent(meta)
+    found = await Clients(config)._find_existing_torrent(meta)
 
     assert found == str(with_subtitles)  # noqa: S101
     assert meta.reuse_torrent_client == "second"  # noqa: S101
@@ -189,7 +191,36 @@ async def test_client_search_keeps_best_piece_size_video_only_fallback(tmp_path,
     }
     meta = Meta({"client": "none", "subtitle_files": [str(selected_subtitle)]})
 
-    assert await Clients(config).find_existing_torrent(meta) == str(small_piece_torrent)  # noqa: S101
+    assert await Clients(config)._find_existing_torrent(meta) == str(small_piece_torrent)  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_client_search_registers_variants_from_multiple_clients(tmp_path):
+    media = tmp_path / "release.mkv"
+    media.touch()
+    client_dirs = [tmp_path / "first", tmp_path / "second"]
+    for directory, piece_size in zip(client_dirs, (1024 * 1024, 2 * 1024 * 1024), strict=True):
+        directory.mkdir()
+        torrent = Torrent()
+        torrent.metainfo["info"] = {
+            "name": media.name,
+            "length": 8 * 1024 * 1024,
+            "piece length": piece_size,
+            "pieces": b"x" * (20 * (8 * 1024 * 1024 // piece_size)),
+        }
+        torrent.write(directory / "abc.torrent")
+    config = {
+        "DEFAULT": {"default_torrent_client": "first", "searching_client_list": ["first", "second"], "prefer_max_16_torrent": False},
+        "TRACKERS": {},
+        "TORRENT_CLIENTS": {name: {"torrent_client": "qbit", "torrent_storage_dir": str(directory)} for name, directory in zip(("first", "second"), client_dirs, strict=True)},
+    }
+    meta = Meta(base_dir=str(tmp_path), uuid="release", path=str(media), filelist=[str(media)], trackers=["OTHER"], client="none")
+    meta.torrenthash = "abc"
+
+    paths = await Clients(config).find_existing_torrents(meta)
+
+    assert len(paths) == 2
+    assert {entry.piece_size for entry in TorrentManifest(meta.base_dir, meta.uuid).entries()} == {1024 * 1024, 2 * 1024 * 1024}
     assert meta.reuse_torrent_client == "second"  # noqa: S101
 
 

--- a/tests/test_torrent_reuse.py
+++ b/tests/test_torrent_reuse.py
@@ -6,6 +6,7 @@ from torf import Torrent
 from src.clients import Clients
 from src.meta import Meta
 from src.torrent_manifest import TorrentManifest
+from src.torrent_policy import MIB, TorrentPolicy
 from src.torrentcreate import TorrentCreator
 
 
@@ -219,9 +220,78 @@ async def test_client_search_registers_variants_from_multiple_clients(tmp_path):
 
     paths = await Clients(config).find_existing_torrents(meta)
 
-    assert len(paths) == 2
-    assert {entry.piece_size for entry in TorrentManifest(meta.base_dir, meta.uuid).entries()} == {1024 * 1024, 2 * 1024 * 1024}
+    assert len(paths) == 2  # noqa: S101
+    assert {entry.piece_size for entry in TorrentManifest(meta.base_dir, meta.uuid).entries()} == {1024 * 1024, 2 * 1024 * 1024}  # noqa: S101
     assert meta.reuse_torrent_client == "second"  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_client_search_registers_all_variants_from_one_client(tmp_path, monkeypatch):
+    media = tmp_path / "release.mkv"
+    media.touch()
+    candidates = []
+    for piece_size in (8 * MIB, 16 * MIB):
+        torrent = Torrent()
+        torrent.metainfo["info"] = {
+            "name": media.name,
+            "length": 64 * MIB,
+            "piece length": piece_size,
+            "pieces": b"x" * (20 * (64 * MIB // piece_size)),
+        }
+        candidate = tmp_path / f"{piece_size}.torrent"
+        torrent.write(candidate)
+        candidates.append(str(candidate))
+
+    async def fake_search(_self, _meta, _client_name, _prefer_small, _piece_limit, _best_match, collect_all=False):
+        assert collect_all  # noqa: S101
+        return candidates
+
+    monkeypatch.setattr(Clients, "_search_single_client_for_torrent", fake_search)
+    config = {
+        "DEFAULT": {"default_torrent_client": "qbit", "searching_client_list": ["qbit"]},
+        "TORRENT_CLIENTS": {"qbit": {"torrent_client": "qbit"}},
+    }
+    meta = Meta(base_dir=str(tmp_path), uuid="release", path=str(media), filelist=[str(media)], client="none")
+
+    paths = await Clients(config).find_existing_torrents(meta)
+
+    manifest = TorrentManifest(meta.base_dir, meta.uuid)
+    assert len(paths) == 2  # noqa: S101
+    assert {entry.piece_size for entry in manifest.entries()} == {8 * MIB, 16 * MIB}  # noqa: S101
+    eight = manifest.select("EIGHT", "base", TorrentPolicy(validator=lambda stats: stats.piece_size == 8 * MIB))
+    sixteen = manifest.select("SIXTEEN", "base", TorrentPolicy(validator=lambda stats: stats.piece_size == 16 * MIB))
+    assert eight is not None and eight.piece_size == 8 * MIB  # noqa: S101
+    assert sixteen is not None and sixteen.piece_size == 16 * MIB  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_qbit_search_returns_all_valid_matches_when_collecting(tmp_path, monkeypatch):
+    storage = tmp_path / "storage"
+    storage.mkdir()
+    hashes = ["eight", "sixteen"]
+    for torrent_hash in hashes:
+        (storage / f"{torrent_hash}.torrent").touch()
+
+    qbt_client = SimpleNamespace(
+        torrents_info=lambda: [
+            SimpleNamespace(hash=torrent_hash, name="release", save_path=str(tmp_path), content_path=str(tmp_path / "release.mkv"), tracker="", trackers=[], comment="metadata")
+            for torrent_hash in hashes
+        ]
+    )
+    config = {"DEFAULT": {}, "TORRENT_CLIENTS": {}}
+    clients = Clients(config)
+    monkeypatch.setattr(clients, "_matches_qbit_content_path", lambda _torrent, _meta: True)
+
+    async def valid_torrent(_meta, path, _torrent_hash, _client_type, _client):
+        return True, str(path)
+
+    monkeypatch.setattr(clients, "is_valid_torrent", valid_torrent)
+    meta = Meta(base_dir=str(tmp_path), uuid="release", path=str(tmp_path / "release.mkv"), subtitle_files=[], debug=False)
+    client = {"torrent_storage_dir": str(storage)}
+
+    found = await clients.search_qbit_for_torrent(meta, client, qbt_client=qbt_client, collect_all=True)
+
+    assert found == hashes  # noqa: S101
 
 
 @pytest.mark.asyncio

--- a/upload.py
+++ b/upload.py
@@ -86,6 +86,7 @@ from src.queuemanage import QueueManager
 from src.rehostimages import check_tracker_image_hosts
 from src.takescreens import TakeScreensManager, download_artwork_from_meta
 from src.temp_paths import artwork_dir, music_release_snapshot_path, screenshots_dir
+from src.torrent_manifest import TorrentManifest
 from src.torrentcreate import TorrentCreator
 from src.trackerhandle import process_trackers
 from src.trackers.common import Common
@@ -1973,8 +1974,7 @@ async def process_meta(meta: Meta, base_dir: str) -> bool:
             await progress_task
 
     has_local_subs = bool(meta.subtitle_files)
-    torrent_path = str(Path(f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/BASE.torrent").resolve())
-    subs_torrent_path = str(Path(f"{meta.base_dir}{'/' + 'tmp' + '/'}{meta.uuid}/BASE_SUBS.torrent").resolve())
+    torrent_manifest = TorrentManifest(meta.base_dir, meta.uuid)
 
     try:
         await asyncio.gather(early_base_torrent_task, early_usenet_prepare_task)
@@ -1992,7 +1992,7 @@ async def process_meta(meta: Meta, base_dir: str) -> bool:
 
     is_usenet_only = _is_usenet_only(meta)
     if not is_usenet_only:
-        if meta.rehash is False and not Path(torrent_path).exists() and not meta.base_torrent_created and not meta.we_checked_them_all:
+        if meta.rehash is False and torrent_manifest.default_path("base") is None and not meta.base_torrent_created and not meta.we_checked_them_all:
             if not reuse_torrent or not Path(reuse_torrent).exists():
                 reuse_torrent = await client.find_existing_torrent(meta)
             if reuse_torrent is not None:
@@ -2000,28 +2000,29 @@ async def process_meta(meta: Meta, base_dir: str) -> bool:
 
         # 2. Re-create base torrents if rehash is True
         if meta.rehash is True and meta.nohash is False:
-            await TORRENT_CREATOR.create_torrent(meta, Path(cast(str, meta.path)), "BASE")
+            await TORRENT_CREATOR.create_torrent(meta, Path(cast(str, meta.path)), "BASE", make_default=True)
             if has_local_subs:
-                await TORRENT_CREATOR.create_torrent(meta, Path(cast(str, meta.path)), "BASE_SUBS")
+                await TORRENT_CREATOR.create_torrent(meta, Path(cast(str, meta.path)), "BASE_SUBS", make_default=True)
 
         # 3. Otherwise generate if missing
         else:
             if (
-                not Path(torrent_path).exists()
+                torrent_manifest.default_path("base") is None
                 and base_reuse_torrent
                 and Path(base_reuse_torrent).exists()
                 and (not has_local_subs or client._torrent_has_no_subtitles(base_reuse_torrent))
             ):
                 await TORRENT_CREATOR.create_base_from_existing_torrent(base_reuse_torrent, meta.base_dir, meta.uuid)
-            if not Path(torrent_path).exists() and meta.nohash is False:
+            if torrent_manifest.default_path("base") is None and meta.nohash is False:
                 await TORRENT_CREATOR.create_torrent(meta, Path(cast(str, meta.path)), "BASE")
-            if has_local_subs and not Path(subs_torrent_path).exists() and meta.nohash is False:
+            if has_local_subs and torrent_manifest.default_path("base_subs") is None and meta.nohash is False:
                 await TORRENT_CREATOR.create_torrent(meta, Path(cast(str, meta.path)), "BASE_SUBS")
 
     if meta.nohash:
         meta.client = "none"
 
-    if Path(torrent_path).exists():
+    torrent_path = torrent_manifest.default_path("base")
+    if torrent_path is not None:
         raw_trackers = meta.trackers
         trackers_list = [raw_trackers] if isinstance(raw_trackers, str) else [t for t in raw_trackers if t.strip()]
         trackers_normalized = [t.strip().upper() for t in trackers_list]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Reuses compatible torrent variants across trackers and clients, reducing unnecessary rehashing.
  - Selects torrent files according to tracker-specific piece-size and metadata requirements.
  - Supports separate reusable torrents with and without subtitles.
  - Prevents tracker uploads when hashing is disabled and no compatible stored torrent exists.
  - Improves torrent storage and selection consistency across upload workflows.
  - Provides clearer tracker-specific status messages when torrent provisioning is skipped.

- **Documentation**
  - Added CLI reference details for reusable base torrents, storage locations, and `--nohash` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->