### PR TITLE
fix(get_source): type a DVD-sourced encode as a DVDRip

### DIFF
--- a/src/get_name.py
+++ b/src/get_name.py
@@ -151,7 +151,7 @@ class NameManager:
                 name = f"{title} {alt_title} {year} {edition} {repack} {resolution} {source} {audio} {video_encode}"
                 potential_missing = []
             elif type == "DVDRIP":
-                name = f"{title} {alt_title} {year} {source} {video_encode} DVDRip {audio}"
+                name = f"{title} {alt_title} {year} {edition} {repack} {source} {video_encode} DVDRip {audio}"
                 potential_missing = []
         elif meta.category == "TV":  # TV SPECIFIC
             if type == "DISC":  # Disk
@@ -185,7 +185,7 @@ class NameManager:
                 name = f"{title} {year} {alt_title} {season}{episode} {episode_title} {part} {edition} {repack} {resolution} {source} {audio} {video_encode}"
                 potential_missing = []
             elif type == "DVDRIP":
-                name = f"{title} {year} {alt_title} {season} {source} DVDRip {audio} {video_encode}"
+                name = f"{title} {year} {alt_title} {season}{episode} {episode_title} {part} {edition} {repack} {source} DVDRip {audio} {video_encode}"
                 potential_missing = []
         elif meta.category == "BOOK":
             name = self.extract_book_name(meta)

--- a/src/get_source.py
+++ b/src/get_source.py
@@ -103,6 +103,8 @@ async def get_source(type: str, video: str, path: str, is_disc: str, meta: Meta,
             finally:
                 if type == "REMUX":
                     system = f"{system} DVD".strip()
+                elif type == "ENCODE":
+                    type = "DVDRIP"
                 source = system
         if source in ("Web", "WEB") and type == "ENCODE":
             type = "WEBRIP"

--- a/src/trackers/UNIT3D/blutopia.py
+++ b/src/trackers/UNIT3D/blutopia.py
@@ -259,7 +259,7 @@ class Blutopia(UNIT3D):
         reverse: bool = False,
         mapping_only: bool = False,
     ) -> dict[str, str]:
-        type_id = {"DISC": "1", "REMUX": "3", "WEBDL": "4", "WEBRIP": "5", "HDTV": "6", "ENCODE": "12"}
+        type_id = {"DISC": "1", "REMUX": "3", "WEBDL": "4", "WEBRIP": "5", "HDTV": "6", "ENCODE": "12", "DVDRIP": "12"}
 
         if mapping_only:
             return type_id

--- a/src/trackers/UNIT3D/locadora.py
+++ b/src/trackers/UNIT3D/locadora.py
@@ -119,7 +119,7 @@ class Locadora(UNIT3D):
 
     async def get_type_id(self, meta: Meta, type: str | None = None, reverse: bool = False, mapping_only: bool = False) -> dict[str, str]:
         _ = (type, reverse, mapping_only)
-        type_id = {"DISC": "1", "REMUX": "2", "ENCODE": "3", "WEBDL": "4", "WEBRIP": "5", "HDTV": "6"}.get(meta.type or "", "0")
+        type_id = {"DISC": "1", "REMUX": "2", "ENCODE": "3", "WEBDL": "4", "WEBRIP": "5", "HDTV": "6", "DVDRIP": "3"}.get(meta.type or "", "0")
         return {"type_id": type_id}
 
     async def get_resolution_id(self, meta: Meta, resolution: str | None = None, reverse: bool = False, mapping_only: bool = False) -> dict[str, str]:

--- a/src/trackers/UNIT3D/portugas.py
+++ b/src/trackers/UNIT3D/portugas.py
@@ -35,7 +35,7 @@ class Portugas(UNIT3D):
 
     async def get_type_id(self, meta: Meta, type: str | None = None, reverse: bool = False, mapping_only: bool = False) -> dict[str, str]:
         _ = (type, reverse, mapping_only)
-        type_id = {"DISC": "1", "REMUX": "2", "WEBDL": "4", "WEBRIP": "39", "HDTV": "6", "ENCODE": "3"}.get(str(meta.type), "0")
+        type_id = {"DISC": "1", "REMUX": "2", "WEBDL": "4", "WEBRIP": "39", "HDTV": "6", "ENCODE": "3", "DVDRIP": "3"}.get(str(meta.type), "0")
         return {"type_id": type_id}
 
     async def get_resolution_id(self, meta: Meta, resolution: str | None = None, reverse: bool = False, mapping_only: bool = False) -> dict[str, str]:

--- a/src/trackers/UNIT3D/skipthecommercials.py
+++ b/src/trackers/UNIT3D/skipthecommercials.py
@@ -49,7 +49,7 @@ class SkipTheCommercials(UNIT3D):
     ) -> dict[str, str]:
         _ = (type, reverse, mapping_only)
         type_value = str(meta.type)
-        type_id = {"DISC": "1", "REMUX": "2", "WEBDL": "4", "WEBRIP": "5", "HDTV": "6", "ENCODE": "3"}.get(type_value, "0")
+        type_id = {"DISC": "1", "REMUX": "2", "WEBDL": "4", "WEBRIP": "5", "HDTV": "6", "ENCODE": "3", "DVDRIP": "3"}.get(type_value, "0")
         if meta.tv_pack:
             is_web = type_value in ["WEBDL", "WEBRIP"]
             type_id = ("17" if not is_web else "14") if meta.sd else ("18" if not is_web else "13")

--- a/tests/test_get_source.py
+++ b/tests/test_get_source.py
@@ -36,6 +36,88 @@ async def test_release_group_named_vhs_does_not_override_remux_source(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_bare_dvd_source_promotes_encode_to_dvdrip(tmp_path):
+    filename = "Example Movie 1990 DVD x264-GRP.mkv"
+    meta = Meta(category="MOVIE", uuid=filename)
+
+    source, release_type = await get_source("ENCODE", filename, filename, "", meta, "case", str(tmp_path))
+
+    assert source == ""
+    assert release_type == "DVDRIP"
+
+    name_meta = Meta(
+        category="MOVIE",
+        type=release_type,
+        source=source,
+        title="Example Movie",
+        year=1990,
+        resolution="480p",
+        video_encode="x264",
+        audio="DD 2.0",
+        tag="-GRP",
+    )
+    _name_notag, name, _clean_name, _potential_missing = await NameManager({}).get_name(name_meta)
+
+    assert name == "Example Movie 1990 x264 DVDRip DD 2.0-GRP"
+
+
+@pytest.mark.asyncio
+async def test_bare_dvd_source_keeps_edition_and_repack_in_dvdrip_name(tmp_path):
+    filename = "Example Movie 1990 Unrated REPACK DVD x264-GRP.mkv"
+    meta = Meta(category="MOVIE", uuid=filename)
+
+    source, release_type = await get_source("ENCODE", filename, filename, "", meta, "case", str(tmp_path))
+
+    assert release_type == "DVDRIP"
+
+    name_meta = Meta(
+        category="MOVIE",
+        type=release_type,
+        source=source,
+        title="Example Movie",
+        year=1990,
+        edition="Unrated",
+        repack="REPACK",
+        resolution="480p",
+        video_encode="x264",
+        audio="DD 2.0",
+        tag="-GRP",
+    )
+    _name_notag, name, _clean_name, _potential_missing = await NameManager({}).get_name(name_meta)
+
+    assert name == "Example Movie 1990 Unrated REPACK x264 DVDRip DD 2.0-GRP"
+
+
+@pytest.mark.asyncio
+async def test_bare_dvd_source_preserves_tv_episode_in_dvdrip_name(tmp_path):
+    filename = "Example Show S01E03 DVD x264-GRP.mkv"
+    meta = Meta(category="TV", uuid=filename)
+
+    source, release_type = await get_source("ENCODE", filename, filename, "", meta, "case", str(tmp_path))
+
+    assert source == ""
+    assert release_type == "DVDRIP"
+
+    name_meta = Meta(
+        category="TV",
+        type=release_type,
+        source=source,
+        title="Example Show",
+        year=2001,
+        search_year=2001,
+        season="S01",
+        episode="E03",
+        resolution="480p",
+        video_encode="x264",
+        audio="DD 2.0",
+        tag="-GRP",
+    )
+    _name_notag, name, _clean_name, _potential_missing = await NameManager({}).get_name(name_meta)
+
+    assert name == "Example Show 2001 S01E03 DVDRip DD 2.0 x264-GRP"
+
+
+@pytest.mark.asyncio
 async def test_vhs_source_before_a_distinct_release_group_is_preserved(tmp_path):
     filename = "Movie.1995.1080p.VHS.Remux.AVC.FLAC.2.0-GROUP.mkv"
     meta = Meta(category="MOVIE", uuid=filename)


### PR DESCRIPTION
A non-disc encode whose filename carries a bare `DVD` token (no `DVDRip`, no `REMUX`) stayed `ENCODE`, so `get_source` set the source to `PAL`/`NTSC` and the release was named like a Blu-ray encode. It is now promoted to `DVDRIP` in the DVD branch, next to the existing `WEB`→`WEBRIP` promotion.

The `DVDRIP` templates carried neither `{edition} {repack}` nor, on TV, the episode tokens, so a promoted release lost REPACK/edition and a single episode was named like a season pack; both now mirror the `ENCODE` templates.

Blutopia, Locadora, Portugas and SkipTheCommercials map `DVDRIP` to their Encode id; their maps had no `DVDRIP` key and sent `0` for `DVDRip`-named files. TorrentDesi, HDBits, BitHDTV and PTer still have no `DVDRIP` mapping; unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
