### PR TITLE
fix(dreadvault): title DVD-sourced encodes as DVDRip, drop DVD disc/remux rewrites, guard empty tokens and non-linguistic audio

### DIFF
--- a/src/trackers/UNIT3D/dreadvault.py
+++ b/src/trackers/UNIT3D/dreadvault.py
@@ -55,7 +55,6 @@ class DreadVault(UNIT3D):
     async def get_name(self, meta: Meta) -> dict[str, str]:
         dreadvault_name: str = meta.name
         resolution: str = meta.resolution
-        video_codec: str = meta.video_codec
         video_encode: str = meta.video_encode
         name_type: str = meta.type or ""
         source: str = meta.source or ""
@@ -70,43 +69,38 @@ class DreadVault(UNIT3D):
         if meta.no_year:
             year = ""
 
+        if name_type == "ENCODE" and source in ("NTSC", "PAL"):
+            # get_source leaves a bare NTSC/PAL only on a DVD-sourced encode; the site titles that DVDRip.
+            dvd_tokens = " ".join(f"{meta.edition} {meta.repack} {resolution} {source}".split())
+            dreadvault_name = dreadvault_name.replace(dvd_tokens, f"{resolution} DVDRip", 1)
+
         if name_type == "DVDRIP":
             source = "DVDRip"
             encode_token = video_encode.strip()
-            dreadvault_name = dreadvault_name.replace(f"{meta.source} ", "", 1)
-            dreadvault_name = dreadvault_name.replace(f" {encode_token}", "", 1)
+            if meta.source:
+                dreadvault_name = dreadvault_name.replace(f"{meta.source} ", "", 1)
+            if encode_token:
+                dreadvault_name = dreadvault_name.replace(f" {encode_token}", "", 1)
+                dreadvault_name = dreadvault_name.replace((meta.audio), f"{meta.audio} {encode_token}", 1)
             dreadvault_name = dreadvault_name.replace(f"{source}", f"{resolution} {source}", 1)
-            dreadvault_name = dreadvault_name.replace((meta.audio), f"{meta.audio} {encode_token}", 1)
-
-        elif meta.is_disc == "DVD":
-            region_and_source = " ".join(part for part in (meta.region, source) if part)
-            disc_details = " ".join(part for part in (resolution, meta.region, source) if part)
-            if region_and_source:
-                dreadvault_name = dreadvault_name.replace(region_and_source, disc_details, 1)
-            dreadvault_name = dreadvault_name.replace((meta.audio), f"{video_codec} {meta.audio}", 1)
-
-        elif name_type == "REMUX" and source in ("PAL DVD", "NTSC DVD", "DVD"):
-            dreadvault_name = dreadvault_name.replace(meta.source or "", f"{resolution} {meta.source}", 1)
-            dreadvault_name = dreadvault_name.replace((meta.audio), f"{video_codec} {meta.audio}", 1)
 
         if alt_title and year:
             dreadvault_name = dreadvault_name.replace(f"{year} {alt_title}", f"{alt_title} {year}", 1)
 
-        # The marker goes immediately before the resolution, so it has to run AFTER the branches
-        # above: the DVDRip and DVD-disc templates carry no resolution of their own, and those
-        # branches are what insert it. Running first silently dropped the marker on both.
         if not meta.language_checked:
             await languages_manager.process_desc_language(meta, tracker=self.tracker)
-        audio_languages: list[str] = [] if not meta.audio_languages else meta.audio_languages
+        audio_languages: list[str] = [
+            language
+            for language in meta.audio_languages or []
+            if language.lower() not in {"no", "undetermined"}
+        ]
         if audio_languages and not await languages_manager.has_english_language(audio_languages):
             foreign_lang = audio_languages[0].upper()
             dvd_remux = name_type == "REMUX" and source in ("PAL DVD", "NTSC DVD", "DVD")
             if dvd_remux and year:
                 dreadvault_name = dreadvault_name.replace(year, f"{year} {foreign_lang}", 1)
             elif meta.is_disc != "BDMV":
-                # get_name drops the resolution token when it is OTHER; the next slot anchors the marker:
-                # the service on a web release, the source everywhere else.
-                for anchor in (meta.resolution, str(meta.service), source):
+                for anchor in (resolution, str(meta.service), meta.region, source):
                     if anchor and anchor in dreadvault_name:
                         dreadvault_name = dreadvault_name.replace(anchor, f"{foreign_lang} {anchor}", 1)
                         break

--- a/src/trackers/UNIT3D/dreadvault.py
+++ b/src/trackers/UNIT3D/dreadvault.py
@@ -81,7 +81,8 @@ class DreadVault(UNIT3D):
                 dreadvault_name = dreadvault_name.replace(f"{meta.source} ", "", 1)
             if encode_token:
                 dreadvault_name = dreadvault_name.replace(f" {encode_token}", "", 1)
-                dreadvault_name = dreadvault_name.replace((meta.audio), f"{meta.audio} {encode_token}", 1)
+                anchor = meta.audio or source
+                dreadvault_name = dreadvault_name.replace(anchor, f"{anchor} {encode_token}", 1)
             dreadvault_name = dreadvault_name.replace(f"{source}", f"{resolution} {source}", 1)
 
         if alt_title and year:

--- a/src/trackers/UNIT3D/dreadvault.py
+++ b/src/trackers/UNIT3D/dreadvault.py
@@ -70,7 +70,7 @@ class DreadVault(UNIT3D):
             year = ""
 
         if name_type == "ENCODE" and source in ("NTSC", "PAL"):
-            # get_source leaves a bare NTSC/PAL only on a DVD-sourced encode; the site titles that DVDRip.
+            # For an ENCODE, get_source returns a bare NTSC/PAL only for DVD sources; the site titles that DVDRip.
             dvd_tokens = " ".join(f"{meta.edition} {meta.repack} {resolution} {source}".split())
             dreadvault_name = dreadvault_name.replace(dvd_tokens, f"{resolution} DVDRip", 1)
 

--- a/tests/test_dreadvault.py
+++ b/tests/test_dreadvault.py
@@ -124,6 +124,29 @@ def test_dreadvault_formats_dvdrip_with_resolution_and_encode_after_audio():
     assert name == "Example Movie 2001 480p DVDRip DD 2.0 x264-GRP"  # noqa: S101
 
 
+@pytest.mark.parametrize(
+    ("source", "original_name"),
+    [
+        ("PAL DVD", "Example Movie 2001 PAL DVD x264 DVDRip-GRP"),
+        ("", "Example Movie 2001 x264 DVDRip-GRP"),
+    ],
+)
+def test_dreadvault_formats_dvdrip_with_empty_audio(source, original_name):
+    meta = Meta(
+        name=original_name,
+        type="DVDRIP",
+        source=source,
+        resolution="480p",
+        video_encode=" x264",
+        audio="",
+        language_checked=True,
+    )
+
+    name = asyncio.run(_tracker().get_name(meta))["name"]
+
+    assert name == "Example Movie 2001 480p DVDRip x264-GRP"  # noqa: S101
+
+
 def test_dreadvault_names_a_dvd_sourced_encode_as_a_dvdrip():
     meta = Meta(
         name="Ghost 1984 480p NTSC DD 2.0 x264-SaL",

--- a/tests/test_dreadvault.py
+++ b/tests/test_dreadvault.py
@@ -124,6 +124,41 @@ def test_dreadvault_formats_dvdrip_with_resolution_and_encode_after_audio():
     assert name == "Example Movie 2001 480p DVDRip DD 2.0 x264-GRP"  # noqa: S101
 
 
+def test_dreadvault_names_a_dvd_sourced_encode_as_a_dvdrip():
+    meta = Meta(
+        name="Ghost 1984 480p NTSC DD 2.0 x264-SaL",
+        type="ENCODE",
+        source="NTSC",
+        resolution="480p",
+        video_encode="x264",
+        audio="DD 2.0",
+        language_checked=True,
+    )
+
+    name = asyncio.run(_tracker().get_name(meta))["name"]
+
+    assert name == "Ghost 1984 480p DVDRip DD 2.0 x264-SaL"  # noqa: S101
+
+
+def test_dreadvault_keeps_the_episode_on_a_dvd_sourced_encode():
+    meta = Meta(
+        name="Example Show 1989 S04E02 Unrated REPACK 480p PAL DD 2.0 x264-GRP",
+        category="TV",
+        type="ENCODE",
+        source="PAL",
+        resolution="480p",
+        edition="Unrated",
+        repack="REPACK",
+        video_encode="x264",
+        audio="DD 2.0",
+        language_checked=True,
+    )
+
+    name = asyncio.run(_tracker().get_name(meta))["name"]
+
+    assert name == "Example Show 1989 S04E02 480p DVDRip DD 2.0 x264-GRP"  # noqa: S101
+
+
 def test_dreadvault_formats_hi10p_dvdrip_with_encode_after_audio():
     meta = Meta(
         name="Example Movie 2001 PAL DVD Hi10P x264 DVDRip DD 2.0-GRP",
@@ -140,38 +175,20 @@ def test_dreadvault_formats_hi10p_dvdrip_with_encode_after_audio():
     assert name == "Example Movie 2001 480p DVDRip DD 2.0 Hi10P x264-GRP"  # noqa: S101
 
 
-def test_dreadvault_formats_dvd_disc_with_resolution_codec_region_and_source():
+def test_dreadvault_preserves_title_spaces_when_dvdrip_source_and_encode_are_empty():
     meta = Meta(
-        name="Example Movie 2001 R1 NTSC DVD DVD9 DD 5.1-GRP",
-        type="DISC",
-        is_disc="DVD",
-        source="NTSC DVD",
+        name="Example Movie 1990 DVDRip DD 2.0-GRP",
+        type="DVDRIP",
+        source="",
         resolution="480p",
-        region="R1",
-        video_codec="MPEG-2",
-        audio="DD 5.1",
+        video_encode="",
+        audio="DD 2.0",
         language_checked=True,
     )
 
     name = asyncio.run(_tracker().get_name(meta))["name"]
 
-    assert name == "Example Movie 2001 480p R1 NTSC DVD DVD9 MPEG-2 DD 5.1-GRP"  # noqa: S101
-
-
-def test_dreadvault_formats_dvd_remux_with_resolution_before_source():
-    meta = Meta(
-        name="Example Movie 2001 PAL DVD REMUX DD 5.1-GRP",
-        type="REMUX",
-        source="PAL DVD",
-        resolution="576p",
-        video_codec="MPEG-2",
-        audio="DD 5.1",
-        language_checked=True,
-    )
-
-    name = asyncio.run(_tracker().get_name(meta))["name"]
-
-    assert name == "Example Movie 2001 576p PAL DVD REMUX MPEG-2 DD 5.1-GRP"  # noqa: S101
+    assert name == "Example Movie 1990 480p DVDRip DD 2.0-GRP"  # noqa: S101
 
 
 def test_dreadvault_adds_foreign_audio_language_before_encode_resolution():
@@ -251,6 +268,24 @@ def test_dreadvault_omits_language_marker_when_audio_includes_english():
     assert name == "Example Movie 2001 1080p BluRay DD 5.1 x264-GRP"  # noqa: S101
 
 
+@pytest.mark.parametrize("audio_language", ["No", "Undetermined"])
+def test_dreadvault_omits_language_marker_for_non_linguistic_audio(audio_language):
+    meta = Meta(
+        name="Ghost 1984 NTSC x264 DVDRip DD 2.0-SaL",
+        type="DVDRIP",
+        source="NTSC",
+        resolution="480p",
+        video_encode=" x264",
+        audio="DD 2.0",
+        audio_languages=[audio_language],
+        language_checked=True,
+    )
+
+    name = asyncio.run(_tracker().get_name(meta))["name"]
+
+    assert name == "Ghost 1984 480p DVDRip DD 2.0 x264-SaL"  # noqa: S101
+
+
 def test_dreadvault_adds_foreign_audio_language_to_a_dvdrip():
     # The DVDRip template carries no resolution of its own, so a language pass that ran before the
     # DVDRip branch had nothing to anchor to and dropped the marker (kainoa 2026-09-09).
@@ -272,11 +307,11 @@ def test_dreadvault_adds_foreign_audio_language_to_a_dvdrip():
 
 def test_dreadvault_adds_foreign_audio_language_to_a_dvd_full_disc():
     meta = Meta(
-        name="Hausu 1977 USA NTSC DVD DVD9 LPCM 2.0",
+        name="Hausu 1977 USA NTSC DVD9 LPCM 2.0",
         year=1977,
         type="DISC",
         is_disc="DVD",
-        source="NTSC DVD",
+        source="NTSC",
         resolution="480p",
         region="USA",
         video_codec="MPEG-2",
@@ -287,7 +322,7 @@ def test_dreadvault_adds_foreign_audio_language_to_a_dvd_full_disc():
 
     name = asyncio.run(_tracker().get_name(meta))["name"]
 
-    assert name.startswith("Hausu 1977 JAPANESE 480p USA NTSC DVD")  # noqa: S101
+    assert name == "Hausu 1977 JAPANESE USA NTSC DVD9 LPCM 2.0"  # noqa: S101
 
 
 def test_dreadvault_adds_foreign_audio_language_after_year_for_dvd_remux():
@@ -305,10 +340,10 @@ def test_dreadvault_adds_foreign_audio_language_after_year_for_dvd_remux():
 
     name = asyncio.run(_tracker().get_name(meta))["name"]
 
-    assert name == "Example Movie 2001 JAPANESE 576p PAL DVD REMUX MPEG-2 DD 5.1-GRP"  # noqa: S101
+    assert name == "Example Movie 2001 JAPANESE PAL DVD REMUX DD 5.1-GRP"  # noqa: S101
 
 
-def test_dreadvault_adds_foreign_audio_language_before_resolution_for_yearless_dvd_remux():
+def test_dreadvault_adds_foreign_audio_language_before_source_for_yearless_dvd_remux():
     meta = Meta(
         name="Example Movie PAL DVD REMUX DD 2.0-GRP",
         no_year=True,
@@ -323,7 +358,7 @@ def test_dreadvault_adds_foreign_audio_language_before_resolution_for_yearless_d
 
     name = asyncio.run(_tracker().get_name(meta))["name"]
 
-    assert name == "Example Movie JAPANESE 576p PAL DVD REMUX MPEG-2 DD 2.0-GRP"  # noqa: S101
+    assert name == "Example Movie JAPANESE PAL DVD REMUX DD 2.0-GRP"  # noqa: S101
 
 
 def test_dreadvault_never_adds_trump_suffix_for_exact_match():
@@ -371,4 +406,4 @@ def test_dreadvault_moves_tv_aka_before_year_with_foreign_audio_language():
 
     name = asyncio.run(_tracker().get_name(meta))["name"]
 
-    assert name == "Example Show AKA Alt Show 2024 JAPANESE S01 576p PAL DVD REMUX MPEG-2 DD 2.0-GRP"  # noqa: S101
+    assert name == "Example Show AKA Alt Show 2024 JAPANESE S01 PAL DVD REMUX DD 2.0-GRP"  # noqa: S101


### PR DESCRIPTION
A DVD-sourced encode reaches `get_name` as `ENCODE` with a bare `NTSC`/`PAL` source (`get_source` adds ` DVD` only on a remux), so its DreadVault title read `480p NTSC … x264`. It is now titled `<resolution> DVDRip <audio> <encode>`, edition and repack removed, season/episode kept.

The DVD full-disc and DVD remux rewrites (resolution inserted before the region/source, video codec before the audio) are removed; those titles pass through as UA's generic name: `PAL DVD9 DD 5.1`, `NTSC DVD REMUX DD 2.0`. The full-disc fixtures use the bare `NTSC` source `get_source` yields for a disc.

The DVDRip rewrite replaced `f"{meta.source} "` and `f" {encode_token}"` unconditionally, so an empty source or encode token deleted the first space of the title, and an empty encode token left a stray space after the audio. Each replace now runs only when its token is non-empty.

A track tagged `zxx` reaches `get_name` as `No` (`languages.py` keeps the first word of "No linguistic content") and became the marker `NO`. Non-linguistic and undetermined values are skipped before choosing the marker.

The marker's anchor list gains the region, so on a DVD full disc it sits before the region: `Hausu 1977 JAPANESE USA NTSC DVD9 LPCM 2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved DreadVault release naming for DVD-sourced encodes, including DVDRip and DVD remux formats.
  - Corrected placement of video encode, resolution, source, and foreign-language markers.
  - Preserved episode information and title-embedded years in generated names.
  - Improved handling of empty or non-linguistic audio metadata.
  - Prevented duplicate naming tokens in preformatted and repeated lookups.

- **Tests**
  - Added regression coverage for movie and TV naming across DVD, DVDRip, remux, and foreign-audio scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->