### PR TITLE
fix(hdbits): expose upload result link

### DIFF
--- a/src/trackers/hdbits.py
+++ b/src/trackers/hdbits.py
@@ -37,6 +37,7 @@ class HDBits:
     signature: str | None = None
     banned_groups: tuple[str, ...] = ("",)
     base_url = "https://hdbits.org"
+    torrent_url = f"{base_url}/details.php?id="
     supported_categories = ("TV", "MOVIE")
     torrent_policy = HDBITS_POLICY
     tracker_urls = ("https://tracker.hdbits.org",)
@@ -316,6 +317,7 @@ class HDBits:
         match = re.match(rf".*?{re.escape(self.base_url.replace('https://', ''))}/details\.php\?id=(\d+)&uploaded=(\d+)", str(up.url))
         if match:
             meta.tracker_status[self.tracker]["status_message"] = match.group(0)
+            meta.tracker_status[self.tracker]["torrent_id"] = match.group(1)
             if id_match := re.search(r"(id=)(\d+)", urlparse(str(up.url)).query):
                 id = id_match.group(2)
                 await self.download_new_torrent(id, torrent_file_path)

--- a/tests/test_hdbits_result_links.py
+++ b/tests/test_hdbits_result_links.py
@@ -1,0 +1,72 @@
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from torf import Torrent
+
+import src.trackers.hdbits as hdbits_module
+from src.meta import Meta
+from src.torrent_manifest import TorrentManifest
+from src.trackers.common import Common
+from src.trackers.hdbits import HDBits
+
+MIB = 1024**2
+
+
+def write_torrent(path, piece_size, size, name="release.mkv"):
+    torrent = Torrent()
+    count = (size + piece_size - 1) // piece_size
+    torrent.metainfo["info"] = {"name": name, "length": size, "piece length": piece_size, "pieces": b"x" * (20 * count)}
+    torrent.write(path, overwrite=True)
+    return torrent
+
+
+@pytest.fixture
+def setup_release(tmp_path, monkeypatch):
+    directory = tmp_path / "tmp" / "release"
+    directory.mkdir(parents=True)
+    media = tmp_path / "release.mkv"
+    media.touch()
+    meta = Meta(base_dir=str(tmp_path), uuid="release", path=str(media), filelist=[str(media)], trackers=["HDBITS"], category="MOVIE")
+    meta.debug = False
+    meta.video = str(media)
+    meta.tracker_status = {"HDBITS": {}}
+    for filename in ("[HDBITS]DESCRIPTION.txt", "MEDIAINFO_CLEANPATH.txt"):
+        (directory / filename).write_text("")
+    for method in ("edit_desc", "get_name", "get_type_category_id", "get_type_codec_id", "get_type_medium_id", "get_tags"):
+        monkeypatch.setattr(HDBits, method, AsyncMock(return_value=1))
+    config = {"DEFAULT": {"default_torrent_client": "none"}, "TORRENT_CLIENTS": {}, "TRACKERS": {"HDBITS": {}}}
+    return directory, meta, config
+
+
+@pytest.mark.asyncio
+async def test_successful_upload_records_torrent_id_for_result_link(setup_release, monkeypatch):
+    directory, meta, config = setup_release
+    source = directory / "candidate.torrent"
+    write_torrent(source, 2 * MIB, 4000 * 2 * MIB)
+    TorrentManifest(meta.base_dir, meta.uuid).register(source, "base", "client:test")
+
+    monkeypatch.setattr("src.cookie_auth.find_cookie_file", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(Common, "parse_cookie_file", AsyncMock(return_value={}))
+    monkeypatch.setattr(HDBits, "download_new_torrent", AsyncMock())
+
+    original_async_client = httpx.AsyncClient
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST":
+            return httpx.Response(303, headers={"Location": "https://hdbits.org/details.php?id=12345&uploaded=1"}, request=request)
+        return httpx.Response(200, request=request)
+
+    def make_client(*args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(handler)
+        return original_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(hdbits_module.httpx, "AsyncClient", make_client)
+
+    assert await HDBits(config).upload(meta) is True  # noqa: S101
+    assert meta.tracker_status["HDBITS"]["torrent_id"] == "12345"  # noqa: S101
+    assert f"{HDBits.torrent_url}{meta.tracker_status['HDBITS']['torrent_id']}" == "https://hdbits.org/details.php?id=12345"  # noqa: S101
+
+
+def test_class_exposes_details_url_for_result_links():
+    assert HDBits.torrent_url == "https://hdbits.org/details.php?id="  # noqa: S101


### PR DESCRIPTION
### Summary

- HDBits never recorded `tracker_status["torrent_id"]` and the tracker class had no `torrent_url` attribute, so the result-link handling in `process_trackers()` never produced a details link after a successful upload. Other trackers with a details page (e.g. BeyondHD) set both.
- The upload response is already matched against `details.php?id=...&uploaded=...`; this records the id from that match and adds the missing class attribute.

### Changes

- `src/trackers/hdbits.py`: add `torrent_url`; record `torrent_id` after a successful upload.
- `tests/test_hdbits_result_links.py`: verify the recorded id and link composition in the upload flow.

### Test plan

- `python -m pytest -q` (full suite passing on Python 3.14)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - HDBits uploads now display the newly created torrent ID in tracker status information.
  - HDBits torrent links now provide a direct path to the uploaded torrent’s details page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->