### PR TITLE
fix: normalize tracker color tags

### DIFF
--- a/src/bbcode.py
+++ b/src/bbcode.py
@@ -5,8 +5,12 @@ import urllib.parse
 from pathlib import Path
 from typing import Any
 
+from matplotlib.colors import CSS4_COLORS
+
 from src.console import logger
 from src.meta import Meta
+
+CSS4_COLORS_BY_HEX = {color_hex.lower(): color_name for color_name, color_hex in CSS4_COLORS.items()}
 
 # Bold - KEEP
 # Italic - KEEP
@@ -590,6 +594,28 @@ class BBCODE:
         """
         pattern = r"\[/?color(?:=[^\]]*)?\]"
         return re.sub(pattern, "", desc, flags=re.IGNORECASE)
+
+    def convert_named_colors(self, desc: str) -> str:
+        """Convert CSS named colors in BBCode color tags to hexadecimal values."""
+
+        def convert(match: re.Match[str]) -> str:
+            color_name = match.group(1).strip().lower()
+            color_hex = CSS4_COLORS.get(color_name)
+            return f"[color={color_hex.lower()}]" if color_hex else match.group(0)
+
+        return re.sub(r"\[color=([^\]]+)\]", convert, desc, flags=re.IGNORECASE)
+
+    def convert_hex_colors_to_named(self, desc: str) -> str:
+        """Convert exact CSS4 hexadecimal colors in BBCode tags to named colors."""
+
+        def convert(match: re.Match[str]) -> str:
+            color_hex = match.group(1).lower()
+            if len(color_hex) == 4:
+                color_hex = "#" + "".join(character * 2 for character in color_hex[1:])
+            color_name = CSS4_COLORS_BY_HEX.get(color_hex)
+            return f"[color={color_name}]" if color_name else match.group(0)
+
+        return re.sub(r"\[color=(#[0-9a-fA-F]{3}|#[0-9a-fA-F]{6})\]", convert, desc, flags=re.IGNORECASE)
 
     def convert_named_spoiler_to_normal_spoiler(self, desc: str) -> str:
         return re.sub(r"(\[spoiler=[^]]+])", "[spoiler]", desc, flags=re.IGNORECASE)

--- a/src/get_desc.py
+++ b/src/get_desc.py
@@ -2392,7 +2392,7 @@ class DescriptionBuilder:
             description = bbcode.remove_spoiler(description)
             description = bbcode.remove_list(description)
 
-        if tracker in {"LAJIDUI", "LEMONHD", "LONGPT", "1PTBA", "PTCAFE", "PTFANS", "PTGTK", "PTZONE", "RAILGUNPT", "XINGYUNGEPT"}:
+        if tracker in {"LAJIDUI", "LEMONHD", "LONGPT", "1PTBA", "PTCAFE", "PTFANS", "PTGTK", "PTSKIT", "PTZONE", "RAILGUNPT", "XINGYUNGEPT"}:
             description = description.replace("[user]", "").replace("[/user]", "")
             description = description.replace("[align=left]", "").replace("[/align]", "")
             description = description.replace("[right]", "").replace("[/right]", "")

--- a/src/get_desc.py
+++ b/src/get_desc.py
@@ -2229,6 +2229,7 @@ class DescriptionBuilder:
 
         if tracker in {"ANTHELION", "BJSHARE", "BRASILTRACKER", "GREATPOSTERWALL"}:
             description = bbcode.clamp_size_tags(description)
+            description = bbcode.convert_named_colors(description)
 
         if tracker == "BRASILTRACKER":
             description = bbcode.remove_img_resize(description)
@@ -2338,7 +2339,7 @@ class DescriptionBuilder:
             description = bbcode.remove_img_resize(description)
             description = bbcode.convert_comparison_to_centered(description, 1000)
             description = bbcode.remove_spoiler(description)
-            description = bbcode.remove_color(description)
+            description = bbcode.convert_hex_colors_to_named(description)
 
             # Apply custom image line breaks for HDSPACE: if "imgbox" is not in the web_url, place only one image per line.
             def hds_image_formatter(match) -> str:
@@ -2391,7 +2392,7 @@ class DescriptionBuilder:
             description = bbcode.remove_spoiler(description)
             description = bbcode.remove_list(description)
 
-        if tracker == "PTSKIT":
+        if tracker in {"LAJIDUI", "LEMONHD", "LONGPT", "1PTBA", "PTCAFE", "PTFANS", "PTGTK", "PTZONE", "RAILGUNPT", "XINGYUNGEPT"}:
             description = description.replace("[user]", "").replace("[/user]", "")
             description = description.replace("[align=left]", "").replace("[/align]", "")
             description = description.replace("[right]", "").replace("[/right]", "")
@@ -2407,6 +2408,7 @@ class DescriptionBuilder:
             description = description.replace("[ul]", "").replace("[/ul]", "")
             description = description.replace("[ol]", "").replace("[/ol]", "")
             description = description.replace("[hide]", "").replace("[/hide]", "")
+            description = bbcode.remove_img_resize(description)
             description = re.sub(r"\[center\]\[spoiler=.*? NFO:\]\[code\](.*?)\[/code\]\[/spoiler\]\[/center\]", r"", description, flags=re.DOTALL)
             description = bbcode.convert_comparison_to_centered(description, 1000)
             description = bbcode.remove_spoiler(description)

--- a/src/trackers/NEXUSPHP/ptzone.py
+++ b/src/trackers/NEXUSPHP/ptzone.py
@@ -197,7 +197,7 @@ class PTZone(NEXUSPHP):
         subtitle_tracks = meta.subtitle_languages or []
         mhdr = meta.hdr
 
-        checkboxes = []
+        checkboxes: list[str] = []
 
         if meta.exclusive:
             checkboxes.append(str(reposting_prohibited))

--- a/tests/test_bbcode.py
+++ b/tests/test_bbcode.py
@@ -81,11 +81,30 @@ def test_tracker_specific_formats_removes_image_resize_for_nexusphp_trackers() -
         "PTCAFE",
         "PTFANS",
         "PTGTK",
+        "PTSKIT",
         "PTZONE",
         "RAILGUNPT",
         "XINGYUNGEPT",
     ):
         assert builder.tracker_specific_formats(tracker, description) == "[img]https://example.test/image.jpg[/img]"
+
+
+def test_tracker_specific_formats_cleans_ptskit_descriptions() -> None:
+    builder = object.__new__(DescriptionBuilder)
+    description = """[hide]Details[/hide]
+[img=450]https://example.test/image.jpg[/img]
+[comparison=Source A, Source B]
+https://example.test/a.jpg
+https://example.test/b.jpg
+[/comparison]"""
+
+    formatted = builder.tracker_specific_formats("PTSKIT", description)
+
+    assert "[hide]" not in formatted
+    assert "[img=450]" not in formatted
+    assert "[img]https://example.test/image.jpg[/img]" in formatted
+    assert "[comparison=" not in formatted
+    assert "[center]Source A | Source B" in formatted
 
 
 def test_clean_unit3d_description_removes_line_wrapped_align_center_signature() -> None:

--- a/tests/test_bbcode.py
+++ b/tests/test_bbcode.py
@@ -21,11 +21,52 @@ def test_clamp_size_tags_preserves_malformed_or_non_integer_values() -> None:
     assert BBCODE().clamp_size_tags(description) == description
 
 
+def test_convert_named_colors_to_hex() -> None:
+    description = "[color=SkyBlue]Text[/color] [color=red]Red[/color]"
+
+    assert BBCODE().convert_named_colors(description) == "[color=#87ceeb]Text[/color] [color=#ff0000]Red[/color]"
+
+
+def test_convert_named_colors_preserves_hex_and_unknown_values() -> None:
+    description = "[color=#123456]Hex[/color] [color=not-a-color]Unknown[/color]"
+
+    assert BBCODE().convert_named_colors(description) == description
+
+
+def test_convert_hex_colors_to_named() -> None:
+    description = "[color=#87CEEB]Text[/color] [color=#f00]Red[/color]"
+
+    assert BBCODE().convert_hex_colors_to_named(description) == "[color=skyblue]Text[/color] [color=red]Red[/color]"
+
+
+def test_convert_hex_colors_to_named_preserves_unknown_values() -> None:
+    description = "[color=#123456]Unknown[/color] [color=skyblue]Named[/color]"
+
+    assert BBCODE().convert_hex_colors_to_named(description) == description
+
+
 def test_tracker_specific_formats_only_clamps_gazelle_descriptions() -> None:
     builder = object.__new__(DescriptionBuilder)
 
     assert builder.tracker_specific_formats("ANTHELION", "[size=16]Text[/size]") == "[size=10]Text[/size]"
     assert builder.tracker_specific_formats("HDTORRENTS", "[size=16]Text[/size]") == "[size=16]Text[/size]"
+
+
+def test_tracker_specific_formats_converts_colors_for_gazelle_trackers() -> None:
+    builder = object.__new__(DescriptionBuilder)
+    description = "[color=skyblue]Text[/color]"
+
+    for tracker in ("ANTHELION", "BJSHARE", "BRASILTRACKER", "GREATPOSTERWALL"):
+        assert builder.tracker_specific_formats(tracker, description) == "[color=#87ceeb]Text[/color]"
+
+    assert builder.tracker_specific_formats("HDTORRENTS", description) == description
+
+
+def test_tracker_specific_formats_converts_colors_for_hdspace() -> None:
+    builder = object.__new__(DescriptionBuilder)
+    description = "[color=#87ceeb]Text[/color]"
+
+    assert builder.tracker_specific_formats("HDSPACE", description) == "[color=skyblue]Text[/color]"
 
 
 def test_tracker_specific_formats_removes_image_resize_for_nexusphp_trackers() -> None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for converting named BBCode colors to hexadecimal values.
  - Added support for converting recognized hexadecimal colors to CSS color names.
  - Expanded tracker-specific formatting across additional trackers, including Gazelle and HD-Space formats.
  - Preserved unknown and already-compatible color values.

- **Bug Fixes**
  - Improved description formatting consistency, including image-resize handling and cleanup for applicable trackers.

- **Tests**
  - Added coverage for color conversion and tracker-specific formatting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->