### PR TITLE
refactor(trackers): centralize framework lookup

### DIFF
--- a/src/get_desc.py
+++ b/src/get_desc.py
@@ -32,20 +32,6 @@ from src.tracker_images import get_tracker_image_collection, has_tracker_image_c
 from src.trackers.common import Common
 from src.uploadscreens import UploadScreensManager
 
-NEXUSPHP_TRACKERS = {
-    "1PTBA",
-    "LAJIDUI",
-    "LEMONHD",
-    "LONGPT",
-    "PTCAFE",
-    "PTFANS",
-    "PTGTK",
-    "PTZONE",
-    "RAILGUNPT",
-    "XINGYUNGEPT",
-    "NEXUSPHP",
-}
-
 
 def html_to_bbcode(text: str) -> str:
     """Convert HTML tags to BBCode format."""
@@ -2206,7 +2192,9 @@ class DescriptionBuilder:
         if not thumb_size:
             thumb_size = self._get_int_config("thumbnail_size", 350)
 
-        if self.tracker in NEXUSPHP_TRACKERS:
+        from src.trackersetup import get_tracker_framework
+
+        if get_tracker_framework(self.tracker) == "NEXUSPHP":
             return f"[img]{raw_url}[/img]"
         if self.tracker == "HDTORRENTS":
             return f"<a href='{raw_url}'><img src='{img_url}' height=137></a> "
@@ -2224,7 +2212,9 @@ class DescriptionBuilder:
 
     def tracker_specific_formats(self, tracker: str, description: str) -> str:
         bbcode = BBCODE()
-        if tracker in NEXUSPHP_TRACKERS:
+        from src.trackersetup import get_tracker_framework
+
+        if get_tracker_framework(tracker) == "NEXUSPHP":
             description = bbcode.remove_img_resize(description)
 
         if tracker in {"ANTHELION", "BJSHARE", "BRASILTRACKER", "GREATPOSTERWALL"}:
@@ -2392,7 +2382,7 @@ class DescriptionBuilder:
             description = bbcode.remove_spoiler(description)
             description = bbcode.remove_list(description)
 
-        if tracker in {"LAJIDUI", "LEMONHD", "LONGPT", "1PTBA", "PTCAFE", "PTFANS", "PTGTK", "PTSKIT", "PTZONE", "RAILGUNPT", "XINGYUNGEPT"}:
+        if get_tracker_framework(tracker) == "NEXUSPHP":
             description = description.replace("[user]", "").replace("[/user]", "")
             description = description.replace("[align=left]", "").replace("[/align]", "")
             description = description.replace("[right]", "").replace("[/right]", "")
@@ -2443,9 +2433,7 @@ class DescriptionBuilder:
             # Strip BBCode names and attributes while retaining their contents.
             description = re.sub(r"\[/?[a-z][a-z0-9_-]*(?:=[^\]]*|\s+[^\]]*)?\]|\[\*\]", "", description, flags=re.IGNORECASE)
 
-        from src.trackersetup import api_trackers as unit3d_trackers
-
-        if tracker in unit3d_trackers:
+        if get_tracker_framework(tracker) == "UNIT3D":
             description = bbcode.convert_hide_to_spoiler(description)
             description = description.replace("[user]", "").replace("[/user]", "")
             description = description.replace("[hr]", "").replace("[/hr]", "")

--- a/src/trackers/NEXUSPHP/ptskit.py
+++ b/src/trackers/NEXUSPHP/ptskit.py
@@ -1,19 +1,16 @@
 # Upload Assistant © 2025 Audionut & wastaken7 — Licensed under UAPL v1.0
-import platform
 from typing import Any, cast
 
-import httpx
 from bs4 import BeautifulSoup
 
-from src.cookie_auth import CookieAuthUploader, CookieValidator
 from src.get_desc import DescriptionBuilder
 from src.meta import Meta
-from src.trackers.common import Common
+from src.trackers.NEXUSPHP import NEXUSPHP
 
 Config = dict[str, Any]
 
 
-class Ptskit:
+class Ptskit(NEXUSPHP):
     """
     PTSKIT is a CHINESE Private Torrent Tracker for MOVIES / TV / GENERAL
     """
@@ -31,25 +28,15 @@ class Ptskit:
     tracker_urls = ("tracker.ptskit.com",)
 
     def __init__(self, config: Config) -> None:
-        self.config: Config = config
-        self.common = Common(config)
-        self.cookie_validator = CookieValidator(config)
-        self.cookie_auth_uploader = CookieAuthUploader(config)
-        self.announce = str(self.config["TRACKERS"][self.tracker]["announce_url"])
-        self.session = httpx.AsyncClient(headers={"User-Agent": f"Upload-Assistant/2.3 ({platform.system()} {platform.release()})"}, timeout=60.0)
+        super().__init__(config, "PTSKIT")
 
-    async def validate_credentials(self, meta: Meta) -> bool:
-        cookies = await self.cookie_validator.load_session_cookies(meta, self.tracker)
-        self.session.cookies = cast(Any, cookies)
-        return cookies is not None
-
-    async def get_type(self, meta: Meta) -> str | None:
+    def get_type(self, meta: Meta) -> int:
         if meta.anime:
-            return "407"
+            return 407
 
         category_map = {"TV": "405", "MOVIE": "404"}
 
-        return category_map.get(meta.category)
+        return int(category_map.get(meta.category, "404"))
 
     async def generate_description(self, meta: Meta) -> str:
         builder = DescriptionBuilder(self.tracker, self.config)
@@ -64,10 +51,10 @@ class Ptskit:
     async def get_additional_checks(self, meta: Meta) -> bool:
         return await self.common.check_language_requirements(meta, self.tracker, languages_to_check=["mandarin", "chinese"], check_audio=True, check_subtitle=True)
 
-    async def search_existing(self, meta: Meta) -> list[str] | None:
+    async def search_existing(self, meta: Meta) -> list[dict[str, str]]:
         search_url = f"{self.base_url}/torrents.php"
         params: dict[str, Any] = {"incldead": 1, "search": meta.imdb_tt, "search_area": 4}
-        found_items: list[str] = []
+        found_items: list[dict[str, str]] = []
 
         response = await self.session.get(search_url, params=params, cookies=self.session.cookies)
         if "login.php" in str(response.url) or "login.php" in response.text:
@@ -87,16 +74,16 @@ class Ptskit:
                 name_tag = torrent_table.find("b")
                 if name_tag:
                     torrent_name = name_tag.get_text(strip=True)
-                    found_items.append(torrent_name)
+                    found_items.append({"name": torrent_name})
 
         return found_items
 
     async def get_data(self, meta: Meta) -> dict[str, Any]:
         data: dict[str, Any] = {
-            "name": await self.get_name(meta),
+            "name": (await self.get_name(meta))["name"],
             "url": str(meta.imdb_info.get("imdb_url", "")),
             "descr": await self.generate_description(meta),
-            "type": await self.get_type(meta),
+            "type": self.get_type(meta),
         }
 
         return data
@@ -119,5 +106,5 @@ class Ptskit:
             success_status_code="302, 303",
         )
 
-    async def get_name(self, meta: Meta) -> str:
-        return meta.name
+    async def get_name(self, meta: Meta) -> dict[str, str]:
+        return {"name": meta.name}

--- a/src/trackers/NEXUSPHP/ptskit.py
+++ b/src/trackers/NEXUSPHP/ptskit.py
@@ -56,7 +56,11 @@ class Ptskit(NEXUSPHP):
         params: dict[str, Any] = {"incldead": 1, "search": meta.imdb_tt, "search_area": 4}
         found_items: list[dict[str, str]] = []
 
-        response = await self.session.get(search_url, params=params, cookies=self.session.cookies)
+        cookies = await self.cookie_validator.load_session_cookies(meta, self.tracker)
+        if cookies:
+            self.session.cookies.update(cookies)
+
+        response = await self.session.get(search_url, params=params)
         if "login.php" in str(response.url) or "login.php" in response.text:
             await self.cookie_validator.handle_validation_failure(meta, self.tracker, response.text)
             meta.skipping = f"{self.tracker}"

--- a/src/trackersetup.py
+++ b/src/trackersetup.py
@@ -1479,7 +1479,7 @@ tracker_class_map: Any = LazyTrackerDict(
         "PTERCLUB": ("src.trackers.pterclub", "PTerClub"),
         "PTFANS": ("src.trackers.NEXUSPHP.ptfans", "PTFans"),
         "PTGTK": ("src.trackers.NEXUSPHP.ptgtk", "PTGTK"),
-        "PTSKIT": ("src.trackers.ptskit", "Ptskit"),
+        "PTSKIT": ("src.trackers.NEXUSPHP.ptskit", "Ptskit"),
         "PTZONE": ("src.trackers.NEXUSPHP.ptzone", "PTZone"),
         "RACING4EVERYONE": ("src.trackers.UNIT3D.racing4everyone", "Racing4Everyone"),
         "RAILGUNPT": ("src.trackers.NEXUSPHP.railgunpt", "RailgunPT"),
@@ -1509,6 +1509,26 @@ tracker_class_map: Any = LazyTrackerDict(
         "ZENITH": ("src.trackers.UNIT3D.znth", "Zenith"),
     }
 )
+
+
+def _tracker_framework_from_module(module_name: str) -> str | None:
+    """Return the framework directory for a registered tracker module."""
+    parts = module_name.split(".")
+    if len(parts) < 4 or parts[:2] != ["src", "trackers"]:
+        return None
+    return parts[2]
+
+
+# Keep framework classification derived from the tracker registry without
+# importing tracker modules (the registry is intentionally lazy).
+tracker_framework_map: dict[str, str] = {
+    tracker: framework for tracker, (module_name, _class_name) in tracker_class_map._modules.items() if (framework := _tracker_framework_from_module(module_name)) is not None
+}
+
+
+def get_tracker_framework(tracker: str) -> str | None:
+    """Return the codebase framework for a tracker, if it has one."""
+    return tracker_framework_map.get(tracker.upper())
 
 
 def get_tracker_comment_hosts(config: dict[str, Any]) -> dict[str, tuple[str, ...]]:

--- a/tests/test_bbcode.py
+++ b/tests/test_bbcode.py
@@ -1,6 +1,30 @@
 # ruff: noqa: S101
+import asyncio
+
 from src.bbcode import BBCODE
 from src.get_desc import DescriptionBuilder
+from src.trackers.NEXUSPHP import NEXUSPHP
+from src.trackers.NEXUSPHP.ptskit import Ptskit
+from src.trackersetup import get_tracker_framework
+
+
+def test_tracker_framework_is_derived_from_registered_module_path() -> None:
+    assert get_tracker_framework("ANTHELION") == "GAZELLE"
+    assert get_tracker_framework("AITHER") == "UNIT3D"
+    assert get_tracker_framework("LEMONHD") == "NEXUSPHP"
+    assert get_tracker_framework("PTSKIT") == "NEXUSPHP"
+    assert get_tracker_framework("UNKNOWN") is None
+
+
+def test_ptskit_uses_the_nexusphp_base_initializer() -> None:
+    tracker = Ptskit({"DEFAULT": {"tmdb_api": "test-key"}, "TRACKERS": {"PTSKIT": {"announce_url": "https://example.test/announce"}}})
+
+    try:
+        assert isinstance(tracker, NEXUSPHP)
+        assert tracker.tracker == "PTSKIT"
+        assert tracker.announce_url == "https://example.test/announce"
+    finally:
+        asyncio.run(tracker.session.aclose())
 
 
 def test_clamp_size_tags_preserves_supported_sizes_and_other_markup() -> None:

--- a/tests/test_webui_trackers.py
+++ b/tests/test_webui_trackers.py
@@ -4,18 +4,17 @@ import web_ui.server as server
 from src.trackers.retroflix import RetroFlix
 
 
-def test_tracker_codebase_uses_known_module_families_only() -> None:
-    for module, expected in (
-        ("src.trackers.UNIT3D.blutopia", "UNIT3D"),
-        ("src.trackers.GAZELLE.orpheus", "Gazelle"),
-        ("src.trackers.NEXUSPHP.oneptba", "NexusPHP"),
-        ("src.trackers.AVISTAZ.avistaz", "AvistaZ"),
-        ("src.trackers.USENET.nzbgeek", None),
-        ("src.trackers.broadcasthenet", None),
-        ("unrelated.trackers.GAZELLE.example", None),
+def test_tracker_codebase_uses_registered_frameworks_only() -> None:
+    for tracker_name, expected in (
+        ("BLUTOPIA", "UNIT3D"),
+        ("ORPHEUS", "Gazelle"),
+        ("1PTBA", "NexusPHP"),
+        ("AVISTAZ", "AvistaZ"),
+        ("NZBGEEK", None),
+        ("BROADCASTHENET", None),
+        ("UNKNOWN", None),
     ):
-        tracker_class = type("Tracker", (), {"__module__": module})
-        assert server._tracker_codebase(tracker_class) == expected
+        assert server._tracker_codebase(tracker_name) == expected
 
 
 def test_tracker_destination_type_uses_existing_usenet_marker() -> None:

--- a/web_ui/server.py
+++ b/web_ui/server.py
@@ -4750,12 +4750,12 @@ def _configured_cookie_tracker_names(
     return configured
 
 
-def _tracker_codebase(tracker_class: Any) -> str | None:
-    """Expose known tracker families without guessing from ungrouped modules."""
-    module_parts = str(getattr(tracker_class, "__module__", "")).split(".")
-    if len(module_parts) < 4 or module_parts[:2] != ["src", "trackers"]:
-        return None
-    return {"UNIT3D": "UNIT3D", "GAZELLE": "Gazelle", "NEXUSPHP": "NexusPHP", "AVISTAZ": "AvistaZ"}.get(module_parts[2])
+def _tracker_codebase(tracker_name: str) -> str | None:
+    """Expose the framework registered for a tracker."""
+    from src.trackersetup import get_tracker_framework
+
+    framework = get_tracker_framework(tracker_name) or ""
+    return {"UNIT3D": "UNIT3D", "GAZELLE": "Gazelle", "NEXUSPHP": "NexusPHP", "AVISTAZ": "AvistaZ"}.get(framework)
 
 
 def _tracker_destination_type(tracker_class: Any) -> str:
@@ -5032,7 +5032,7 @@ def get_trackers():
             {
                 "name": tracker_name,
                 "display_name": display_name,
-                "codebase": _tracker_codebase(tracker_class),
+                "codebase": _tracker_codebase(tracker_name),
                 "base_url": base_url,
                 "favicon": favicon_url,
                 "configured": tracker_name.upper() in configured_trackers,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Tracker framework identification is now derived consistently from registered tracker information.
  - PTS-Kit now follows the standardized NexusPHP tracker framework for more consistent tracker interactions.
  - Tracker listings and related Web UI features now display the appropriate tracker family more reliably.

- **Bug Fixes**
  - Improved framework detection for NexusPHP and UNIT3D trackers.
  - Unknown or unregistered trackers are handled safely without incorrect family classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->